### PR TITLE
UI polish: full theming, instant chat reopen, DM name, switcher

### DIFF
--- a/docs/superpowers/specs/2026-05-29-ui-polish-audit.md
+++ b/docs/superpowers/specs/2026-05-29-ui-polish-audit.md
@@ -1,0 +1,52 @@
+# Teamsly UI/UX Polish Audit — 2026-05-29
+
+Goal: make Teamsly **feel better than the native MS Teams client**. Audit across four dimensions (theming, loading/perceived-perf, native-feel/interactions, layout/spacing). Findings below, grouped and prioritized. Branch: `fix/ui-polish`.
+
+## P0 — The "this is a web app, not a native client" tells (fix first)
+
+### 1. Left nav + always-visible surfaces are NOT themed (hardcoded Slack-ish hex)
+~441 hardcoded colors repo-wide; **39 instances of `#0F5A8F` (a Slack blue)** used where `var(--accent)` (#6366F1) belongs. Breaks light mode + non-default palettes, off-brand (BRAND.md).
+Always-visible offenders (priority order): `LeftRail.tsx` (23, incl. `bg-[#19171d]`, `#0F5A8F`, `#4da3e0`, `#cd2553`, `#1e2027`), `AppShell.tsx` notification banner (`#0F5A8F/15 text-blue-200`), `ToastViewport.tsx` (4), `MessageInput.tsx` (status `#007a5a`), `PresenceDot.tsx` (status dots).
+Canonical vars (globals.css): `--bg`/`--content-bg`, `--sidebar-bg`, `--modal-bg`, `--surface`/`--surface-raised`/`--surface-hover`, `--text-primary`/`--text-secondary`/`--text-muted`, `--accent`, `--border`, `--status-{online,away,busy,offline}`, `--text-mention`.
+**Fix:** replace every hex with the matching var; all `#0F5A8F` → `var(--accent)`.
+
+### 2. Loading skeleton flashes on chat open (should be instant from IDB cache)
+Messages ARE persisted to IndexedDB + hydrated on boot (`message-cache.ts`, `hydrateMessageCache`), but:
+- `isLoadingMessages` is a **single global flag** (`workspace.ts:32`) — switching from a cached chat to an uncached one, then back, keeps the skeleton on the cached one.
+- **Cold-boot race:** `ChatView`/`ChannelView` effects set `setLoadingMessages(true)` when `getMessages(id).length===0` *before* `hydrateMessageCache()` fills the store (AppShell effect, async, not gated). No `isHydrated` flag exists.
+**Fix:** add `isHydrated` to the store (set true after hydrate); only `setLoadingMessages(true)` if `cached.length===0 && isHydrated`. Ideally make loading **per-context** (`loadingContexts: Set<string>` + `isContextLoading(id)`), pass per-context loading to `MessageFeed`. Result: reopening a previously-loaded chat NEVER shows a skeleton.
+
+### 3. DM header name blank for 1:1 DMs
+`ChatView.tsx:142` fetches members into **local state only**, never patches the store like the sidebar (`patchChatMembers`). When the chat object lacks members/`chatType`, `getChatLabel` returns `""` (chat-label.ts:26) so the header is blank while the sidebar shows the name.
+**Fix:** patch fetched members into the store (unify source with sidebar) + a fallback label.
+
+### 4. JumpToSwitcher top gap
+`JumpToSwitcher.tsx:100-103` — the "Recent/Results" `h3` sits *inside* the scrollable `p-3` container, stacking padding into a large top gap. Also missing explicit Escape handler (`:62-75`).
+**Fix:** move the header out of the scroll container / tighten padding; add explicit Escape close.
+
+## P1 — Theming the rest (light-mode + palette correctness)
+Modals/pickers with heavy hardcoded hex (unusable in light mode): `SettingsModal.tsx` (37, incl. 5× `#0F5A8F`), `ForwardMessageModal.tsx` (20), `EmojiPicker.tsx` (9), `GifPicker.tsx` (8), `AttachmentCard.tsx` (16), `AdaptiveCard.tsx` (10, incl. `rgba(15,90,143,...)`), `LinkPreviewCard.tsx` (14), `ContextFilesTab.tsx` (15). Same fix pattern as P0.1.
+
+## P2 — Native-feel interactions
+- **Modal exit animations missing/inconsistent:** PreferencesModal, FeedbackModal, StatusMessageModal, SettingsModal Dialog.Content have no enter/exit animation; JumpToSwitcher overlay animates differently than SearchModal. Define shared `.modal-content`/`.modal-overlay` enter+exit keyframes in globals.css, apply via `data-[state]`.
+- **ThreadPanel** uses a hardcoded cubic-bezier instead of `var(--ease-spring)` (ThreadPanel.tsx:84-90).
+- **MessageHoverToolbar** micro-jank: base `translate-x-1 translate-y-1` → 1px shift on hover (`:36-40`); use opacity-only.
+- **Scroll asymmetry:** initial/channel-switch uses `instant`, new-message uses `smooth` (MessageFeed.tsx ~94-100). Smooth after first settle.
+- **Section collapse** uses `ease-out` not `var(--ease-spring)` (Sidebar collapsibles).
+- **Reaction pop** (`react-burst`/`react-plus-one` in globals.css) defined but not applied on add.
+- **Failed-send Retry/Discard buttons** lack hover bg + focus ring (MessageItem.tsx:255-278).
+- **Empty states / intro cards** appear with no entrance animation (utility classes exist, not applied).
+
+## P3 — Layout/spacing polish
+- Sidebar section gaps `mb-1` → `mb-2`; DMs header `mt-3` inconsistent with Channels (Sidebar.tsx).
+- MessageItem: body density style not applied to continuation rows (font-size jump) (~:479).
+- ReactionPill padding tight (`h-[24px] px-2` → `h-6 px-2.5 py-0.5`).
+- MessageHeader TabRow `items-end` → `items-center` + symmetric padding.
+- MessageInput textarea (`px-3 py-2`) vs toolbar (`px-2 py-1`) asymmetry.
+- DateDivider tight vertical padding.
+
+## Execution batches
+- **Batch 1 (P0 — the 4 asks + always-visible theming):** LeftRail theming, loading-flash (isHydrated + per-context), DM name, JumpToSwitcher gap+Escape, AppShell banner + ToastViewport + PresenceDot + MessageInput status colors → vars.
+- **Batch 2 (P1):** theme the modals/pickers.
+- **Batch 3 (P2 + P3):** interaction + spacing polish.
+Each batch: `npm run build` green, commit per logical unit.

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -305,23 +305,23 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <div className="flex h-screen flex-col overflow-hidden bg-[var(--content-bg)]">
       {/* Electron auto-update banner — shown above the reconnect banner */}
       {updateStatus.kind === 'available' && (
-        <div className="flex flex-shrink-0 items-center justify-center gap-3 border-b border-[#0F5A8F]/40 bg-[#0F5A8F]/15 px-4 py-2 text-[13px] text-blue-200">
+        <div className="flex flex-shrink-0 items-center justify-center gap-3 border-b border-[var(--accent)]/40 bg-[var(--accent-light)] px-4 py-2 text-[13px] text-[var(--text-primary)]">
           <span>Teamsly v{updateStatus.version} is available — downloading…</span>
         </div>
       )}
       {updateStatus.kind === 'downloading' && (
-        <div className="flex flex-shrink-0 items-center justify-center gap-3 border-b border-[#0F5A8F]/40 bg-[#0F5A8F]/15 px-4 py-2 text-[13px] text-blue-200">
+        <div className="flex flex-shrink-0 items-center justify-center gap-3 border-b border-[var(--accent)]/40 bg-[var(--accent-light)] px-4 py-2 text-[13px] text-[var(--text-primary)]">
           <span>Downloading update… {updateStatus.percent ?? 0}%</span>
         </div>
       )}
       {updateStatus.kind === 'downloaded' && (
-        <div className="flex flex-shrink-0 items-center justify-center gap-3 border-b border-[#0F5A8F]/40 bg-[#0F5A8F]/15 px-4 py-2 text-[13px] text-blue-200">
+        <div className="flex flex-shrink-0 items-center justify-center gap-3 border-b border-[var(--accent)]/40 bg-[var(--accent-light)] px-4 py-2 text-[13px] text-[var(--text-primary)]">
           <span>Update ready — v{updateStatus.version}.</span>
           {autoInstallSupported ? (
             <button
               type="button"
               onClick={() => window.electron?.installUpdate()}
-              className="rounded bg-[#0F5A8F] px-2.5 py-0.5 text-[12px] font-semibold text-white transition-colors hover:bg-[#0d4f7d]"
+              className="rounded bg-[var(--accent)] px-2.5 py-0.5 text-[12px] font-semibold text-white transition-colors hover:opacity-90"
             >
               Restart &amp; install
             </button>
@@ -329,7 +329,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <button
               type="button"
               onClick={() => window.electron?.openReleasesPage()}
-              className="rounded bg-[#0F5A8F] px-2.5 py-0.5 text-[12px] font-semibold text-white transition-colors hover:bg-[#0d4f7d]"
+              className="rounded bg-[var(--accent)] px-2.5 py-0.5 text-[12px] font-semibold text-white transition-colors hover:opacity-90"
             >
               Open release page
             </button>
@@ -370,7 +370,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <header className="flex h-[50px] flex-shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--sidebar-bg)] px-4">
         {/* Left: logomark */}
         <div className="flex w-[56px] flex-shrink-0 items-center justify-center">
-          <Logo size={22} className="text-[#4da3e0]" />
+          <Logo size={22} className="text-[var(--accent)]" />
         </div>
 
         {/* Center: search input */}

--- a/src/components/layout/LeftRail.tsx
+++ b/src/components/layout/LeftRail.tsx
@@ -114,7 +114,7 @@ export function LeftRail() {
   return (
     <nav
       aria-label="Primary navigation"
-      className="flex w-[56px] flex-shrink-0 flex-col items-center bg-[#19171d] py-2"
+      className="flex w-[56px] flex-shrink-0 flex-col items-center bg-[var(--sidebar-bg)] py-2"
     >
       {/* macOS traffic-light clearance + window drag region.
           hiddenInset removes the native title bar so we provide a drag handle
@@ -130,12 +130,12 @@ export function LeftRail() {
           onClick={openSearch}
           aria-label="Search (Cmd+K)"
           title="Search (Cmd+K)"
-          className="group flex w-full flex-col items-center gap-0.5 px-1 py-2 text-[10px] font-medium transition-colors focus-ring text-[#a0a3a8] hover:text-[#d1d2d3]"
+          className="group flex w-full flex-col items-center gap-0.5 px-1 py-2 text-[10px] font-medium transition-colors focus-ring text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
         >
-          <span className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors group-hover:bg-white/8">
-            <Search size={18} strokeWidth={1.8} className="text-[#a0a3a8] group-hover:text-[#d1d2d3]" />
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors group-hover:bg-[var(--surface-hover)]">
+            <Search size={18} strokeWidth={1.8} className="text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]" />
           </span>
-          <span className="leading-none text-[#a0a3a8] group-hover:text-[#d1d2d3]">Search</span>
+          <span className="leading-none text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]">Search</span>
         </button>
 
         {NAV_ITEMS.map((item) => {
@@ -158,15 +158,15 @@ export function LeftRail() {
               className={cn(
                 "group relative flex w-full flex-col items-center gap-0.5 px-1 py-2 text-[10px] font-medium transition-colors focus-ring",
                 active
-                  ? "text-white"
-                  : "text-[#a0a3a8] hover:text-[#d1d2d3]"
+                  ? "text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
               )}
             >
               {/* Left border accent for active state */}
               {active && (
                 <span
                   aria-hidden="true"
-                  className="absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-r-full bg-[#0F5A8F]"
+                  className="absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-r-full bg-[var(--accent)]"
                 />
               )}
               {/* Icon container with hover/active fill */}
@@ -175,22 +175,22 @@ export function LeftRail() {
                   className={cn(
                     "flex h-8 w-8 items-center justify-center rounded-lg transition-colors",
                     active
-                      ? "bg-[#0F5A8F]/20"
-                      : "group-hover:bg-white/8"
+                      ? "bg-[var(--accent)]/20"
+                      : "group-hover:bg-[var(--surface-hover)]"
                   )}
                 >
                   <Icon
                     size={18}
                     strokeWidth={active ? 2.2 : 1.8}
                     className={cn(
-                      active ? "text-[#4da3e0]" : "text-[#a0a3a8] group-hover:text-[#d1d2d3]"
+                      active ? "text-[var(--accent)]" : "text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]"
                     )}
                   />
                 </span>
                 {showBadge && (
                   <span
                     aria-hidden="true"
-                    className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full bg-[#cd2553] px-[3px] text-[9px] font-bold leading-none text-white"
+                    className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full bg-[var(--text-mention)] px-[3px] text-[9px] font-bold leading-none text-white"
                   >
                     {badgeCount > 99 ? "99+" : badgeCount}
                   </span>
@@ -199,7 +199,7 @@ export function LeftRail() {
               <span
                 className={cn(
                   "leading-none",
-                  active ? "text-white" : "text-[#a0a3a8] group-hover:text-[#d1d2d3]"
+                  active ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]"
                 )}
               >
                 {item.label}
@@ -218,22 +218,22 @@ export function LeftRail() {
           aria-expanded={moreOpen}
           className={cn(
             "group flex w-full flex-col items-center gap-0.5 px-1 py-2 text-[10px] font-medium transition-colors focus-ring",
-            moreOpen ? "text-white" : "text-[#a0a3a8] hover:text-[#d1d2d3]"
+            moreOpen ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
           )}
         >
           <span
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-lg transition-colors",
-              moreOpen ? "bg-[#0F5A8F]/20" : "group-hover:bg-white/8"
+              moreOpen ? "bg-[var(--accent)]/20" : "group-hover:bg-[var(--surface-hover)]"
             )}
           >
             <MoreHorizontal
               size={18}
               strokeWidth={moreOpen ? 2.2 : 1.8}
-              className={moreOpen ? "text-[#4da3e0]" : "text-[#a0a3a8] group-hover:text-[#d1d2d3]"}
+              className={moreOpen ? "text-[var(--accent)]" : "text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]"}
             />
           </span>
-          <span className={moreOpen ? "text-white" : "text-[#a0a3a8] group-hover:text-[#d1d2d3] leading-none"}>
+          <span className={moreOpen ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)] group-hover:text-[var(--text-primary)] leading-none"}>
             More
           </span>
         </button>
@@ -243,7 +243,7 @@ export function LeftRail() {
           <div
             role="menu"
             aria-label="More options menu"
-            className="absolute bottom-full left-full z-[200] mb-1 ml-1 w-48 overflow-hidden rounded-lg border border-white/10 bg-[#1e2027] py-1 shadow-xl"
+            className="absolute bottom-full left-full z-[200] mb-1 ml-1 w-48 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] py-1 shadow-xl"
           >
             <button
               role="menuitem"
@@ -251,9 +251,9 @@ export function LeftRail() {
                 setMoreOpen(false);
                 setPrefsOpen(true);
               }}
-              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[#d1d2d3] transition-colors hover:bg-white/8 focus-ring"
+              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[var(--text-primary)] transition-colors hover:bg-[var(--surface-hover)] focus-ring"
             >
-              <Settings size={15} strokeWidth={1.8} className="shrink-0 text-[#a0a3a8]" />
+              <Settings size={15} strokeWidth={1.8} className="shrink-0 text-[var(--text-secondary)]" />
               Preferences
             </button>
             <button
@@ -262,29 +262,29 @@ export function LeftRail() {
                 setMoreOpen(false);
                 setFeedbackOpen(true);
               }}
-              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[#d1d2d3] transition-colors hover:bg-white/8 focus-ring"
+              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[var(--text-primary)] transition-colors hover:bg-[var(--surface-hover)] focus-ring"
             >
-              <MessageCircleQuestion size={15} strokeWidth={1.8} className="shrink-0 text-[#a0a3a8]" />
+              <MessageCircleQuestion size={15} strokeWidth={1.8} className="shrink-0 text-[var(--text-secondary)]" />
               Send feedback…
             </button>
             <button
               role="menuitem"
               onClick={() => setMoreOpen(false)}
-              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[#d1d2d3] transition-colors hover:bg-white/8 focus-ring"
+              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[var(--text-primary)] transition-colors hover:bg-[var(--surface-hover)] focus-ring"
             >
-              <Info size={15} strokeWidth={1.8} className="shrink-0 text-[#a0a3a8]" />
+              <Info size={15} strokeWidth={1.8} className="shrink-0 text-[var(--text-secondary)]" />
               About Teamsly
             </button>
-            <hr className="my-1 border-white/10" />
+            <hr className="my-1 border-[var(--border)]" />
             <button
               role="menuitem"
               onClick={() => {
                 setMoreOpen(false);
                 void handleSignOut();
               }}
-              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[#e8534a] transition-colors hover:bg-white/8 focus-ring"
+              className="flex w-full items-center gap-3 px-3 py-2 text-sm text-[var(--status-busy)] transition-colors hover:bg-[var(--surface-hover)] focus-ring"
             >
-              <LogOut size={15} strokeWidth={1.8} className="shrink-0 text-[#e8534a]" />
+              <LogOut size={15} strokeWidth={1.8} className="shrink-0 text-[var(--status-busy)]" />
               Sign out
             </button>
           </div>

--- a/src/components/messages/AdaptiveCard.tsx
+++ b/src/components/messages/AdaptiveCard.tsx
@@ -100,18 +100,18 @@ const COLOR_MAP: Record<string, string> = {
   good: "var(--status-online)",
   warning: "var(--status-away)",
   attention: "var(--status-busy)",
-  dark: "#ffffff",
+  dark: "var(--text-primary)",
   light: "var(--text-muted)",
   subtle: "var(--text-secondary)",
 };
 
 const CONTAINER_STYLE_MAP: Record<string, string> = {
   default: "",
-  emphasis: "bg-[#27292d] rounded-md px-3 py-2",
-  good: "bg-[#1a2e24] border border-[#2bac76]/40 rounded-md px-3 py-2",
-  attention: "bg-[#2e1a1e] border border-[#e01e5a]/40 rounded-md px-3 py-2",
-  warning: "bg-[#2e2519] border border-[#e8a838]/40 rounded-md px-3 py-2",
-  accent: "bg-[rgba(15,90,143,0.15)] border border-[#0F5A8F]/40 rounded-md px-3 py-2",
+  emphasis: "bg-[var(--surface-raised)] rounded-md px-3 py-2",
+  good: "bg-[var(--status-online)]/10 border border-[var(--status-online)]/40 rounded-md px-3 py-2",
+  attention: "bg-[var(--status-busy)]/10 border border-[var(--status-busy)]/40 rounded-md px-3 py-2",
+  warning: "bg-[var(--status-away)]/10 border border-[var(--status-away)]/40 rounded-md px-3 py-2",
+  accent: "bg-[var(--accent-light)] border border-[var(--accent)]/40 rounded-md px-3 py-2",
 };
 
 // ---------------------------------------------------------------------------
@@ -268,7 +268,7 @@ function ActionSetEl({ el }: { el: ACActionSet }) {
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded border border-[#0F5A8F] px-3 py-1.5 text-[12px] font-medium text-[#1d9bd1] transition-colors hover:bg-[rgba(15,90,143,0.15)]"
+                className="inline-flex items-center gap-1.5 rounded border border-[var(--accent)] px-3 py-1.5 text-[12px] font-medium text-[var(--accent)] transition-colors hover:bg-[var(--accent-light)]"
               >
                 {action.title ?? "Open"}
                 <ExternalLink size={11} />
@@ -282,7 +282,7 @@ function ActionSetEl({ el }: { el: ACActionSet }) {
             key={i}
             type="button"
             disabled
-            className="inline-flex cursor-not-allowed items-center rounded border border-[#3f4144] px-3 py-1.5 text-[12px] font-medium text-[#6c6f75] opacity-60"
+            className="inline-flex cursor-not-allowed items-center rounded border border-[var(--border)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-muted)] opacity-60"
           >
             {action.title ?? action.type}
           </button>
@@ -348,12 +348,12 @@ export function AdaptiveCard({ data }: AdaptiveCardProps) {
 
   return (
     <div
-      className="mt-2 max-w-[520px] rounded-md border border-[#3f4144] bg-[#1a1d21] px-4 py-3 text-[13px]"
+      className="mt-2 max-w-[520px] rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-4 py-3 text-[13px]"
       style={{ color: "var(--text-primary)" }}
     >
       <ElementList items={body} />
       {topActions && topActions.length > 0 && (
-        <div className="mt-3 border-t border-[#3f4144] pt-3">
+        <div className="mt-3 border-t border-[var(--border)] pt-3">
           <ActionSetEl el={{ type: "ActionSet", actions: topActions }} />
         </div>
       )}

--- a/src/components/messages/AttachmentCard.tsx
+++ b/src/components/messages/AttachmentCard.tsx
@@ -38,20 +38,20 @@ export function AttachmentCard({ attachment }: AttachmentCardProps) {
 
   const content = (
     <>
-      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[#2c2d30] text-[#ababad]">
+      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[var(--surface)] text-[var(--text-secondary)]">
         <FileIcon size={18} />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-bold text-[#d1d2d3]">{label}</span>
-        <span className="block truncate text-[12px] text-[#6c6f75]">{contentType}</span>
+        <span className="block truncate text-[13px] font-bold text-[var(--text-primary)]">{label}</span>
+        <span className="block truncate text-[12px] text-[var(--text-muted)]">{contentType}</span>
       </span>
-      <Download className="h-4 w-4 flex-shrink-0 text-[#ababad]" />
+      <Download className="h-4 w-4 flex-shrink-0 text-[var(--text-secondary)]" />
     </>
   );
 
   if (!href) {
     return (
-      <div className="mt-2 flex max-w-[420px] items-center gap-3 rounded-md border border-[#3f4144] bg-[#1a1d21] px-3 py-2 text-left opacity-70">
+      <div className="mt-2 flex max-w-[420px] items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left opacity-70">
         {content}
       </div>
     );
@@ -80,7 +80,7 @@ export function AttachmentCard({ attachment }: AttachmentCardProps) {
       // Middle-click (button 1) goes to onAuxClick, not onClick, so the
       // browser's default "open in new tab" already works for us — no
       // explicit handler needed.
-      className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[#3f4144] bg-[#1a1d21] px-3 py-2 text-left transition-colors duration-150 hover:border-[#565856] hover:bg-[#27292d]"
+      className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left transition-colors duration-150 hover:border-[var(--border-input)] hover:bg-[var(--surface-hover)]"
     >
       {content}
     </a>
@@ -103,19 +103,19 @@ function InlineImageAttachment({ attachment }: { attachment: MSAttachment }) {
     const contentType = attachment.contentType || "File";
     const content = (
       <>
-        <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[#2c2d30] text-[#ababad]">
+        <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[var(--surface)] text-[var(--text-secondary)]">
           <FileIcon size={18} />
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] font-bold text-[#d1d2d3]">{label}</span>
-          <span className="block truncate text-[12px] text-[#6c6f75]">{contentType}</span>
+          <span className="block truncate text-[13px] font-bold text-[var(--text-primary)]">{label}</span>
+          <span className="block truncate text-[12px] text-[var(--text-muted)]">{contentType}</span>
         </span>
-        <Download className="h-4 w-4 flex-shrink-0 text-[#ababad]" />
+        <Download className="h-4 w-4 flex-shrink-0 text-[var(--text-secondary)]" />
       </>
     );
     if (!href) {
       return (
-        <div className="mt-2 flex max-w-[420px] items-center gap-3 rounded-md border border-[#3f4144] bg-[#1a1d21] px-3 py-2 text-left opacity-70">
+        <div className="mt-2 flex max-w-[420px] items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left opacity-70">
           {content}
         </div>
       );
@@ -125,7 +125,7 @@ function InlineImageAttachment({ attachment }: { attachment: MSAttachment }) {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[#3f4144] bg-[#1a1d21] px-3 py-2 text-left transition-colors duration-150 hover:border-[#565856] hover:bg-[#27292d]"
+        className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left transition-colors duration-150 hover:border-[var(--border-input)] hover:bg-[var(--surface-hover)]"
       >
         {content}
       </a>
@@ -218,15 +218,15 @@ function AdaptiveCardAttachment({ attachment }: { attachment: MSAttachment }) {
     // Parse failed or content missing — render name-only stub
     const FallbackIcon = getFileIcon(attachment.contentType, false, attachment.name ?? undefined);
     return (
-      <div className="mt-2 flex max-w-[420px] items-center gap-3 rounded-md border border-[#3f4144] bg-[#1a1d21] px-3 py-2 text-left opacity-70">
-        <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[#2c2d30] text-[#ababad]">
+      <div className="mt-2 flex max-w-[420px] items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left opacity-70">
+        <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[var(--surface)] text-[var(--text-secondary)]">
           <FallbackIcon size={18} />
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] font-bold text-[#d1d2d3]">
+          <span className="block truncate text-[13px] font-bold text-[var(--text-primary)]">
             {attachment.name || "Adaptive Card"}
           </span>
-          <span className="block truncate text-[12px] text-[#6c6f75]">
+          <span className="block truncate text-[12px] text-[var(--text-muted)]">
             application/vnd.microsoft.card.adaptive
           </span>
         </span>

--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -35,6 +35,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     setLoadingMessages,
     toggleReaction,
   } = useWorkspaceStore();
+  const isHydrated = useWorkspaceStore((s) => s.isHydrated);
   const [threadMessage, setThreadMessage] = useState<MSMessage | null>(null);
   const [forwardMessage, setForwardMessage] = useState<MSMessage | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("messages");
@@ -74,7 +75,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
   useEffect(() => {
     let cancelled = false;
     const cached = getMessages(contextId);
-    const isFirstLoad = cached.length === 0;
+    const isFirstLoad = cached.length === 0 && isHydrated;
 
     if (isFirstLoad) setLoadingMessages(true);
 
@@ -121,7 +122,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamId, channelId, contextId, setLoadingMessages, setMessages, showToast]);
+  }, [teamId, channelId, contextId, isHydrated, setLoadingMessages, setMessages, showToast]);
 
   useRealtimeEvents(
     useCallback(

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -40,7 +40,9 @@ export function ChatView({ chatId }: { chatId: string }) {
     editMessage,
     revertMessageEdit,
     patchChat,
+    patchChatMembers,
   } = useWorkspaceStore();
+  const isHydrated = useWorkspaceStore((s) => s.isHydrated);
   const [threadMessage, setThreadMessage] = useState<MSMessage | null>(null);
   const [forwardMessage, setForwardMessage] = useState<MSMessage | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("messages");
@@ -139,7 +141,12 @@ export function ChatView({ chatId }: { chatId: string }) {
     let cancelled = false;
     fetch(`/api/chats/${encodeURIComponent(chatId)}/members`)
       .then((r) => r.ok ? r.json() : Promise.reject())
-      .then((data: MSChatMember[]) => { if (!cancelled) setLocalMembers(data); })
+      .then((data: MSChatMember[]) => {
+        if (!cancelled) {
+          setLocalMembers(data);
+          patchChatMembers(chatId, data);
+        }
+      })
       .catch(() => {});
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,7 +164,7 @@ export function ChatView({ chatId }: { chatId: string }) {
   useEffect(() => {
     let cancelled = false;
     const cached = getMessages(chatId);
-    const isFirstLoad = cached.length === 0;
+    const isFirstLoad = cached.length === 0 && isHydrated;
 
     if (isFirstLoad) setLoadingMessages(true);
 
@@ -215,7 +222,7 @@ export function ChatView({ chatId }: { chatId: string }) {
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatId, setLoadingMessages, setMessages, showToast, sweepExpired]);
+  }, [chatId, isHydrated, setLoadingMessages, setMessages, showToast, sweepExpired]);
 
   useRealtimeEvents(
     useCallback(

--- a/src/components/messages/ContextFilesTab.tsx
+++ b/src/components/messages/ContextFilesTab.tsx
@@ -91,14 +91,14 @@ function ChannelFileRow({ item }: { item: MSDriveItem }) {
     <RowEl
       type={previewable ? "button" : undefined}
       onClick={previewable ? onRowClick : undefined}
-      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[80ms] hover:bg-[#27292d]"
+      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
     >
-      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[#2c2d30] text-[#ababad]">
+      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[var(--surface)] text-[var(--text-secondary)]">
         <Icon size={18} />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-bold text-[#d1d2d3]">{item.name}</span>
-        <span className="block truncate text-[12px] text-[#6c6f75]">
+        <span className="block truncate text-[13px] font-bold text-[var(--text-primary)]">{item.name}</span>
+        <span className="block truncate text-[12px] text-[var(--text-muted)]">
           {item.lastModifiedDateTime ? `Modified ${relativeTime(item.lastModifiedDateTime)}` : ""}
         </span>
       </span>
@@ -109,7 +109,7 @@ function ChannelFileRow({ item }: { item: MSDriveItem }) {
           rel="noopener noreferrer"
           title={`Open ${item.name} in browser`}
           aria-label={`Open ${item.name} in browser`}
-          className="flex-shrink-0 text-[#ababad] opacity-0 transition-opacity duration-[80ms] group-hover:opacity-100 focus:opacity-100"
+          className="flex-shrink-0 text-[var(--text-secondary)] opacity-0 transition-opacity duration-[80ms] group-hover:opacity-100 focus:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <ExternalLink size={15} />
@@ -142,14 +142,14 @@ function ChatFileRow({ item }: { item: MSChatFileAttachment }) {
     <RowEl
       type={href ? "button" : undefined}
       onClick={href ? onRowClick : undefined}
-      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[80ms] hover:bg-[#27292d]"
+      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
     >
-      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[#2c2d30] text-[#ababad]">
+      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[var(--surface)] text-[var(--text-secondary)]">
         <Icon size={18} />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-bold text-[#d1d2d3]">{item.name}</span>
-        <span className="block truncate text-[12px] text-[#6c6f75]">
+        <span className="block truncate text-[13px] font-bold text-[var(--text-primary)]">{item.name}</span>
+        <span className="block truncate text-[12px] text-[var(--text-muted)]">
           {sharer ? `Shared by ${sharer} · ` : ""}
           {item.sharedDateTime ? relativeTime(item.sharedDateTime) : ""}
         </span>
@@ -161,7 +161,7 @@ function ChatFileRow({ item }: { item: MSChatFileAttachment }) {
           rel="noopener noreferrer"
           title={`Open ${item.name} in browser`}
           aria-label={`Open ${item.name} in browser`}
-          className="flex-shrink-0 text-[#ababad] opacity-0 transition-opacity duration-[80ms] group-hover:opacity-100 focus:opacity-100"
+          className="flex-shrink-0 text-[var(--text-secondary)] opacity-0 transition-opacity duration-[80ms] group-hover:opacity-100 focus:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <ExternalLink size={15} />
@@ -223,11 +223,11 @@ export function ContextFilesTab({ mode }: ContextFilesTabProps) {
   if (error) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 py-16 text-center">
-        <FileX size={36} className="text-[#6c6f75]" />
-        <p className="text-[13px] text-[#ababad]">Couldn&apos;t load files</p>
+        <FileX size={36} className="text-[var(--text-muted)]" />
+        <p className="text-[13px] text-[var(--text-secondary)]">Couldn&apos;t load files</p>
         <button
           onClick={fetchFiles}
-          className="flex items-center gap-1.5 rounded-md border border-[#3f4144] px-3 py-1.5 text-[13px] text-[#d1d2d3] transition-colors duration-[80ms] hover:bg-[#27292d]"
+          className="flex items-center gap-1.5 rounded-md border border-[var(--border)] px-3 py-1.5 text-[13px] text-[var(--text-primary)] transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
         >
           <RefreshCw size={13} />
           Retry
@@ -239,7 +239,7 @@ export function ContextFilesTab({ mode }: ContextFilesTabProps) {
   if (mode.kind === "channel") {
     if (channelItems.length === 0) {
       return (
-        <div className="flex flex-1 items-center justify-center text-[13px] text-[#6c6f75]">
+        <div className="flex flex-1 items-center justify-center text-[13px] text-[var(--text-muted)]">
           No files have been shared here yet.
         </div>
       );
@@ -256,7 +256,7 @@ export function ContextFilesTab({ mode }: ContextFilesTabProps) {
   // chat mode
   if (chatItems.length === 0) {
     return (
-      <div className="flex flex-1 items-center justify-center text-[13px] text-[#6c6f75]">
+      <div className="flex flex-1 items-center justify-center text-[13px] text-[var(--text-muted)]">
         No files have been shared here yet.
       </div>
     );

--- a/src/components/messages/EmojiPicker.tsx
+++ b/src/components/messages/EmojiPicker.tsx
@@ -27,20 +27,20 @@ export function EmojiPicker({ children, onSelect }: EmojiPickerProps) {
           side="top"
           align="end"
           sideOffset={8}
-          className="z-[120] h-[420px] w-[360px] rounded-lg border border-[#3f4144] bg-[#1a1d21] p-3 text-[#d1d2d3] shadow-[0_8px_32px_rgba(0,0,0,0.5)] outline-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-[120] h-[420px] w-[360px] rounded-lg border border-[var(--border)] bg-[var(--modal-bg)] p-3 text-[var(--text-primary)] shadow-[0_8px_32px_rgba(0,0,0,0.5)] outline-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
-          <div className="mb-3 flex h-7 items-center gap-2 rounded-md border border-[#565856] bg-[#2c2d30] px-2 text-[#ababad] focus-within:border-white focus-within:bg-[#1a1d21]">
+          <div className="mb-3 flex h-7 items-center gap-2 rounded-md border border-[var(--border-input)] bg-[var(--surface)] px-2 text-[var(--text-secondary)] focus-within:border-[var(--text-primary)] focus-within:bg-[var(--modal-bg)]">
             <Search className="h-3.5 w-3.5" />
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search emoji"
-              className="min-w-0 flex-1 bg-transparent text-[13px] text-[#d1d2d3] outline-none placeholder:text-[#ababad]"
+              className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-secondary)]"
             />
           </div>
 
           <section className="mb-4">
-            <h3 className="mb-2 text-[12px] font-bold uppercase tracking-wide text-[#6c6f75]">Frequently used</h3>
+            <h3 className="mb-2 text-[12px] font-bold uppercase tracking-wide text-[var(--text-muted)]">Frequently used</h3>
             <div className="grid grid-cols-9 gap-1">
               {REACTION_TYPES.map((type) => (
                 <EmojiButton key={type} type={type} onSelect={onSelect} />
@@ -48,11 +48,11 @@ export function EmojiPicker({ children, onSelect }: EmojiPickerProps) {
             </div>
           </section>
 
-          <div className="mb-3 flex gap-1 overflow-hidden text-[11px] font-bold text-[#ababad]">
+          <div className="mb-3 flex gap-1 overflow-hidden text-[11px] font-bold text-[var(--text-secondary)]">
             {["Smileys", "People", "Nature", "Food"].map((label, index) => (
               <span
                 key={label}
-                className={`rounded px-2 py-1 ${index === 0 ? "bg-[#27292d] text-white" : "text-[#6c6f75]"}`}
+                className={`rounded px-2 py-1 ${index === 0 ? "bg-[var(--surface-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}
               >
                 {label}
               </span>
@@ -60,14 +60,14 @@ export function EmojiPicker({ children, onSelect }: EmojiPickerProps) {
           </div>
 
           <section>
-            <h3 className="mb-2 text-[12px] font-bold uppercase tracking-wide text-[#6c6f75]">Teams reactions</h3>
+            <h3 className="mb-2 text-[12px] font-bold uppercase tracking-wide text-[var(--text-muted)]">Teams reactions</h3>
             <div className="grid grid-cols-9 gap-1">
               {filtered.map((type) => (
                 <EmojiButton key={type} type={type} onSelect={onSelect} />
               ))}
             </div>
             {filtered.length === 0 && (
-              <p className="px-1 py-4 text-center text-[13px] text-[#6c6f75]">No matching reactions</p>
+              <p className="px-1 py-4 text-center text-[13px] text-[var(--text-muted)]">No matching reactions</p>
             )}
           </section>
         </Popover.Content>
@@ -84,7 +84,7 @@ function EmojiButton({ type, onSelect }: { type: ReactionType; onSelect: (reacti
         aria-label={type}
         title={type}
         onClick={() => onSelect(type)}
-        className="flex h-9 w-9 items-center justify-center rounded-md text-[22px] transition-colors duration-150 hover:bg-[#27292d]"
+        className="flex h-9 w-9 items-center justify-center rounded-md text-[22px] transition-colors duration-150 hover:bg-[var(--surface-hover)]"
       >
         {REACTION_EMOJI[type]}
       </button>

--- a/src/components/messages/GifPicker.tsx
+++ b/src/components/messages/GifPicker.tsx
@@ -63,17 +63,17 @@ export function GifPicker({ children, onSelect }: Props) {
           side="top"
           align="end"
           sideOffset={8}
-          className="z-[120] w-[340px] rounded-lg border border-[var(--border)] bg-[#1a1d21] shadow-[0_8px_32px_rgba(0,0,0,0.5)] outline-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-[120] w-[340px] rounded-lg border border-[var(--border)] bg-[var(--modal-bg)] shadow-[0_8px_32px_rgba(0,0,0,0.5)] outline-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
-          <div className="border-b border-[#3f4144] p-2">
-            <div className="flex h-8 items-center gap-2 rounded-md border border-[#565856] bg-[#2c2d30] px-2 text-[#ababad] focus-within:border-white">
+          <div className="border-b border-[var(--border)] p-2">
+            <div className="flex h-8 items-center gap-2 rounded-md border border-[var(--border-input)] bg-[var(--surface)] px-2 text-[var(--text-secondary)] focus-within:border-[var(--text-primary)]">
               <Search className="h-3.5 w-3.5 flex-shrink-0" />
               <input
                 ref={inputRef}
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Search GIFs"
-                className="min-w-0 flex-1 bg-transparent text-[13px] text-[#d1d2d3] outline-none placeholder:text-[#ababad]"
+                className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-secondary)]"
               />
             </div>
           </div>
@@ -81,10 +81,10 @@ export function GifPicker({ children, onSelect }: Props) {
           <div className="h-[300px] overflow-y-auto p-2">
             {loading ? (
               <div className="flex h-full items-center justify-center">
-                <Loader2 className="h-5 w-5 animate-spin text-[#ababad]" />
+                <Loader2 className="h-5 w-5 animate-spin text-[var(--text-secondary)]" />
               </div>
             ) : gifs.length === 0 ? (
-              <div className="flex h-full items-center justify-center text-[13px] text-[#6c6f75]">
+              <div className="flex h-full items-center justify-center text-[13px] text-[var(--text-muted)]">
                 {query ? "No GIFs found" : "Type to search…"}
               </div>
             ) : (
@@ -99,7 +99,7 @@ export function GifPicker({ children, onSelect }: Props) {
                       <button
                         type="button"
                         onClick={() => onSelect(full.url, gif.title)}
-                        className="block w-full overflow-hidden rounded-md bg-[#2c2d30] transition-opacity hover:opacity-90"
+                        className="block w-full overflow-hidden rounded-md bg-[var(--surface)] transition-opacity hover:opacity-90"
                       >
                         {/* eslint-disable-next-line @next/next/no-img-element */}
                         <img
@@ -116,7 +116,7 @@ export function GifPicker({ children, onSelect }: Props) {
             )}
           </div>
 
-          <div className="border-t border-[#3f4144] px-3 py-1.5 text-[10px] text-[#6c6f75]">
+          <div className="border-t border-[var(--border)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
             Powered by Tenor
           </div>
         </Popover.Content>

--- a/src/components/messages/MessageHeader.tsx
+++ b/src/components/messages/MessageHeader.tsx
@@ -50,8 +50,8 @@ function TabRow({
           onClick={() => onTabChange(id)}
           className={`px-3 py-1 text-[13px] font-medium transition-colors focus-ring ${
             activeTab === id
-              ? "border-b-2 border-white text-white"
-              : "text-[var(--text-secondary)] hover:text-white"
+              ? "border-b-2 border-[var(--text-primary)] text-[var(--text-primary)]"
+              : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
           }`}
         >
           {label}
@@ -183,7 +183,7 @@ export function ChannelMessageHeader({
         {/* Left: icon + name + description */}
         <div className="flex min-w-0 items-center gap-2">
           <Hash className="h-4 w-4 flex-shrink-0 text-[var(--text-secondary)]" />
-          <span className="truncate text-[17px] font-bold text-white">{name}</span>
+          <span className="truncate text-[17px] font-bold text-[var(--text-primary)]">{name}</span>
           {description && (
             <>
               <span className="text-[var(--border)]">|</span>
@@ -244,7 +244,7 @@ export function DmMessageHeader({
               onOpenMembers={onOpenMembers}
             />
           ) : null}
-          <span className="truncate text-[17px] font-bold text-white">{displayLabel}</span>
+          <span className="truncate text-[17px] font-bold text-[var(--text-primary)]">{displayLabel}</span>
         </div>
         {/* Right: voice trigger + icon cluster */}
         <div className="flex flex-shrink-0 items-center gap-0.5">

--- a/src/components/messages/MessageHeader.tsx
+++ b/src/components/messages/MessageHeader.tsx
@@ -227,6 +227,10 @@ export function DmMessageHeader({
   );
   const displayMembers = otherMembers.length > 0 ? otherMembers : members;
 
+  // Fallback: if getChatLabel returned "" (members not yet in store), use the
+  // first other member's displayName from the local prop, or a generic label.
+  const displayLabel = label || otherMembers[0]?.displayName || "Direct message";
+
   return (
     <div className="flex flex-col border-b border-[var(--border)] bg-[var(--content-bg)] px-4 shadow-sm">
       {/* Top row */}
@@ -240,7 +244,7 @@ export function DmMessageHeader({
               onOpenMembers={onOpenMembers}
             />
           ) : null}
-          <span className="truncate text-[17px] font-bold text-white">{label}</span>
+          <span className="truncate text-[17px] font-bold text-white">{displayLabel}</span>
         </div>
         {/* Right: voice trigger + icon cluster */}
         <div className="flex flex-shrink-0 items-center gap-0.5">

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -1178,17 +1178,17 @@ export function MessageInput({
                   aria-label="Disappearing message"
                   onClick={() => setShowDisappearMenu((v) => !v)}
                   className={`rounded p-1 text-[15px] transition-colors press-snap ${
-                    disappearMs ? "text-[var(--accent,#6366F1)]" : "text-[var(--text-secondary,#ababad)] hover:text-white"
+                    disappearMs ? "text-[var(--accent)]" : "text-[var(--text-secondary)] hover:text-white"
                   }`}
                 >
                   ⏱{disappearMs ? <span className="ml-[2px] text-[10px]">on</span> : null}
                 </button>
                 {showDisappearMenu && (
-                  <div className="absolute bottom-full z-50 mb-2 min-w-[160px] rounded-md border border-[var(--border,#3f4144)] bg-[var(--modal-bg,#222529)] py-1 shadow-lg">
+                  <div className="absolute bottom-full z-50 mb-2 min-w-[160px] rounded-md border border-[var(--border)] bg-[var(--modal-bg)] py-1 shadow-lg">
                     <button
                       type="button"
                       onClick={() => { setDisappearMs(null); setShowDisappearMenu(false); }}
-                      className={`block w-full px-3 py-1 text-left text-[13px] hover:bg-[var(--bg-hover,#2a2d31)] ${disappearMs === null ? "text-[var(--accent,#6366F1)]" : "text-[var(--text-primary,#d1d2d3)]"}`}
+                      className={`block w-full px-3 py-1 text-left text-[13px] hover:bg-[var(--surface-hover)] ${disappearMs === null ? "text-[var(--accent)]" : "text-[var(--text-primary)]"}`}
                     >
                       Off
                     </button>
@@ -1197,7 +1197,7 @@ export function MessageInput({
                         key={d.ms}
                         type="button"
                         onClick={() => { setDisappearMs(d.ms); setShowDisappearMenu(false); }}
-                        className={`block w-full px-3 py-1 text-left text-[13px] hover:bg-[var(--bg-hover,#2a2d31)] ${disappearMs === d.ms ? "text-[var(--accent,#6366F1)]" : "text-[var(--text-primary,#d1d2d3)]"}`}
+                        className={`block w-full px-3 py-1 text-left text-[13px] hover:bg-[var(--surface-hover)] ${disappearMs === d.ms ? "text-[var(--accent)]" : "text-[var(--text-primary)]"}`}
                       >
                         {d.label}
                       </button>
@@ -1216,7 +1216,7 @@ export function MessageInput({
                 className={cn(
                   "relative overflow-hidden flex h-8 w-8 items-center justify-center rounded transition-[background,color,transform] duration-150 ease-out focus-ring",
                   canSend
-                    ? "bg-[#007a5a] text-white hover:bg-[#148567] hover:scale-105 active:scale-95"
+                    ? "bg-[var(--status-online)] text-white hover:opacity-90 hover:scale-105 active:scale-95"
                     : "text-[var(--text-muted)]"
                 )}
               >

--- a/src/components/modals/ForwardMessageModal.tsx
+++ b/src/components/modals/ForwardMessageModal.tsx
@@ -144,36 +144,36 @@ export function ForwardMessageModal({ open, onOpenChange, message, onForward }: 
             event.preventDefault();
             inputRef.current?.focus();
           }}
-          className="fixed left-1/2 top-1/2 z-[70] flex max-h-[80vh] w-[560px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-[#3f4144] bg-[#1a1d21] text-[#d1d2d3] shadow-[0_16px_64px_rgba(0,0,0,0.6)] outline-none"
+          className="fixed left-1/2 top-1/2 z-[70] flex max-h-[80vh] w-[560px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] outline-none"
         >
           <Dialog.Title className="sr-only">Forward message</Dialog.Title>
 
-          <header className="flex h-[49px] flex-shrink-0 items-center justify-between border-b border-[#3f4144] px-4">
-            <h2 className="text-[15px] font-bold text-white">Forward message</h2>
+          <header className="flex h-[49px] flex-shrink-0 items-center justify-between border-b border-[var(--border)] px-4">
+            <h2 className="text-[15px] font-bold text-[var(--text-primary)]">Forward message</h2>
             <Dialog.Close
               aria-label="Close"
-              className="flex h-7 w-7 items-center justify-center rounded text-[#ababad] transition-colors duration-150 hover:bg-[#27292d] hover:text-white"
+              className="flex h-7 w-7 items-center justify-center rounded text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
             >
               <X size={16} />
             </Dialog.Close>
           </header>
 
           {/* Search input */}
-          <div className="flex items-center border-b border-[#3f4144]">
-            <Search className="ml-5 h-4 w-4 flex-shrink-0 text-[#ababad]" />
+          <div className="flex items-center border-b border-[var(--border)]">
+            <Search className="ml-5 h-4 w-4 flex-shrink-0 text-[var(--text-secondary)]" />
             <input
               ref={inputRef}
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search chats and channels..."
-              className="h-[44px] min-w-0 flex-1 bg-transparent px-3 text-[14px] text-[#d1d2d3] outline-none placeholder:text-[#6c6f75]"
+              className="h-[44px] min-w-0 flex-1 bg-transparent px-3 text-[14px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
             />
           </div>
 
           {/* Destination list */}
           <div className="max-h-[280px] flex-1 overflow-y-auto px-3 py-3">
             {!hasResults ? (
-              <div className="px-3 py-8 text-center text-[13px] text-[#6c6f75]">
+              <div className="px-3 py-8 text-center text-[13px] text-[var(--text-muted)]">
                 No matching chats or channels
               </div>
             ) : (
@@ -214,8 +214,8 @@ export function ForwardMessageModal({ open, onOpenChange, message, onForward }: 
           </div>
 
           {/* Note + quoted preview */}
-          <div className="flex flex-col gap-2 border-t border-[#3f4144] px-4 py-3">
-            <label className="text-[11px] font-bold uppercase tracking-wide text-[#6c6f75]">
+          <div className="flex flex-col gap-2 border-t border-[var(--border)] px-4 py-3">
+            <label className="text-[11px] font-bold uppercase tracking-wide text-[var(--text-muted)]">
               Add a note (optional)
             </label>
             <textarea
@@ -223,16 +223,16 @@ export function ForwardMessageModal({ open, onOpenChange, message, onForward }: 
               onChange={(event) => setNote(event.target.value)}
               rows={2}
               placeholder="Write something to go with the forwarded message"
-              className="w-full resize-none rounded border border-[#3f4144] bg-[#222529] px-2 py-1.5 text-[13px] text-[#d1d2d3] placeholder-[#6c6f75] outline-none focus:border-[#565856]"
+              className="w-full resize-none rounded border border-[var(--border)] bg-[var(--surface)] px-2 py-1.5 text-[13px] text-[var(--text-primary)] placeholder-[var(--text-muted)] outline-none focus:border-[var(--border-input)]"
             />
 
             {message && (
-              <div className="rounded-md border-l-[3px] border-[var(--accent)] bg-[#222529] px-3 py-1.5">
-                <div className="text-[12px] font-semibold text-[#d1d2d3]">
+              <div className="rounded-md border-l-[3px] border-[var(--accent)] bg-[var(--surface)] px-3 py-1.5">
+                <div className="text-[12px] font-semibold text-[var(--text-primary)]">
                   {message.from?.user?.displayName ?? "Unknown"}
                 </div>
                 {previewText && (
-                  <div className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-[12px] text-[#ababad]">
+                  <div className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-[12px] text-[var(--text-secondary)]">
                     {previewText}
                   </div>
                 )}
@@ -241,7 +241,7 @@ export function ForwardMessageModal({ open, onOpenChange, message, onForward }: 
           </div>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-2 border-t border-[#3f4144] px-4 py-3">
+          <div className="flex items-center justify-end gap-2 border-t border-[var(--border)] px-4 py-3">
             <Dialog.Close asChild>
               <button
                 type="button"
@@ -276,7 +276,7 @@ function DestinationSection({
 }) {
   return (
     <section>
-      <h3 className="px-3 pb-1 text-[11px] font-bold uppercase tracking-wide text-[#6c6f75]">
+      <h3 className="px-3 pb-1 text-[11px] font-bold uppercase tracking-wide text-[var(--text-muted)]">
         {title}
       </h3>
       <div className="flex flex-col gap-1">{children}</div>
@@ -303,13 +303,13 @@ function DestinationRow({
       onClick={onSelect}
       className={cn(
         "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[80ms]",
-        active ? "bg-[#0F5A8F] text-white" : "text-[#d1d2d3] hover:bg-[#27292d]"
+        active ? "bg-[var(--accent)] text-white" : "text-[var(--text-primary)] hover:bg-[var(--surface-hover)]"
       )}
     >
       <span
         className={cn(
           "flex h-6 w-6 flex-shrink-0 items-center justify-center rounded",
-          active ? "bg-white/15 text-white" : "bg-[#2c2d30] text-[#ababad]"
+          active ? "bg-white/15 text-white" : "bg-[var(--surface-raised)] text-[var(--text-secondary)]"
         )}
       >
         {icon}
@@ -319,14 +319,14 @@ function DestinationRow({
         <span
           className={cn(
             "block truncate text-[12px]",
-            active ? "text-white/75" : "text-[#6c6f75]"
+            active ? "text-white/75" : "text-[var(--text-muted)]"
           )}
         >
           {subtitle}
         </span>
       </span>
       {active && (
-        <span className="ml-auto flex h-4 w-4 items-center justify-center rounded-full bg-white text-[#0F5A8F]">
+        <span className="ml-auto flex h-4 w-4 items-center justify-center rounded-full bg-white text-[var(--accent)]">
           <svg viewBox="0 0 10 10" className="h-2 w-2" aria-hidden>
             <path d="M1 5l3 3 5-6" fill="none" stroke="currentColor" strokeWidth="2" />
           </svg>

--- a/src/components/modals/JumpToSwitcher.tsx
+++ b/src/components/modals/JumpToSwitcher.tsx
@@ -60,6 +60,11 @@ export function JumpToSwitcher({ open, onOpenChange, items }: JumpToSwitcherProp
             inputRef.current?.focus();
           }}
           onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              onOpenChange(false);
+              return;
+            }
             if (event.key === "ArrowDown") {
               event.preventDefault();
               setActiveIndex((index) => Math.min(index + 1, filtered.length - 1));
@@ -97,10 +102,10 @@ export function JumpToSwitcher({ open, onOpenChange, items }: JumpToSwitcherProp
             </Dialog.Close>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-3">
-            <h3 className="px-3 pb-2 text-[12px] font-bold uppercase tracking-wide text-[var(--text-muted)]">
-              {query.trim() ? "Results" : "Recent"}
-            </h3>
+          <h3 className="px-3 pt-3 pb-1 text-[12px] font-bold uppercase tracking-wide text-[var(--text-muted)]">
+            {query.trim() ? "Results" : "Recent"}
+          </h3>
+          <div className="flex-1 overflow-y-auto px-3 pb-3">
             {filtered.length === 0 ? (
               <p className="px-3 py-8 text-center text-[13px] text-[var(--text-muted)]">No matching channels or DMs</p>
             ) : (

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -30,13 +30,13 @@ export function SettingsModal({ open, onOpenChange, account, onSignOut }: Props)
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 z-[70] flex h-[540px] w-[720px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[#3f4144] bg-[#1a1d21] text-[#d1d2d3] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
+          className="fixed left-1/2 top-1/2 z-[70] flex h-[540px] w-[720px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
           aria-describedby={undefined}
         >
           <Dialog.Title className="sr-only">Settings</Dialog.Title>
 
-          <nav className="flex w-[200px] flex-shrink-0 flex-col gap-1 border-r border-[#3f4144] bg-[#19171d] p-3">
-            <p className="px-2 pb-2 pt-1 text-[11px] font-bold uppercase tracking-wider text-[#6c6f75]">
+          <nav className="flex w-[200px] flex-shrink-0 flex-col gap-1 border-r border-[var(--border)] bg-[var(--sidebar-bg)] p-3">
+            <p className="px-2 pb-2 pt-1 text-[11px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
               Settings
             </p>
             <TabButton icon={User} label="Account" active={tab === "account"} onClick={() => setTab("account")} />
@@ -46,11 +46,11 @@ export function SettingsModal({ open, onOpenChange, account, onSignOut }: Props)
           </nav>
 
           <section className="flex flex-1 flex-col overflow-hidden">
-            <header className="flex h-[49px] flex-shrink-0 items-center justify-between border-b border-[#3f4144] px-5">
-              <h2 className="text-[15px] font-black text-white">{TAB_TITLES[tab]}</h2>
+            <header className="flex h-[49px] flex-shrink-0 items-center justify-between border-b border-[var(--border)] px-5">
+              <h2 className="text-[15px] font-black text-[var(--text-primary)]">{TAB_TITLES[tab]}</h2>
               <Dialog.Close
                 aria-label="Close"
-                className="flex h-7 w-7 items-center justify-center rounded text-[#ababad] hover:bg-[#27292d] hover:text-white"
+                className="flex h-7 w-7 items-center justify-center rounded text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
               >
                 <X size={16} />
               </Dialog.Close>
@@ -92,7 +92,7 @@ function TabButton({
       type="button"
       onClick={onClick}
       className={`flex items-center gap-2 rounded-md px-2 py-[6px] text-left text-[14px] transition-colors duration-100 ${
-        active ? "bg-[#0F5A8F] text-white" : "text-[#ababad] hover:bg-[#27242c] hover:text-white"
+        active ? "bg-[var(--accent)] text-white" : "text-[var(--text-secondary)] hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-primary)]"
       }`}
     >
       <Icon size={14} />
@@ -105,14 +105,14 @@ function AccountPanel({ account, onSignOut }: { account: AccountInfo; onSignOut?
   return (
     <div className="flex flex-col gap-5">
       <div className="flex items-center gap-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded bg-[#0F5A8F] text-[16px] font-bold text-white">
+        <div className="flex h-12 w-12 items-center justify-center rounded bg-[var(--accent)] text-[16px] font-bold text-white">
           {account.initials}
         </div>
         <div className="min-w-0">
-          <p className="truncate text-[15px] font-black text-white">{account.name}</p>
-          {account.email && <p className="truncate text-[13px] text-[#ababad]">{account.email}</p>}
+          <p className="truncate text-[15px] font-black text-[var(--text-primary)]">{account.name}</p>
+          {account.email && <p className="truncate text-[13px] text-[var(--text-secondary)]">{account.email}</p>}
           {account.badge && (
-            <p className="mt-1 inline-block rounded bg-[#27292d] px-2 py-[2px] text-[11px] font-bold uppercase tracking-wide text-[#ababad]">
+            <p className="mt-1 inline-block rounded bg-[var(--surface-raised)] px-2 py-[2px] text-[11px] font-bold uppercase tracking-wide text-[var(--text-secondary)]">
               {account.badge}
             </p>
           )}
@@ -120,14 +120,14 @@ function AccountPanel({ account, onSignOut }: { account: AccountInfo; onSignOut?
       </div>
 
       <FieldGroup label="Signed in via" hint="Microsoft 365 (read-only)">
-        <p className="text-[13px] text-[#ababad]">All data lives in Microsoft Graph. Teamsly never stores messages, files, or credentials locally.</p>
+        <p className="text-[13px] text-[var(--text-secondary)]">All data lives in Microsoft Graph. Teamsly never stores messages, files, or credentials locally.</p>
       </FieldGroup>
 
       {onSignOut && (
         <button
           type="button"
           onClick={onSignOut}
-          className="inline-flex w-fit items-center gap-2 rounded-md border border-[#3f4144] bg-transparent px-3 py-[6px] text-[13px] font-bold text-[#d1d2d3] hover:border-[#cd2553] hover:bg-[rgba(205,37,83,0.1)] hover:text-[#cd2553]"
+          className="inline-flex w-fit items-center gap-2 rounded-md border border-[var(--border)] bg-transparent px-3 py-[6px] text-[13px] font-bold text-[var(--text-primary)] hover:border-[var(--status-busy)] hover:bg-[rgba(205,37,83,0.1)] hover:text-[var(--status-busy)]"
         >
           <LogOut size={14} />
           Sign out
@@ -192,7 +192,7 @@ function NotificationsPanel() {
           value={keywords}
           onChange={(event) => setKeywords(event.target.value)}
           placeholder="launch, incident, blocker"
-          className="h-8 rounded-md border border-[#3f4144] bg-[#222529] px-3 text-[13px] text-[#d1d2d3] outline-none transition-colors duration-150 placeholder:text-[#6c6f75] focus:border-white"
+          className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
         />
       </FieldGroup>
       <FieldGroup
@@ -204,7 +204,7 @@ function NotificationsPanel() {
           onChange={(event) => handleMutedChange(event.target.value)}
           placeholder="standup, lunch, friday-jam"
           rows={2}
-          className="min-h-[56px] resize-y rounded-md border border-[#3f4144] bg-[#222529] px-3 py-2 text-[13px] text-[#d1d2d3] outline-none transition-colors duration-150 placeholder:text-[#6c6f75] focus:border-white"
+          className="min-h-[56px] resize-y rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
         />
       </FieldGroup>
       <FieldGroup
@@ -217,27 +217,27 @@ function NotificationsPanel() {
             value={quietHoursEnabled}
             onChange={setQuietHoursEnabled}
           />
-          <div className="flex items-center gap-2 text-[13px] text-[#d1d2d3]">
-            <span className="text-[12px] text-[#6c6f75]">From</span>
+          <div className="flex items-center gap-2 text-[13px] text-[var(--text-primary)]">
+            <span className="text-[12px] text-[var(--text-muted)]">From</span>
             <input
               type="time"
               value={quietHoursStart}
               onChange={(event) => setQuietHoursStart(event.target.value)}
               disabled={!quietHoursEnabled}
-              className="h-8 rounded-md border border-[#3f4144] bg-[#222529] px-2 text-[13px] text-[#d1d2d3] outline-none transition-colors duration-150 focus:border-white disabled:opacity-50"
+              className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 focus:border-[var(--text-primary)] disabled:opacity-50"
             />
-            <span className="text-[12px] text-[#6c6f75]">to</span>
+            <span className="text-[12px] text-[var(--text-muted)]">to</span>
             <input
               type="time"
               value={quietHoursEnd}
               onChange={(event) => setQuietHoursEnd(event.target.value)}
               disabled={!quietHoursEnabled}
-              className="h-8 rounded-md border border-[#3f4144] bg-[#222529] px-2 text-[13px] text-[#d1d2d3] outline-none transition-colors duration-150 focus:border-white disabled:opacity-50"
+              className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 focus:border-[var(--text-primary)] disabled:opacity-50"
             />
           </div>
         </div>
       </FieldGroup>
-      <p className="mt-2 text-[12px] text-[#6c6f75]">
+      <p className="mt-2 text-[12px] text-[var(--text-muted)]">
         Mute keywords and quiet hours work for all users. Desktop OS notifications require Pro.
       </p>
     </div>
@@ -280,24 +280,24 @@ function AppearancePanel() {
 
 function AboutPanel() {
   return (
-    <div className="flex flex-col gap-3 text-[13px] text-[#d1d2d3]">
+    <div className="flex flex-col gap-3 text-[13px] text-[var(--text-primary)]">
       <div className="flex items-center gap-3">
-        <Logo size={28} className="text-white" />
-        <p className="text-[15px] font-black text-white">Teamsly</p>
+        <Logo size={28} className="text-[var(--text-primary)]" />
+        <p className="text-[15px] font-black text-[var(--text-primary)]">Teamsly</p>
       </div>
-      <p className="text-[#ababad]">Open-source Microsoft Teams client built for focus. All data stays in Microsoft Graph — Teamsly stores nothing.</p>
+      <p className="text-[var(--text-secondary)]">Open-source Microsoft Teams client built for focus. All data stays in Microsoft Graph — Teamsly stores nothing.</p>
       <dl className="grid grid-cols-[100px_1fr] gap-y-1 text-[12px]">
-        <dt className="text-[#6c6f75]">Version</dt>
-        <dd className="text-[#d1d2d3]">0.1.0</dd>
-        <dt className="text-[#6c6f75]">License</dt>
-        <dd className="text-[#d1d2d3]">AGPL-3.0</dd>
-        <dt className="text-[#6c6f75]">Source</dt>
+        <dt className="text-[var(--text-muted)]">Version</dt>
+        <dd className="text-[var(--text-primary)]">0.1.0</dd>
+        <dt className="text-[var(--text-muted)]">License</dt>
+        <dd className="text-[var(--text-primary)]">AGPL-3.0</dd>
+        <dt className="text-[var(--text-muted)]">Source</dt>
         <dd>
           <a
             href="https://github.com/mayurrawte/teamsly"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[#1d9bd1] hover:underline"
+            className="text-[var(--text-link)] hover:underline"
           >
             github.com/mayurrawte/teamsly
           </a>
@@ -311,8 +311,8 @@ function FieldGroup({ label, hint, children }: { label: string; hint?: string; c
   return (
     <div className="flex flex-col gap-2">
       <div>
-        <p className="text-[13px] font-bold text-white">{label}</p>
-        {hint && <p className="text-[12px] text-[#6c6f75]">{hint}</p>}
+        <p className="text-[13px] font-bold text-[var(--text-primary)]">{label}</p>
+        {hint && <p className="text-[12px] text-[var(--text-muted)]">{hint}</p>}
       </div>
       {children}
     </div>
@@ -331,10 +331,10 @@ function ToggleRow({
   onChange: (v: boolean) => void;
 }) {
   return (
-    <label className="flex cursor-pointer items-start justify-between gap-4 rounded-md border border-[#3f4144] bg-[#222529] px-3 py-2 hover:border-[#565856]">
+    <label className="flex cursor-pointer items-start justify-between gap-4 rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 hover:border-[var(--border-input)]">
       <span className="min-w-0 flex-1">
-        <span className="block text-[13px] font-bold text-white">{label}</span>
-        {hint && <span className="mt-[2px] block text-[12px] text-[#6c6f75]">{hint}</span>}
+        <span className="block text-[13px] font-bold text-[var(--text-primary)]">{label}</span>
+        {hint && <span className="mt-[2px] block text-[12px] text-[var(--text-muted)]">{hint}</span>}
       </span>
       <button
         type="button"
@@ -342,7 +342,7 @@ function ToggleRow({
         aria-checked={value}
         onClick={() => onChange(!value)}
         className={`relative mt-[2px] h-5 w-9 flex-shrink-0 rounded-full transition-colors duration-150 ${
-          value ? "bg-[#007a5a]" : "bg-[#565856]"
+          value ? "bg-[var(--status-online)]" : "bg-[var(--border-input)]"
         }`}
       >
         <span
@@ -375,20 +375,20 @@ function RadioRow({
       disabled={disabled}
       className={`flex items-start gap-3 rounded-md border px-3 py-2 text-left transition-colors duration-100 ${
         checked
-          ? "border-[#0F5A8F] bg-[rgba(15,90,143,0.15)]"
-          : "border-[#3f4144] bg-[#222529]"
-      } ${disabled ? "cursor-not-allowed opacity-50" : "hover:border-[#565856]"}`}
+          ? "border-[var(--accent)] bg-[var(--accent-light)]"
+          : "border-[var(--border)] bg-[var(--surface)]"
+      } ${disabled ? "cursor-not-allowed opacity-50" : "hover:border-[var(--border-input)]"}`}
     >
       <span
         className={`mt-[2px] flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border-2 ${
-          checked ? "border-[#0F5A8F]" : "border-[#565856]"
+          checked ? "border-[var(--accent)]" : "border-[var(--border-input)]"
         }`}
       >
-        {checked && <span className="h-2 w-2 rounded-full bg-[#0F5A8F]" />}
+        {checked && <span className="h-2 w-2 rounded-full bg-[var(--accent)]" />}
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block text-[13px] font-bold text-white">{label}</span>
-        {description && <span className="mt-[2px] block text-[12px] text-[#6c6f75]">{description}</span>}
+        <span className="block text-[13px] font-bold text-[var(--text-primary)]">{label}</span>
+        {description && <span className="mt-[2px] block text-[12px] text-[var(--text-muted)]">{description}</span>}
       </span>
     </button>
   );

--- a/src/components/ui/PresenceDot.tsx
+++ b/src/components/ui/PresenceDot.tsx
@@ -13,7 +13,7 @@ export function PresenceDot({ availability, className }: PresenceDotProps) {
       <span
         aria-label="Away"
         className={cn(
-          "absolute bottom-[-2px] right-[-2px] h-[10px] w-[10px] rounded-full border-2 border-[var(--sidebar-bg)] bg-[#e8a838]",
+          "absolute bottom-[-2px] right-[-2px] h-[10px] w-[10px] rounded-full border-2 border-[var(--sidebar-bg)] bg-[var(--status-away)]",
           className
         )}
       />
@@ -25,7 +25,7 @@ export function PresenceDot({ availability, className }: PresenceDotProps) {
       <span
         aria-label="Busy"
         className={cn(
-          "absolute bottom-[-2px] right-[-2px] flex h-[10px] w-[10px] items-center justify-center rounded-full border-2 border-[var(--sidebar-bg)] bg-[#e01e5a]",
+          "absolute bottom-[-2px] right-[-2px] flex h-[10px] w-[10px] items-center justify-center rounded-full border-2 border-[var(--sidebar-bg)] bg-[var(--status-busy)]",
           className
         )}
       >
@@ -38,11 +38,11 @@ export function PresenceDot({ availability, className }: PresenceDotProps) {
   return (
     <span className={cn("absolute bottom-[-2px] right-[-2px] h-[10px] w-[10px]", className)}>
       {/* Ping ring — slow sonar pulse */}
-      <span className="absolute inset-0 rounded-full bg-[#2bac76] opacity-75 animate-[presence-ping_2.5s_ease-out_infinite]" />
+      <span className="absolute inset-0 rounded-full bg-[var(--status-online)] opacity-75 animate-[presence-ping_2.5s_ease-out_infinite]" />
       {/* Solid dot */}
       <span
         aria-label="Available"
-        className="absolute inset-0 rounded-full border-2 border-[var(--sidebar-bg)] bg-[#2bac76]"
+        className="absolute inset-0 rounded-full border-2 border-[var(--sidebar-bg)] bg-[var(--status-online)]"
       />
     </span>
   );

--- a/src/components/ui/ToastViewport.tsx
+++ b/src/components/ui/ToastViewport.tsx
@@ -30,28 +30,28 @@ export function ToastViewport() {
       {toasts.map((toast) => (
         <div
           key={toast.id}
-          className={`rounded-md border border-[#3f4144] bg-[#1a1d21] p-3 text-[#d1d2d3] shadow-[0_8px_32px_rgba(0,0,0,0.45)] ${exiting.has(toast.id) ? "toast-exit" : "toast-enter"}`}
+          className={`rounded-md border border-[var(--border)] bg-[var(--modal-bg)] p-3 text-[var(--text-primary)] shadow-[0_8px_32px_rgba(0,0,0,0.45)] ${exiting.has(toast.id) ? "toast-exit" : "toast-enter"}`}
         >
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
               <p
                 className={
                   toast.tone === "error"
-                    ? "text-[13px] font-bold text-[#e01e5a]"
-                    : "text-[13px] font-bold text-white"
+                    ? "text-[13px] font-bold text-[var(--status-busy)]"
+                    : "text-[13px] font-bold text-[var(--text-primary)]"
                 }
               >
                 {toast.title}
               </p>
               {toast.description && (
-                <p className="mt-1 text-[12px] text-[#ababad]">{toast.description}</p>
+                <p className="mt-1 text-[12px] text-[var(--text-secondary)]">{toast.description}</p>
               )}
             </div>
             <button
               type="button"
               aria-label="Dismiss"
               onClick={() => handleDismiss(toast.id)}
-              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-[#ababad] hover:bg-[#27292d] hover:text-white"
+              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
             >
               <X size={14} />
             </button>

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -52,6 +52,13 @@ interface WorkspaceState {
    * on reload MessageItem re-decodes and re-expires, so the set self-heals.
    */
   expiredMessageIds: Set<string>;
+  /**
+   * True once `hydrateMessageCache` has finished writing IDB data into the
+   * store. Views use this to defer the loading skeleton until after hydration
+   * so a cached chat never flashes blank. Not persisted — resets to false on
+   * every page reload (intentionally: IDB hydration must run each time).
+   */
+  isHydrated: boolean;
 
   setTeams: (teams: MSTeam[]) => void;
   setActiveTeam: (id: string) => void;
@@ -131,6 +138,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       starredIds: [],
       pendingAnchorMessageId: null,
       expiredMessageIds: new Set<string>(),
+      isHydrated: false,
 
       setTeams: (teams) => set({ teams }),
       setActiveTeam: (id) => set({ activeTeamId: id, activeChannelId: null }),
@@ -202,7 +210,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           for (const [k, v] of Object.entries(s.messagesByContext)) {
             merged[k] = v;
           }
-          return { messagesByContext: merged };
+          return { messagesByContext: merged, isHydrated: true };
         });
       },
 


### PR DESCRIPTION
UI/UX polish pass (audit: `docs/superpowers/specs/2026-05-29-ui-polish-audit.md`). Goal: feel like a native client, not a web app.

## Changes
- **Full theming with CSS vars** (#12, #16): left nav rail, app notification banner, toasts, presence dots, composer, conversation header, Settings/Forward modals, Emoji/GIF pickers, attachment & adaptive & link-preview cards, context-files tab. Removed hardcoded Slack-grey/blue hex (incl. ~39× `#0F5A8F`) so everything follows palette/accent/light-mode. Third-party brand colors (Loom/Figma/Teams) intentionally kept.
- **Instant chat reopen** (#13): gate the loading skeleton on an `isHydrated` flag so a previously-loaded chat renders instantly from the IndexedDB cache.
- **DM header name** (#14): patch fetched members into the store so 1:1 DM headers show the contact's name; added a fallback.
- **Quick-switcher** (#15): remove the top gap (header out of the scroll container) + explicit Escape-to-close.

## Test plan (preview deploy — verify in BOTH light and dark mode)
- [ ] Left rail + all modals/pickers follow palette + light mode (no Slack-grey, no white-on-white)
- [ ] Reopen a previously-viewed chat → no skeleton flash
- [ ] 1:1 DM header shows the contact's full name
- [ ] Cmd-K switcher: no top gap, Esc closes

Closes #12
Closes #13
Closes #14
Closes #15
Closes #16