### PR TITLE
Add /features page showcasing what Teamsly adds

### DIFF
--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -1,0 +1,231 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Zap,
+  Timer,
+  Clock,
+  Mic,
+  CalendarClock,
+  Slash,
+  GitBranch,
+  FileText,
+  Link2,
+  Palette,
+  Eye,
+  Bot,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  MarketingNav,
+  MarketingFooter,
+  Eyebrow,
+} from "@/components/marketing/primitives";
+
+export const metadata: Metadata = {
+  title: "Features — Teamsly",
+  description:
+    "Everything Teamsly adds on top of your Microsoft Teams workspace — real-time messaging, scheduled and disappearing DMs, voice rooms, AI digests, themes, an MCP server, and more. Try the live demo, no sign-in required.",
+};
+
+type Group = {
+  eyebrow: string;
+  features: { icon: typeof Zap; title: string; body: string }[];
+};
+
+const GROUPS: Group[] = [
+  {
+    eyebrow: "Messaging",
+    features: [
+      {
+        icon: Zap,
+        title: "Real-time messages",
+        body: "DMs and channels update sub-second via Microsoft Graph change notifications — no waiting on a poll.",
+      },
+      {
+        icon: Timer,
+        title: "Disappearing DMs",
+        body: "Send a message that vanishes after 30 seconds, 5 minutes, or an hour — with a live countdown.",
+      },
+      {
+        icon: Clock,
+        title: "Send later",
+        body: "Compose now, pick a time, and Teamsly delivers the DM at the perfect moment.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Presence & voice",
+    features: [
+      {
+        icon: Mic,
+        title: "Voice rooms",
+        body: "Drop-in audio for any channel or DM — Discord-style rooms, right where the conversation lives.",
+      },
+      {
+        icon: CalendarClock,
+        title: "Calendar auto-status",
+        body: "Your Outlook calendar sets your presence automatically — “In a meeting until 12:30”, heads-down, or away.",
+      },
+    ],
+  },
+  {
+    eyebrow: "In the flow",
+    features: [
+      {
+        icon: Slash,
+        title: "Slash toybox",
+        body: "/coinflip, /roll, /giphy, /8ball and more — a little fun without leaving the composer.",
+      },
+      {
+        icon: GitBranch,
+        title: "GitHub & Linear cards",
+        body: "Paste a PR or issue link and it unfurls into a live card with status, author, and activity.",
+      },
+      {
+        icon: Link2,
+        title: "Rich link previews",
+        body: "YouTube, Loom, Figma, and Teams meeting links render as clean, joinable previews.",
+      },
+    ],
+  },
+  {
+    eyebrow: "AI & automation",
+    features: [
+      {
+        icon: FileText,
+        title: "AI thread digest",
+        body: "/tldr summarizes a long thread into the key points in seconds.",
+      },
+      {
+        icon: Bot,
+        title: "Built-in MCP server",
+        body: "Drive your Teams workspace from any MCP client — read, search, and send messages programmatically.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Make it yours",
+    features: [
+      {
+        icon: Palette,
+        title: "Themes, density & motion",
+        body: "Color palettes, true light and dark, compact density, and motion that feels native — not a web app.",
+      },
+      {
+        icon: Eye,
+        title: "Focus mode & quick-react",
+        body: "Quiet the noise so only mentions break through, and react to any message with a number key.",
+      },
+    ],
+  },
+  {
+    eyebrow: "Privacy",
+    features: [
+      {
+        icon: ShieldCheck,
+        title: "Private by default",
+        body: "No third-party analytics or tracking pixels. Sessions live in memory and your browser — never a database.",
+      },
+    ],
+  },
+];
+
+export default function FeaturesPage() {
+  return (
+    <div className="min-h-screen bg-[#0d1117] text-white">
+      <MarketingNav stars={null} />
+
+      {/* Hero */}
+      <header className="mx-auto max-w-6xl px-6 pb-10 pt-16 text-center lg:pt-24">
+        <Eyebrow>Features</Eyebrow>
+        <h1 className="mx-auto mb-5 max-w-3xl text-4xl font-black leading-[1.08] tracking-tight sm:text-5xl">
+          Everything Teamsly adds to your Teams workspace
+        </h1>
+        <p className="mx-auto mb-8 max-w-2xl text-[16px] leading-relaxed text-[#8b9ab0]">
+          Teamsly is a modern client for Microsoft Teams. It keeps your existing
+          workspace and layers on the things you wish it had — faster messaging,
+          scheduling, voice rooms, AI, deep theming, and an MCP server.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href="/demo"
+            className="rounded-lg px-5 py-2.5 text-[14px] font-semibold text-white transition-all hover:brightness-110"
+            style={{ background: "linear-gradient(135deg, #6366F1 0%, #818CF8 100%)" }}
+          >
+            Try the live demo
+          </Link>
+          <Link
+            href="/login"
+            className="rounded-lg border px-5 py-2.5 text-[14px] font-semibold text-[#c9d3e0] transition-colors hover:text-white"
+            style={{ borderColor: "rgba(255,255,255,0.12)" }}
+          >
+            Sign in
+          </Link>
+        </div>
+        <p className="mt-3 text-[12px] text-[#3d4a5c]">The demo runs in your browser — no sign-in required.</p>
+      </header>
+
+      {/* Feature groups */}
+      <main className="mx-auto max-w-6xl px-6 pb-16">
+        {GROUPS.map((group) => (
+          <section key={group.eyebrow} className="py-8">
+            <Eyebrow>{group.eyebrow}</Eyebrow>
+            <div className="mt-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {group.features.map((f) => {
+                const Icon = f.icon;
+                return (
+                  <div
+                    key={f.title}
+                    className="rounded-2xl p-5 transition-colors"
+                    style={{ background: "#111827", border: "1px solid rgba(255,255,255,0.08)" }}
+                  >
+                    <span
+                      className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-xl"
+                      style={{ background: "rgba(129,140,248,0.15)" }}
+                    >
+                      <Icon size={20} style={{ color: "#818CF8" }} strokeWidth={2} />
+                    </span>
+                    <h3 className="mb-1.5 text-[16px] font-bold tracking-tight text-white">{f.title}</h3>
+                    <p className="text-[14px] leading-relaxed text-[#8b9ab0]">{f.body}</p>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </main>
+
+      {/* Closing CTA */}
+      <section className="mx-auto max-w-6xl px-6 pb-24">
+        <div
+          className="flex flex-col items-center gap-5 rounded-3xl px-8 py-14 text-center"
+          style={{ background: "linear-gradient(135deg, rgba(99,102,241,0.12) 0%, rgba(129,140,248,0.06) 100%)", border: "1px solid rgba(129,140,248,0.2)" }}
+        >
+          <h2 className="max-w-2xl text-3xl font-black tracking-tight">See it for yourself</h2>
+          <p className="max-w-xl text-[15px] leading-relaxed text-[#8b9ab0]">
+            Open the interactive demo — no account, no install. Then bring your own
+            Teams workspace whenever you’re ready.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/demo"
+              className="rounded-lg px-5 py-2.5 text-[14px] font-semibold text-white transition-all hover:brightness-110"
+              style={{ background: "linear-gradient(135deg, #6366F1 0%, #818CF8 100%)" }}
+            >
+              Try the live demo
+            </Link>
+            <Link
+              href="/login"
+              className="rounded-lg border px-5 py-2.5 text-[14px] font-semibold text-[#c9d3e0] transition-colors hover:text-white"
+              style={{ borderColor: "rgba(255,255,255,0.12)" }}
+            >
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <MarketingFooter />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ export default async function LandingPage() {
             </span>
           </div>
           <div className="hidden items-center gap-7 md:flex">
-            <a href="#features" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">Features</a>
+            <Link href="/features" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">Features</Link>
             <a href="#mcp" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">MCP</a>
             <a href="#self-host" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">Self-host</a>
             <a href="#faq" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">FAQ</a>

--- a/src/components/marketing/primitives.tsx
+++ b/src/components/marketing/primitives.tsx
@@ -1,0 +1,138 @@
+import Link from "next/link";
+import { Logo } from "@/components/ui/Logo";
+import { Star, Check } from "lucide-react";
+
+export const REPO = "https://github.com/mayurrawte/teamsly";
+export const RELEASES = `${REPO}/releases/latest`;
+
+export function MarketingNav({ stars }: { stars: number | null }) {
+  return (
+    <nav className="sticky top-0 z-50 border-b border-white/5 bg-[#0d1117]/80 backdrop-blur-md">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+        <Link href="/" className="flex items-center gap-2.5">
+          <Logo size={26} className="text-white" />
+          <span className="text-[15px] font-bold tracking-tight">
+            <span style={{ color: "#818CF8" }}>Teams</span>
+            <span className="text-white">ly</span>
+          </span>
+        </Link>
+        <div className="hidden items-center gap-7 md:flex">
+          <Link href="/features" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">Features</Link>
+          <Link href="/#mcp" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">MCP</Link>
+          <Link href="/#self-host" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">Self-host</Link>
+          <Link href="/#faq" className="text-[13px] text-[#8b9ab0] transition-colors hover:text-white">FAQ</Link>
+        </div>
+        <div className="flex items-center gap-3">
+          <StarButton stars={stars} />
+          <Link
+            href="/login"
+            className="rounded-lg px-4 py-2 text-[13px] font-semibold text-white transition-all hover:brightness-110"
+            style={{ background: "linear-gradient(135deg, #6366F1 0%, #818CF8 100%)" }}
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+export function MarketingFooter() {
+  return (
+    <footer className="border-t px-6 py-8" style={{ borderColor: "rgba(255,255,255,0.07)" }}>
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <Logo size={20} className="text-white" />
+          <span className="text-[13px] text-[#3d4a5c]">Teamsly · AGPL-3.0 · Not affiliated with Microsoft</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-6 text-[12px] text-[#3d4a5c]">
+          <Link href="/features" className="transition-colors hover:text-white">Features</Link>
+          <a href={REPO} target="_blank" rel="noopener noreferrer" className="transition-colors hover:text-white">GitHub</a>
+          <a href={RELEASES} target="_blank" rel="noopener noreferrer" className="transition-colors hover:text-white">Releases</a>
+          <a href={`${REPO}/issues`} target="_blank" rel="noopener noreferrer" className="transition-colors hover:text-white">Issues</a>
+          <Link href="/demo" className="transition-colors hover:text-white">Demo</Link>
+          <Link href="/privacy" className="transition-colors hover:text-white">Privacy</Link>
+          <Link href="/terms" className="transition-colors hover:text-white">Terms</Link>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export function StarButton({ stars }: { stars: number | null }) {
+  return (
+    <a
+      href={REPO}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 rounded-lg border px-3 py-2 text-[13px] font-semibold text-[#8b9ab0] transition-colors hover:border-[#6366F1] hover:text-white"
+      style={{ borderColor: "rgba(255,255,255,0.1)" }}
+    >
+      <Star size={14} />
+      <span className="hidden sm:inline">Star</span>
+      {stars !== null && (
+        <span className="rounded px-1.5 py-0.5 text-[11px] tabular-nums" style={{ background: "rgba(255,255,255,0.06)", color: "#c9d3e0" }}>
+          {stars}
+        </span>
+      )}
+    </a>
+  );
+}
+
+export function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="mb-4 inline-block rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-widest" style={{ background: "rgba(129,140,248,0.15)", color: "#818CF8" }}>
+      {children}
+    </span>
+  );
+}
+
+export function BrowserFrame({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`relative overflow-hidden rounded-2xl ${className}`} style={{ border: "1px solid rgba(255,255,255,0.08)", background: "#111827", boxShadow: "0 32px 80px rgba(0,0,0,0.6)" }}>
+      <div className="flex items-center gap-2 border-b px-4 py-3" style={{ borderColor: "rgba(255,255,255,0.07)" }}>
+        <div className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+        <div className="h-3 w-3 rounded-full bg-[#febc2e]" />
+        <div className="h-3 w-3 rounded-full bg-[#28c840]" />
+        <div className="ml-2 rounded px-3 py-0.5 text-[11px] text-[#3d4a5c]" style={{ background: "rgba(255,255,255,0.04)" }}>teamsly.app</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function CodeBlock({ children }: { children: React.ReactNode }) {
+  return (
+    <pre className="overflow-x-auto rounded-xl p-4 font-mono text-[12px] leading-loose text-[#8b9ab0]" style={{ background: "#0d1117", border: "1px solid rgba(255,255,255,0.08)" }}>
+      {children}
+    </pre>
+  );
+}
+
+export function FeatureRow({
+  eyebrow, title, body, points, shot, alt, reverse = false,
+}: {
+  eyebrow: string; title: string; body: string; points: string[]; shot: string; alt: string; reverse?: boolean;
+}) {
+  return (
+    <div className={`flex flex-col items-center gap-10 py-12 lg:gap-16 ${reverse ? "lg:flex-row-reverse" : "lg:flex-row"}`}>
+      <div className="lg:flex-1">
+        <Eyebrow>{eyebrow}</Eyebrow>
+        <h2 className="mb-4 text-2xl font-black tracking-tight lg:text-3xl">{title}</h2>
+        <p className="mb-6 text-[15px] leading-relaxed text-[#8b9ab0]">{body}</p>
+        <ul className="flex flex-col gap-2.5 text-[14px] text-[#c9d3e0]">
+          {points.map((p) => (
+            <li key={p} className="flex items-center gap-2.5">
+              <Check size={15} style={{ color: "#818CF8" }} strokeWidth={2.5} /> {p}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="w-full lg:flex-1">
+        <BrowserFrame>
+          <img src={shot} alt={alt} className="block w-full" loading="lazy" />
+        </BrowserFrame>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements #47. A dedicated `/features` marketing page that shows everything Teamsly layers on top of a Microsoft Teams workspace, with a clear path to try it.

## What's here
- New `/features` page: hero + grouped feature cards (Messaging, Presence & voice, In the flow, AI & automation, Make it yours, Privacy) + a closing CTA band.
- Primary CTA everywhere → the interactive **/demo** (no sign-in), secondary → /login.
- Extracted the shared marketing nav/footer into `src/components/marketing/primitives.tsx`; landing nav "Features" now links to `/features`.
- Static page, matches the landing's dark marketing styling. Framed as "on top of Teams" (no disparagement, per BRAND.md).

## Test plan (preview)
- [ ] /features renders with all groups; nav + footer match the landing
- [ ] "Try the live demo" → /demo; "Sign in" → /login
- [ ] Landing nav "Features" goes to /features
- [ ] Responsive (mobile → desktop)

Closes #47