### PR TITLE
Send later: schedule DMs to deliver at a chosen time

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -14,6 +14,7 @@ import { Logo } from "@/components/ui/Logo";
 import { EMPTY_MESSAGES, useWorkspaceStore } from "@/store/workspace";
 import { useDraftsStore } from "@/store/drafts";
 import { useBookmarksStore } from "@/store/bookmarks";
+import { useScheduledStore } from "@/store/scheduled";
 import { ToastViewport } from "@/components/ui/ToastViewport";
 import { useToastStore } from "@/store/toasts";
 import { sendUnreadCount } from "@/lib/electron-bridge";
@@ -130,6 +131,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     // already-in-memory state so a quick draft typed during boot isn't lost.
     void useDraftsStore.getState().hydrate();
     void useBookmarksStore.getState().hydrate();
+    void useScheduledStore.getState().hydrate();
   }, [hydrateMessageCache]);
 
   // Record visits so the next cold-start prefetch knows what to warm. We watch

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -19,6 +19,7 @@ import { getChatLabel } from "@/lib/utils/chat-label";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
 import { isDisappearing, unwrapMessage, wrapMessage } from "@/lib/utils/disappear";
 import { useRealtimeEvents } from "@/hooks/useRealtimeEvents";
+import { useScheduledStore } from "@/store/scheduled";
 
 export function ChatView({ chatId }: { chatId: string }) {
   const {
@@ -43,9 +44,14 @@ export function ChatView({ chatId }: { chatId: string }) {
     patchChatMembers,
   } = useWorkspaceStore();
   const isHydrated = useWorkspaceStore((s) => s.isHydrated);
+  const scheduledMessages = useScheduledStore((s) => s.scheduled);
+  const addScheduled = useScheduledStore((s) => s.addScheduled);
+  const removeScheduled = useScheduledStore((s) => s.removeScheduled);
+  const markScheduledFailed = useScheduledStore((s) => s.markFailed);
   const [threadMessage, setThreadMessage] = useState<MSMessage | null>(null);
   const [forwardMessage, setForwardMessage] = useState<MSMessage | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("messages");
+  const [scheduledBannerOpen, setScheduledBannerOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<number | undefined>(undefined);
   const showToast = useToastStore((state) => state.showToast);
@@ -73,6 +79,15 @@ export function ChatView({ chatId }: { chatId: string }) {
   const messages = getMessages(chatId);
   const chat = chats.find((c) => c.id === chatId);
 
+  // Pending scheduled ("send later") messages for this chat, soonest-first.
+  const pendingScheduled = useMemo(
+    () =>
+      scheduledMessages
+        .filter((m) => m.contextId === chatId && m.status === "pending")
+        .sort((a, b) => a.scheduleTime - b.scheduleTime),
+    [scheduledMessages, chatId]
+  );
+
   // loadRef lets the realtime handler trigger a fetch without becoming a
   // dependency of the polling effect (which would re-run it on every change).
   const loadRef = useRef<() => Promise<void>>(async () => {});
@@ -98,6 +113,42 @@ export function ChatView({ chatId }: { chatId: string }) {
       }
     }
   }, [chatId, currentUserId, removeMessage]);
+
+  // Deliver any due scheduled ("send later") messages for this chat. Reads
+  // the queue from the store imperatively so it isn't a dependency of the
+  // polling effect. POSTs to the same endpoint as handleSend; on success we
+  // drop the queue entry and reload so the message appears, on failure we
+  // mark it failed so the sweep stops retrying it.
+  const sweepScheduled = useCallback(async () => {
+    const now = Date.now();
+    const due = useScheduledStore
+      .getState()
+      .scheduled.filter(
+        (m) => m.contextId === chatId && m.status === "pending" && m.scheduleTime <= now
+      );
+    for (const m of due) {
+      let outgoing = m.content;
+      if (m.disappearMs) {
+        outgoing = await wrapMessage(chatId, m.content, Date.now() + m.disappearMs);
+      }
+      try {
+        const res = await fetch(`/api/chats/${chatId}/messages`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            content: outgoing,
+            ...(m.mentions?.length ? { mentions: m.mentions } : {}),
+            ...(m.disappearMs ? { contentType: "text" } : {}),
+          }),
+        });
+        if (!res.ok) throw new Error("Failed to send scheduled message");
+        removeScheduled(chatId, m.id);
+        void loadRef.current();
+      } catch {
+        markScheduledFailed(chatId, m.id);
+      }
+    }
+  }, [chatId, removeScheduled, markScheduledFailed]);
 
   // Compute typing indicator visibility — recalculates whenever clockNow ticks
   const { showTypingIndicator, typingPersonName } = useMemo(() => {
@@ -197,6 +248,11 @@ export function ChatView({ chatId }: { chatId: string }) {
     // ~4s auto-delete latency the feature shipped with.
     const sweep = setInterval(() => void sweepExpired(getMessages(chatId)), 4000);
 
+    // Scheduled ("send later") due-sweep — independent cadence, network-free
+    // unless a queued message has actually come due.
+    void sweepScheduled();
+    const scheduleSweep = setInterval(() => void sweepScheduled(), 5000);
+
     // Fire-and-forget: create a Graph change notification subscription so the
     // webhook endpoint can push new DM messages via SSE instead of waiting for poll.
     fetch("/api/realtime/subscribe", {
@@ -218,11 +274,12 @@ export function ChatView({ chatId }: { chatId: string }) {
       cancelled = true;
       clearInterval(interval);
       clearInterval(sweep);
+      clearInterval(scheduleSweep);
       clearInterval(resubscribe);
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatId, isHydrated, setLoadingMessages, setMessages, showToast, sweepExpired]);
+  }, [chatId, isHydrated, setLoadingMessages, setMessages, showToast, sweepExpired, sweepScheduled]);
 
   useRealtimeEvents(
     useCallback(
@@ -237,8 +294,28 @@ export function ChatView({ chatId }: { chatId: string }) {
 
   async function handleSend(
     content: string,
-    options?: { mentions?: { id: string; name: string }[]; disappearMs?: number }
+    options?: { mentions?: { id: string; name: string }[]; disappearMs?: number; scheduleTime?: number }
   ) {
+    // Send later: queue the message client-side instead of POSTing now. The
+    // due-sweep (here + Sidebar) delivers it once scheduleTime arrives. The
+    // composer already cleared the draft before calling us.
+    if (options?.scheduleTime && options.scheduleTime > Date.now()) {
+      addScheduled({
+        contextId: chatId,
+        id: crypto.randomUUID(),
+        content,
+        ...(options.mentions?.length ? { mentions: options.mentions } : {}),
+        ...(options.disappearMs ? { disappearMs: options.disappearMs } : {}),
+        scheduleTime: options.scheduleTime,
+        createdAt: Date.now(),
+        status: "pending",
+      });
+      showToast({
+        title: `Scheduled for ${new Date(options.scheduleTime).toLocaleString()}`,
+      });
+      return;
+    }
+
     const tempId = `temp-${crypto.randomUUID()}`;
     const now = new Date().toISOString();
 
@@ -582,6 +659,50 @@ export function ChatView({ chatId }: { chatId: string }) {
         <ContextFilesTab mode={{ kind: "chat", chatId }} />
       ) : activeTab === "messages" ? (
         <>
+          {pendingScheduled.length > 0 && (
+            <div className="border-b border-[var(--border)] bg-[var(--surface)] text-[13px] text-[var(--text-secondary)]">
+              <button
+                type="button"
+                onClick={() => setScheduledBannerOpen((v) => !v)}
+                className="flex w-full items-center gap-2 px-4 py-1.5 text-left hover:text-[var(--text-primary)]"
+                aria-expanded={scheduledBannerOpen}
+              >
+                <span aria-hidden="true">📅</span>
+                <span className="font-medium text-[var(--text-primary)]">
+                  {pendingScheduled.length} scheduled
+                </span>
+                <span className="text-[var(--text-muted)]">
+                  {scheduledBannerOpen ? "Hide" : "Show"}
+                </span>
+              </button>
+              {scheduledBannerOpen && (
+                <ul className="border-t border-[var(--border)]">
+                  {pendingScheduled.map((m) => (
+                    <li
+                      key={m.id}
+                      className="flex items-center gap-3 px-4 py-1.5"
+                    >
+                      <span className="min-w-0 flex-1 truncate text-[var(--text-primary)]">
+                        {messagePlainText(m.content, "html") || "(empty message)"}
+                      </span>
+                      <span className="flex-shrink-0 text-[12px] text-[var(--text-muted)]">
+                        {new Date(m.scheduleTime).toLocaleString()}
+                      </span>
+                      <button
+                        type="button"
+                        aria-label="Cancel scheduled message"
+                        title="Cancel scheduled message"
+                        onClick={() => removeScheduled(chatId, m.id)}
+                        className="flex-shrink-0 rounded p-0.5 text-[var(--text-secondary)] transition-colors duration-100 hover:bg-[var(--surface-hover)] hover:text-[var(--accent)]"
+                      >
+                        ✕
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
           <MessageFeed
             messages={messages}
             loading={isLoadingMessages}
@@ -618,6 +739,7 @@ export function ChatView({ chatId }: { chatId: string }) {
             currentUserName={currentUserName}
             channelMembers={mentionCandidates}
             allowDisappearing
+            allowSchedule
           />
         </>
       ) : (

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -62,6 +62,7 @@ export interface PendingMention {
 export interface SendOptions {
   mentions?: PendingMention[];
   disappearMs?: number; // when set, parent wraps the content as a disappearing message
+  scheduleTime?: number; // epoch ms; when set, parent queues the message instead of sending now
 }
 
 interface Props {
@@ -101,6 +102,11 @@ interface Props {
    * timer expecting ephemerality while the message is sent as plaintext.
    */
   allowDisappearing?: boolean;
+  /**
+   * Show the send-later (📅) picker. Only DMs wire the client-side queue +
+   * due-sweep, so channels must leave this false.
+   */
+  allowSchedule?: boolean;
 }
 
 // Sentinel mention id for `@everyone`. The chat/channel API routes turn
@@ -176,6 +182,69 @@ function mimeToExt(mimeType: string): string {
 const MAX_FILE_BYTES = 250 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
+// Send-later presets
+// ---------------------------------------------------------------------------
+
+interface SchedulePreset {
+  label: string;
+  /** Returns the target epoch ms, or null when the preset is in the past now. */
+  at: () => number | null;
+}
+
+// Each preset is computed fresh at open time so "Tonight 6pm" disables itself
+// once 18:00 has passed and "Tomorrow 9am" always lands on the next day.
+const SCHEDULE_PRESETS: SchedulePreset[] = [
+  {
+    label: "In 1 hour",
+    at: () => Date.now() + 60 * 60 * 1000,
+  },
+  {
+    label: "Tonight 6pm",
+    at: () => {
+      const d = new Date();
+      d.setHours(18, 0, 0, 0);
+      return d.getTime() > Date.now() ? d.getTime() : null;
+    },
+  },
+  {
+    label: "Tomorrow 9am",
+    at: () => {
+      const d = new Date();
+      d.setDate(d.getDate() + 1);
+      d.setHours(9, 0, 0, 0);
+      return d.getTime();
+    },
+  },
+  {
+    label: "Monday 9am",
+    at: () => {
+      const d = new Date();
+      // 1 = Monday. Days until next Monday (always strictly in the future).
+      const daysUntilMonday = ((1 - d.getDay() + 7) % 7) || 7;
+      d.setDate(d.getDate() + daysUntilMonday);
+      d.setHours(9, 0, 0, 0);
+      return d.getTime();
+    },
+  },
+];
+
+/** Format an epoch ms for the active-state pill + datetime-local input. */
+function formatScheduleLabel(ms: number): string {
+  return new Date(ms).toLocaleString(undefined, {
+    weekday: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** Convert epoch ms to the `YYYY-MM-DDTHH:mm` string a datetime-local wants. */
+function toDatetimeLocalValue(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
@@ -192,6 +261,7 @@ export function MessageInput({
   currentUserId = "",
   channelMembers,
   allowDisappearing,
+  allowSchedule,
 }: Props) {
   const [value, setValue] = useState("");
   const [sending, setSending] = useState(false);
@@ -199,6 +269,8 @@ export function MessageInput({
   const [emojiOpen, setEmojiOpen] = useState(false);
   const [disappearMs, setDisappearMs] = useState<number | null>(null);
   const [showDisappearMenu, setShowDisappearMenu] = useState(false);
+  const [scheduleTime, setScheduleTime] = useState<number | null>(null);
+  const [showScheduleMenu, setShowScheduleMenu] = useState(false);
   const emojiAnchorRef = useRef<HTMLButtonElement>(null);
   const emojiContainerRef = useRef<HTMLDivElement>(null);
   // Mentions the user has accepted via the autocomplete (or `@everyone`).
@@ -220,6 +292,9 @@ export function MessageInput({
   // draft mutation. When `contextId` is undefined (thread reply composer),
   // skip persistence entirely.
   useEffect(() => {
+    // A schedule selection is per-composition; never carry it across chats.
+    setScheduleTime(null);
+    setShowScheduleMenu(false);
     if (!contextId) {
       setValue("");
       return;
@@ -581,10 +656,12 @@ export function MessageInput({
         {
           ...(mentionsForSend.length > 0 ? { mentions: mentionsForSend } : {}),
           ...(disappearMs ? { disappearMs } : {}),
+          ...(scheduleTime ? { scheduleTime } : {}),
         }
       );
       setPendingMentions([]);
       setDisappearMs(null);
+      setScheduleTime(null);
     } catch {
       setValue(trimmed);
     } finally {
@@ -1207,20 +1284,87 @@ export function MessageInput({
               </div>
               )}
 
+              {/* Send-later (scheduled message) picker */}
+              {allowSchedule && (
+              <div className="relative">
+                <button
+                  type="button"
+                  aria-label="Schedule message"
+                  onClick={() => setShowScheduleMenu((v) => !v)}
+                  className={`rounded p-1 text-[15px] transition-colors press-snap ${
+                    scheduleTime ? "text-[var(--accent)]" : "text-[var(--text-secondary)] hover:text-white"
+                  }`}
+                >
+                  📅{scheduleTime ? <span className="ml-[2px] text-[10px]">{formatScheduleLabel(scheduleTime)}</span> : null}
+                </button>
+                {showScheduleMenu && (
+                  <div className="absolute bottom-full right-0 z-50 mb-2 min-w-[200px] rounded-md border border-[var(--border)] bg-[var(--modal-bg)] py-1 shadow-lg">
+                    {scheduleTime !== null && (
+                      <button
+                        type="button"
+                        onClick={() => { setScheduleTime(null); setShowScheduleMenu(false); }}
+                        className="block w-full px-3 py-1 text-left text-[13px] text-[var(--accent)] hover:bg-[var(--surface-hover)]"
+                      >
+                        Send now (clear)
+                      </button>
+                    )}
+                    {SCHEDULE_PRESETS.map((preset) => {
+                      const at = preset.at();
+                      return (
+                        <button
+                          key={preset.label}
+                          type="button"
+                          disabled={at === null}
+                          onClick={() => { if (at !== null) { setScheduleTime(at); setShowScheduleMenu(false); } }}
+                          className={`block w-full px-3 py-1 text-left text-[13px] hover:bg-[var(--surface-hover)] ${
+                            at === null
+                              ? "cursor-not-allowed text-[var(--text-muted)] opacity-50"
+                              : scheduleTime === at
+                                ? "text-[var(--accent)]"
+                                : "text-[var(--text-primary)]"
+                          }`}
+                        >
+                          {preset.label}
+                        </button>
+                      );
+                    })}
+                    <div className="my-1 h-px bg-[var(--border)]" aria-hidden="true" />
+                    <label className="block px-3 py-1 text-[11px] text-[var(--text-muted)]">
+                      Custom time
+                      <input
+                        type="datetime-local"
+                        min={toDatetimeLocalValue(Date.now())}
+                        value={scheduleTime !== null ? toDatetimeLocalValue(scheduleTime) : ""}
+                        onChange={(e) => {
+                          const next = e.target.value ? new Date(e.target.value).getTime() : NaN;
+                          if (!Number.isNaN(next) && next > Date.now()) {
+                            setScheduleTime(next);
+                          }
+                        }}
+                        className="mt-1 block w-full rounded border border-[var(--border-input)] bg-[var(--surface)] px-2 py-1 text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+                      />
+                    </label>
+                  </div>
+                )}
+              </div>
+              )}
+
               <button
                 ref={sendButtonRef}
                 type="button"
-                aria-label="Send message"
+                aria-label={scheduleTime ? "Schedule message" : "Send message"}
                 onClick={submit}
                 disabled={!canSend}
                 className={cn(
-                  "relative overflow-hidden flex h-8 w-8 items-center justify-center rounded transition-[background,color,transform] duration-150 ease-out focus-ring",
+                  "relative overflow-hidden flex h-8 items-center justify-center rounded transition-[background,color,transform] duration-150 ease-out focus-ring",
+                  scheduleTime ? "w-auto gap-1 px-2.5 text-[13px] font-medium" : "w-8",
                   canSend
                     ? "bg-[var(--status-online)] text-white hover:opacity-90 hover:scale-105 active:scale-95"
                     : "text-[var(--text-muted)]"
                 )}
               >
                 <Send className="h-4 w-4" />
+                {scheduleTime ? <span>Schedule</span> : null}
               </button>
             </div>
           </div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -11,7 +11,8 @@ import { clearAll as clearDraftsCache } from "@/lib/storage/drafts";
 import { clearAll as clearBookmarksCache } from "@/lib/storage/bookmarks";
 import { clearAllScheduled } from "@/lib/storage/scheduled-messages";
 import { cn } from "@/lib/utils";
-import { isDisappearing, unwrapMessage } from "@/lib/utils/disappear";
+import { isDisappearing, unwrapMessage, wrapMessage } from "@/lib/utils/disappear";
+import { useScheduledStore } from "@/store/scheduled";
 
 async function sweepAllDms(
   chatIds: string[],
@@ -36,6 +37,40 @@ async function sweepAllDms(
       } catch {
         /* best-effort */
       }
+    }
+  }
+}
+
+// Deliver due scheduled ("send later") DMs across every chat — the safety
+// net for chats the user isn't currently viewing (ChatView sweeps the open
+// one on a faster cadence). Mirrors sweepAllDms: best-effort POST to the
+// same /api/chats/{id}/messages endpoint, drop the queue entry on success
+// and mark it failed otherwise so we don't keep retrying a doomed send.
+async function sweepAllScheduledDms() {
+  const now = Date.now();
+  const due = useScheduledStore
+    .getState()
+    .scheduled.filter((m) => m.status === "pending" && m.scheduleTime <= now);
+  const { removeScheduled, markFailed } = useScheduledStore.getState();
+  for (const m of due) {
+    let outgoing = m.content;
+    if (m.disappearMs) {
+      outgoing = await wrapMessage(m.contextId, m.content, Date.now() + m.disappearMs);
+    }
+    try {
+      const res = await fetch(`/api/chats/${m.contextId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: outgoing,
+          ...(m.mentions?.length ? { mentions: m.mentions } : {}),
+          ...(m.disappearMs ? { contentType: "text" } : {}),
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to send scheduled message");
+      removeScheduled(m.contextId, m.id);
+    } catch {
+      markFailed(m.contextId, m.id);
     }
   }
 }
@@ -141,6 +176,8 @@ export function Sidebar() {
           ws.removeMessage,
           ws.currentUserId
         );
+        // Deliver any due scheduled DMs on the same 15s cadence + focus.
+        void sweepAllScheduledDms();
       } catch {
         if (!cancelled && !toastShown) {
           toastShown = true;

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import { signOut } from "next-auth/react";
 import { clearAll as clearMessageCache } from "@/lib/storage/message-cache";
 import { clearAll as clearDraftsCache } from "@/lib/storage/drafts";
 import { clearAll as clearBookmarksCache } from "@/lib/storage/bookmarks";
+import { clearAllScheduled } from "@/lib/storage/scheduled-messages";
 import { cn } from "@/lib/utils";
 import { isDisappearing, unwrapMessage } from "@/lib/utils/disappear";
 
@@ -43,7 +44,7 @@ async function handleSignOut() {
   // Drop the IDB caches before redirect so a previous user's messages,
   // drafts, and saved bookmarks don't leak to the next sign-in on the
   // same device.
-  await Promise.all([clearMessageCache(), clearDraftsCache(), clearBookmarksCache()]);
+  await Promise.all([clearMessageCache(), clearDraftsCache(), clearBookmarksCache(), clearAllScheduled()]);
   await signOut({ callbackUrl: "/" });
 }
 import { UserFooter } from "./UserFooter";

--- a/src/lib/storage/drafts.ts
+++ b/src/lib/storage/drafts.ts
@@ -15,10 +15,11 @@
  */
 
 const DB_NAME = "teamsly";
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const MESSAGE_CACHE_STORE = "messages-by-context";
 const DRAFTS_STORE = "drafts";
 const BOOKMARKS_STORE = "bookmarks";
+const SCHEDULED_STORE = "scheduled-messages";
 
 interface DraftRecord {
   contextId: string;
@@ -58,6 +59,12 @@ function openDb(): Promise<IDBDatabase | null> {
             keyPath: ["contextId", "messageId"],
           });
           store.createIndex("savedAt", "savedAt");
+        }
+        if (!db.objectStoreNames.contains(SCHEDULED_STORE)) {
+          const store = db.createObjectStore(SCHEDULED_STORE, {
+            keyPath: ["contextId", "id"],
+          });
+          store.createIndex("scheduleTime", "scheduleTime");
         }
       };
       request.onsuccess = () => resolve(request.result);

--- a/src/lib/storage/scheduled-messages.ts
+++ b/src/lib/storage/scheduled-messages.ts
@@ -1,0 +1,170 @@
+/**
+ * IndexedDB-backed queue for "send later" / scheduled messages.
+ *
+ * Why this exists: New Teams has no client-side scheduled-send and Graph
+ * doesn't expose a server-side one we can drive without our own backend.
+ * We hold the composed message client-side and POST it to the existing
+ * `/api/chats/{chatId}/messages` endpoint once its `scheduleTime` is due —
+ * a due-sweep runs in ChatView (current chat) and Sidebar (all DMs) on the
+ * same cadence as the disappearing-message sweep.
+ *
+ * Schema: keyed by the composite `[contextId, id]` (contextId = chatId,
+ * id = a per-message UUID) so the same chat can hold many pending sends and
+ * each is removed cleanly once delivered. A `scheduleTime` secondary index
+ * lets the sweep find due entries cheaply.
+ *
+ * Scope: DMs only (1:1 + group chats), not channels.
+ *
+ * Mirrors `bookmarks.ts`'s patterns: own object store under the shared
+ * `teamsly` DB, swallow errors, console.warn on failure. UI stays instant.
+ */
+
+import { openTeamslyDb } from "./drafts";
+
+const STORE_NAME = "scheduled-messages";
+
+export interface ScheduledMessage {
+  /** Chat id the message will be sent to. */
+  contextId: string;
+  /** Per-message UUID (crypto.randomUUID()). */
+  id: string;
+  /** HTML body, already rendered the way handleSend produces it. */
+  content: string;
+  /** Structured @mentions, same shape the send handler expects. */
+  mentions?: { id: string; name: string }[];
+  /** Set when the scheduled message should also disappear after sending. */
+  disappearMs?: number;
+  /** Epoch ms at which the message becomes due to send. */
+  scheduleTime: number;
+  /** Epoch ms the schedule was created. */
+  createdAt: number;
+  status: "pending" | "failed";
+}
+
+function openDb(): Promise<IDBDatabase | null> {
+  return openTeamslyDb();
+}
+
+/**
+ * Read every scheduled message, soonest-first. Returns `[]` on any failure
+ * or if IDB is unavailable. Never throws.
+ */
+export async function loadAllScheduled(): Promise<ScheduledMessage[]> {
+  if (typeof window === "undefined") return [];
+  const db = await openDb();
+  if (!db) return [];
+
+  return new Promise<ScheduledMessage[]>((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, "readonly");
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.getAll();
+      request.onsuccess = () => {
+        const records = (request.result ?? []) as ScheduledMessage[];
+        // Soonest-due first — sizes are small (a handful per user) so a
+        // single in-memory sort is simpler than cursoring the index.
+        records.sort((a, b) => a.scheduleTime - b.scheduleTime);
+        resolve(records);
+      };
+      request.onerror = () => {
+        console.warn("[scheduled] loadAll failed", request.error);
+        resolve([]);
+      };
+    } catch (err) {
+      console.warn("[scheduled] loadAll threw", err);
+      resolve([]);
+    }
+  });
+}
+
+/**
+ * Add (or overwrite) a single scheduled message. Tolerates failures silently.
+ */
+export async function addScheduled(message: ScheduledMessage): Promise<void> {
+  if (typeof window === "undefined") return;
+  const db = await openDb();
+  if (!db) return;
+
+  return new Promise<void>((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      store.put(message);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => {
+        console.warn("[scheduled] add failed", tx.error);
+        resolve();
+      };
+      tx.onabort = () => {
+        console.warn("[scheduled] add aborted", tx.error);
+        resolve();
+      };
+    } catch (err) {
+      console.warn("[scheduled] add threw", err);
+      resolve();
+    }
+  });
+}
+
+/**
+ * Remove a single scheduled message by its composite key.
+ */
+export async function removeScheduled(
+  contextId: string,
+  id: string
+): Promise<void> {
+  if (typeof window === "undefined") return;
+  const db = await openDb();
+  if (!db) return;
+
+  return new Promise<void>((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      store.delete([contextId, id]);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => {
+        console.warn("[scheduled] remove failed", tx.error);
+        resolve();
+      };
+      tx.onabort = () => {
+        console.warn("[scheduled] remove aborted", tx.error);
+        resolve();
+      };
+    } catch (err) {
+      console.warn("[scheduled] remove threw", err);
+      resolve();
+    }
+  });
+}
+
+/**
+ * Drop every scheduled message. Called on sign-out alongside the message
+ * cache, drafts, and bookmarks clear so a previous user's queued sends
+ * don't leak to the next sign-in on the same device.
+ */
+export async function clearAllScheduled(): Promise<void> {
+  if (typeof window === "undefined") return;
+  const db = await openDb();
+  if (!db) return;
+
+  return new Promise<void>((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      store.clear();
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => {
+        console.warn("[scheduled] clearAll failed", tx.error);
+        resolve();
+      };
+      tx.onabort = () => {
+        console.warn("[scheduled] clearAll aborted", tx.error);
+        resolve();
+      };
+    } catch (err) {
+      console.warn("[scheduled] clearAll threw", err);
+      resolve();
+    }
+  });
+}

--- a/src/store/scheduled.ts
+++ b/src/store/scheduled.ts
@@ -1,0 +1,87 @@
+import { create } from "zustand";
+import {
+  addScheduled as addScheduledToIdb,
+  clearAllScheduled as clearAllScheduledFromIdb,
+  loadAllScheduled,
+  removeScheduled as removeScheduledFromIdb,
+  type ScheduledMessage,
+} from "@/lib/storage/scheduled-messages";
+
+export type { ScheduledMessage } from "@/lib/storage/scheduled-messages";
+
+interface ScheduledState {
+  scheduled: ScheduledMessage[];
+  /**
+   * Best-effort prefill from IndexedDB. Called once on AppShell mount,
+   * mirroring the bookmarks/drafts hydration.
+   */
+  hydrate: () => Promise<void>;
+  /** Queue a new scheduled message — used by ChatView's handleSend. */
+  addScheduled: (message: ScheduledMessage) => void;
+  removeScheduled: (contextId: string, id: string) => void;
+  /** Flip a due send that failed to POST so the sweep won't keep retrying. */
+  markFailed: (contextId: string, id: string) => void;
+  clearAll: () => void;
+}
+
+function sortBySoonest(list: ScheduledMessage[]): ScheduledMessage[] {
+  return [...list].sort((a, b) => a.scheduleTime - b.scheduleTime);
+}
+
+export const useScheduledStore = create<ScheduledState>((set) => ({
+  scheduled: [],
+
+  hydrate: async () => {
+    const fromIdb = await loadAllScheduled();
+    set((s) => {
+      // Merge by composite key — anything already in-memory (e.g. a message
+      // scheduled between mount and hydration) wins over IDB so a race
+      // doesn't lose a queued send.
+      const keyed = new Map<string, ScheduledMessage>();
+      for (const m of fromIdb) keyed.set(`${m.contextId}::${m.id}`, m);
+      for (const m of s.scheduled) keyed.set(`${m.contextId}::${m.id}`, m);
+      return { scheduled: sortBySoonest([...keyed.values()]) };
+    });
+  },
+
+  addScheduled: (message) => {
+    set((s) => {
+      // Replace any existing entry with the same composite key.
+      const without = s.scheduled.filter(
+        (m) => !(m.contextId === message.contextId && m.id === message.id)
+      );
+      return { scheduled: sortBySoonest([message, ...without]) };
+    });
+    void addScheduledToIdb(message);
+  },
+
+  removeScheduled: (contextId, id) => {
+    set((s) => ({
+      scheduled: s.scheduled.filter(
+        (m) => !(m.contextId === contextId && m.id === id)
+      ),
+    }));
+    void removeScheduledFromIdb(contextId, id);
+  },
+
+  markFailed: (contextId, id) => {
+    set((s) => ({
+      scheduled: s.scheduled.map((m) =>
+        m.contextId === contextId && m.id === id
+          ? { ...m, status: "failed" as const }
+          : m
+      ),
+    }));
+    void (async () => {
+      const target = useScheduledStore
+        .getState()
+        .scheduled.find((m) => m.contextId === contextId && m.id === id);
+      if (target) await addScheduledToIdb(target);
+    })();
+  },
+
+  clearAll: () => {
+    set({ scheduled: [] });
+    void clearAllScheduledFromIdb();
+  },
+}));


### PR DESCRIPTION
Implements #26. Compose a DM, pick a future time, and the client holds it in IndexedDB and delivers it via the existing send endpoint when due. Purely client-side — no server/API changes.

## How it works
- New `scheduled-messages` IndexedDB store (shared `teamsly` DB, v2→v3) + a Zustand store, hydrated on boot, cleared on sign-out — mirrors the bookmarks/drafts pattern.
- Composer: a 📅 button (next to the disappear ⏱) with presets (In 1 hour / Tonight 6pm / Tomorrow 9am / Monday 9am) + a custom date/time input (future-only). Send button relabels to "Schedule".
- Delivery: a due-sweep in the open chat (5s) and across all DMs via the sidebar's existing 15s/focus poll POSTs due messages, then removes them.
- In-chat banner shows "📅 N scheduled", expandable to preview/cancel each.

## Scope & limits
- DMs (1:1 + group) only; channels are a follow-up.
- Client-side: a message fires at its time **if the app is open**, otherwise on next launch (same limitation as disappearing messages). Documented in-product via the toast/banner.

## Test plan (preview, light + dark)
- [ ] Schedule a DM (preset + custom) → banner shows it; Send button reads "Schedule"
- [ ] At the chosen time (app open) → message sends and leaves the banner
- [ ] Cancel from the banner removes it
- [ ] Combines with a disappearing duration

Closes #26