### PR TITLE
UI polish: native-feel interactions + spacing

### DIFF
--- a/src/components/messages/DateDivider.tsx
+++ b/src/components/messages/DateDivider.tsx
@@ -9,7 +9,7 @@ export function DateDivider({ date }: Props) {
     <div role="separator" className="flex items-center px-4 my-3 select-none">
       <div className="h-px flex-1 bg-[var(--border)]" />
       <div
-        className="mx-3 rounded-full border border-[var(--border)] bg-[var(--surface)] px-3 py-0.5 text-[11px] font-bold text-[var(--text-muted)]"
+        className="mx-3 rounded-full border border-[var(--border)] bg-[var(--surface)] px-3 py-1 leading-tight text-[11px] font-bold text-[var(--text-muted)]"
       >
         {formatDateDivider(date)}
       </div>

--- a/src/components/messages/IntroCard.tsx
+++ b/src/components/messages/IntroCard.tsx
@@ -34,7 +34,7 @@ export function ChannelIntroCard({
   createdDateTime,
 }: ChannelIntroCardProps) {
   return (
-    <div className="mx-4 mb-4 mt-4 rounded-lg border border-[var(--border)]/50 bg-[var(--content-bg)] px-5 py-4">
+    <div className="motion-fade-up mx-4 mb-4 mt-4 rounded-lg border border-[var(--border)]/50 bg-[var(--content-bg)] px-5 py-4">
       <div className="mb-2.5 flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--accent)]/20">
         <Hash className="h-5 w-5 text-[var(--accent)]" />
       </div>
@@ -77,7 +77,7 @@ export function DmIntroCard({
 
   if (isSelfDm) {
     return (
-      <div className="mx-4 mb-4 mt-4 rounded-lg border border-[var(--border)]/50 bg-[var(--content-bg)] px-5 py-4">
+      <div className="motion-fade-up mx-4 mb-4 mt-4 rounded-lg border border-[var(--border)]/50 bg-[var(--content-bg)] px-5 py-4">
         <div className="mb-2.5 flex -space-x-2">
           {displayMembers.slice(0, 2).map((m) => (
             <Avatar
@@ -97,7 +97,7 @@ export function DmIntroCard({
   }
 
   return (
-    <div className="mx-4 mb-4 mt-4 rounded-lg border border-[var(--border)]/50 bg-[var(--content-bg)] px-5 py-4">
+    <div className="motion-fade-up mx-4 mb-4 mt-4 rounded-lg border border-[var(--border)]/50 bg-[var(--content-bg)] px-5 py-4">
       <div className="mb-2.5 flex -space-x-2">
         {displayMembers.slice(0, 3).map((m) => (
           <div key={m.id} className="ring-2 ring-[var(--content-bg)]" style={{ borderRadius: 4 }}>

--- a/src/components/messages/MessageHeader.tsx
+++ b/src/components/messages/MessageHeader.tsx
@@ -42,13 +42,13 @@ function TabRow({
   onTabChange: (tab: Tab) => void;
 }) {
   return (
-    <div className="flex items-end gap-1">
+    <div className="flex items-center gap-1">
       {TAB_LABELS.map(({ id, label }) => (
         <button
           key={id}
           type="button"
           onClick={() => onTabChange(id)}
-          className={`px-3 py-1 text-[13px] font-medium transition-colors focus-ring ${
+          className={`px-3 py-2 text-[13px] font-medium transition-colors focus-ring ${
             activeTab === id
               ? "border-b-2 border-[var(--text-primary)] text-[var(--text-primary)]"
               : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"

--- a/src/components/messages/MessageHoverToolbar.tsx
+++ b/src/components/messages/MessageHoverToolbar.tsx
@@ -34,7 +34,7 @@ export function MessageHoverToolbar({
 
   return (
     <div
-      className="absolute right-2 top-[-20px] z-[100] flex translate-x-1 translate-y-1 gap-[2px] rounded-md border border-[var(--border)] bg-[#1a1d21] px-1 py-[2px] opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.35)] transition-[opacity,transform] duration-[80ms] ease-out group-hover:translate-x-0 group-hover:translate-y-0 group-hover:opacity-100"
+      className="absolute right-2 top-[-20px] z-[100] flex gap-[2px] rounded-md border border-[var(--border)] bg-[#1a1d21] px-1 py-[2px] opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.35)] transition-opacity duration-[80ms] ease-out group-hover:opacity-100"
       role="toolbar"
       aria-label="Message actions"
     >

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -1033,7 +1033,7 @@ export function MessageInput({
 
         <div className="rounded-lg border border-[var(--border-input)] bg-[var(--surface)] transition-[border-color,box-shadow] duration-200 focus-within:border-[var(--accent)] focus-within:shadow-[0_0_0_3px_var(--accent-light)]">
           {/* Formatting toolbar */}
-          <div className="flex items-center gap-0.5 border-b border-[var(--border)] px-2 py-1">
+          <div className="flex items-center gap-0.5 border-b border-[var(--border)] px-3 py-1">
             {toolbarButtons.map((item, idx) => {
               if (item === "divider") {
                 return (

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -476,7 +476,7 @@ export function MessageItem({
         ) : (
           hasBody && (
             <>
-              <div className="message-body break-words text-[14px] leading-[1.5] text-[var(--text-primary)]">
+              <div style={bodyDensityStyle} className="message-body break-words text-[var(--text-primary)]">
                 {disappearing
                   ? decoded
                     ? renderMessageBody(decoded.body, "text")

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -260,7 +260,7 @@ export function MessageItem({
         <button
           type="button"
           onClick={() => onRetry(message.__originalText ?? content)}
-          className="text-[12px] font-medium text-[var(--accent)] hover:underline"
+          className="rounded px-2 py-1 text-[12px] font-medium text-[var(--accent)] transition-colors hover:bg-[var(--surface-hover)] focus-ring"
         >
           Retry
         </button>
@@ -269,7 +269,7 @@ export function MessageItem({
         <button
           type="button"
           onClick={() => onDiscard(message.id)}
-          className="text-[12px] font-medium text-[var(--text-muted)] hover:underline"
+          className="rounded px-2 py-1 text-[12px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-hover)] focus-ring"
         >
           Discard
         </button>

--- a/src/components/messages/ReactionPill.tsx
+++ b/src/components/messages/ReactionPill.tsx
@@ -69,7 +69,7 @@ export function ReactionPill({ reactionType, count, active, onClick }: ReactionP
         type="button"
         onClick={handleClick}
         className={[
-          "inline-flex h-[24px] items-center gap-1 rounded-full border px-2 text-[12px] transition-colors duration-150 focus-ring",
+          "inline-flex h-6 items-center gap-1 rounded-full border px-2.5 py-0.5 text-[12px] transition-colors duration-150 focus-ring",
           bursting ? "react-burst" : "",
           active
             ? "border-[var(--accent)] bg-[var(--reaction-active-bg)] text-[var(--text-primary)]"
@@ -89,7 +89,7 @@ export function AddReactionPill({ onSelect }: { onSelect: (reaction: ReactionTyp
       <button
         type="button"
         aria-label="Add reaction"
-        className="inline-flex h-[24px] items-center rounded-full border border-[var(--reaction-border)] bg-[var(--reaction-bg)] px-2 text-[var(--text-secondary)] transition-colors duration-150 hover:border-[var(--accent)] hover:bg-[var(--reaction-active-bg)] hover:text-white focus-ring"
+        className="inline-flex h-6 items-center rounded-full border border-[var(--reaction-border)] bg-[var(--reaction-bg)] px-2.5 py-0.5 text-[var(--text-secondary)] transition-colors duration-150 hover:border-[var(--accent)] hover:bg-[var(--reaction-active-bg)] hover:text-white focus-ring"
       >
         <Plus size={13} />
       </button>

--- a/src/components/messages/ThreadPanel.tsx
+++ b/src/components/messages/ThreadPanel.tsx
@@ -83,7 +83,7 @@ export function ThreadPanel({ message, open, onClose, onSendReply, onForward }: 
     <aside
       className={[
         "absolute bottom-0 right-0 top-0 z-50 flex w-[360px] flex-col border-l border-[#3f4144] bg-[#1a1d21] shadow-[-4px_0_16px_rgba(0,0,0,0.3)]",
-        "transition-transform duration-[250ms] ease-[cubic-bezier(0.34,1.56,0.64,1)]",
+        "[transition:transform_var(--motion-base)_var(--ease-spring)]",
         open ? "translate-x-0" : "translate-x-full",
       ].join(" ")}
       aria-hidden={!open}

--- a/src/components/modals/FeedbackModal.tsx
+++ b/src/components/modals/FeedbackModal.tsx
@@ -127,9 +127,9 @@ export function FeedbackModal({ open, onOpenChange }: Props) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out" />
+        <Dialog.Overlay className="search-modal-overlay fixed inset-0 z-[60] bg-black/70 backdrop-blur-[2px]" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 z-[70] w-[500px] max-w-[94vw] max-h-[90vh] -translate-x-1/2 -translate-y-1/2 overflow-y-auto overflow-x-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
+          className="search-modal-content fixed left-1/2 top-1/2 z-[70] w-[500px] max-w-[94vw] max-h-[90vh] -translate-x-1/2 -translate-y-1/2 overflow-y-auto overflow-x-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
           aria-describedby={undefined}
         >
           <Dialog.Title className="sr-only">Send feedback</Dialog.Title>

--- a/src/components/modals/PreferencesModal.tsx
+++ b/src/components/modals/PreferencesModal.tsx
@@ -81,9 +81,9 @@ export function PreferencesModal({ open, onOpenChange }: Props) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-[60] bg-[var(--modal-overlay)] backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out" />
+        <Dialog.Overlay className="search-modal-overlay fixed inset-0 z-[60] bg-[var(--modal-overlay)] backdrop-blur-[2px]" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 z-[70] flex h-[620px] w-[820px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
+          className="search-modal-content fixed left-1/2 top-1/2 z-[70] flex h-[620px] w-[820px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
           aria-describedby={undefined}
         >
           <Dialog.Title className="sr-only">Preferences</Dialog.Title>

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -28,9 +28,9 @@ export function SettingsModal({ open, onOpenChange, account, onSignOut }: Props)
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out" />
+        <Dialog.Overlay className="search-modal-overlay fixed inset-0 z-[60] bg-black/70 backdrop-blur-[2px]" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 z-[70] flex h-[540px] w-[720px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
+          className="search-modal-content fixed left-1/2 top-1/2 z-[70] flex h-[540px] w-[720px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
           aria-describedby={undefined}
         >
           <Dialog.Title className="sr-only">Settings</Dialog.Title>

--- a/src/components/modals/StatusMessageModal.tsx
+++ b/src/components/modals/StatusMessageModal.tsx
@@ -140,9 +140,9 @@ export function StatusMessageModal({ open, onOpenChange }: Props) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out" />
+        <Dialog.Overlay className="search-modal-overlay fixed inset-0 z-[60] bg-black/70 backdrop-blur-[2px]" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 z-[70] w-[460px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
+          className="search-modal-content fixed left-1/2 top-1/2 z-[70] w-[460px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-[0_16px_64px_rgba(0,0,0,0.6)] focus:outline-none"
           aria-describedby={undefined}
         >
           <Dialog.Title className="sr-only">Set a status message</Dialog.Title>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -544,7 +544,7 @@ export function Sidebar() {
 
       <div className="flex-1 overflow-y-auto pb-2">
         {/* Unreads section */}
-        <div className="mb-1">
+        <div className="mb-2">
           <SectionHeader
             label="Unreads"
             icon={<Inbox className="h-3.5 w-3.5" />}
@@ -595,7 +595,7 @@ export function Sidebar() {
         </div>
 
         {/* Threads section */}
-        <div className="mb-1">
+        <div className="mb-2">
           <SectionHeader
             label="Threads"
             icon={<GitBranch className="h-3.5 w-3.5" />}
@@ -616,7 +616,7 @@ export function Sidebar() {
         </div>
 
         {/* Starred section */}
-        <div className="mb-1">
+        <div className="mb-2">
           <SectionHeader
             label="Starred"
             icon={<Star className="h-3.5 w-3.5" />}
@@ -669,7 +669,7 @@ export function Sidebar() {
         </div>
 
         {/* Channels section */}
-        <div className="mb-1">
+        <div className="mb-2">
           <button
             onClick={() => setChannelsOpen((v) => !v)}
             className="group/section flex w-full items-center justify-between px-4 py-1 text-[11px] font-bold uppercase tracking-wider text-[var(--text-muted)] transition-colors duration-[80ms] ease-out hover:text-[var(--text-secondary)] focus:outline-none"
@@ -715,7 +715,7 @@ export function Sidebar() {
         </div>
 
         {/* DMs section */}
-        <div className="mt-3">
+        <div className="mb-2">
           <button
             onClick={() => setDmsOpen((v) => !v)}
             className="group/section flex w-full items-center justify-between px-4 py-1 text-[11px] font-bold uppercase tracking-wider text-[var(--text-muted)] transition-colors duration-[80ms] ease-out hover:text-[var(--text-secondary)] focus:outline-none"

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -588,7 +588,7 @@ export function Sidebar() {
                 />
               ))}
               {totalUnreads === 0 && (
-                <p className="px-4 py-1 text-[12px] text-[var(--text-muted)]">All caught up</p>
+                <p className="motion-fade-up px-4 py-1 text-[12px] text-[var(--text-muted)]">All caught up</p>
               )}
             </div>
           </div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -554,7 +554,7 @@ export function Sidebar() {
           />
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 ease-out",
+              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
               unreadsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -605,7 +605,7 @@ export function Sidebar() {
           />
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 ease-out",
+              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
               threadsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -626,7 +626,7 @@ export function Sidebar() {
           />
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 ease-out",
+              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
               starredOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -688,7 +688,7 @@ export function Sidebar() {
 
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 ease-out",
+              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
               channelsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -734,7 +734,7 @@ export function Sidebar() {
 
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 ease-out",
+              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
               dmsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >


### PR DESCRIPTION
Second polish pass (audit: `docs/superpowers/specs/2026-05-29-ui-polish-audit.md`). All changes are CSS/className tweaks reusing existing motion tokens — no behavior changes.

## Native-feel (#17)
- Remove 1px hover jitter on the message hover toolbar (opacity-only)
- ThreadPanel + sidebar collapsibles use the spring easing token
- Failed-send Retry/Discard buttons get hover bg + focus ring
- Intro cards + "All caught up" empty state fade in
- Uniform open animation across all Radix dialogs (reused SearchModal's classes)
- (Deferred: message-list scroll behavior — needs live feel-testing)

## Spacing (#18)
- Even sidebar section spacing; consistent body font size on grouped messages
- More tactile reaction pills; centered header tabs; aligned composer padding; date-divider padding

## Test plan (preview — check light + dark)
- [ ] Modals open with a consistent fade/scale; no jarring pops
- [ ] Hovering a message: toolbar fades in without shifting
- [ ] Sidebar sections collapse with a spring feel; spacing reads cleanly
- [ ] Reaction pills look tactile; header tabs centered; composer aligned

Closes #17
Closes #18