### PR TITLE
fix(mcp): mark mcp-server as ESM so the server starts

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -19,6 +19,8 @@ On first run, a sign-in prompt appears in your terminal:
 
 Open the URL, enter the code, sign in with your Microsoft account. Done — tokens are saved to `~/.config/teamsly-mcp/tokens.json` and auto-refreshed.
 
+> **Azure app requirement:** the app registration behind `TEAMSLY_CLIENT_ID` must have **"Allow public client flows"** enabled (Entra ID → App registrations → *app* → Authentication → Advanced settings). The device-code flow is a public-client flow; without this, sign-in fails at the token step with `AADSTS7000218: ... must contain 'client_assertion' or 'client_secret'`.
+
 ## Tools
 
 | Tool | Description |

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Problem

The Teamsly MCP server (`npx tsx mcp-server/index.ts`) failed to start. Clients (`claude mcp list`) reported **✗ Failed to connect**. Running it directly surfaced:

```
ERROR: Top-level await is currently not supported with the "cjs" output format
  mcp-server/index.ts:400:0
```

The server uses ESM syntax — `import` statements and a top-level `await server.connect(transport)`. The repo root `package.json` has no `"type"` field, so it defaults to CommonJS; tsx/esbuild then compiled the server as CJS, where top-level `await` is illegal, and the process crashed before opening the stdio transport.

## Fix

Add a scoped `mcp-server/package.json` containing `{ "type": "module" }`. This marks **only** the `mcp-server/` directory as ESM, so tsx compiles it correctly. The root Next.js project stays CommonJS — its build is untouched.

## Also

Documented in the README that the Azure app registration behind `TEAMSLY_CLIENT_ID` must have **"Allow public client flows"** enabled. The device-code flow is a public-client flow; without this, sign-in succeeds at the device-code step but fails at the token step with `AADSTS7000218: ... must contain 'client_assertion' or 'client_secret'`.

## Verification

- Server now responds to `initialize` with `serverInfo: teamsly v2.0.0`.
- `claude mcp list` → **teamsly: ✓ Connected**.
- Drove the running server end-to-end: `initialize` → `notifications/initialized` → `tools/call list_teams`, which returned the authenticated user's real Teams list from Microsoft Graph.