### PR TITLE
Morning brief: fire the daily summary notification

### DIFF
--- a/src/components/MorningBriefScheduler.tsx
+++ b/src/components/MorningBriefScheduler.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePreferencesStore } from "@/store/preferences";
+import { useWorkspaceStore } from "@/store/workspace";
+import { fireDesktopNotification } from "@/lib/utils/desktop-notification";
+
+function localDayKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Fires the opt-in daily "morning brief" desktop notification once per local
+ * day at the configured time. Client-side: if the app isn't open at that
+ * moment, the brief fires on the next launch that day. Reads/writes prefs
+ * imperatively so the 60s tick never carries a stale closure.
+ */
+export function MorningBriefScheduler() {
+  useEffect(() => {
+    function check() {
+      const prefs = usePreferencesStore.getState();
+      if (!prefs.morningBriefEnabled) return;
+
+      const now = new Date();
+      const todayKey = localDayKey(now);
+      if (prefs.lastMorningBriefDay === todayKey) return; // already fired today
+
+      const [hh, mm] = prefs.morningBriefTime.split(":").map((n) => parseInt(n, 10));
+      if (Number.isNaN(hh) || Number.isNaN(mm)) return;
+      const target = new Date(now);
+      target.setHours(hh, mm, 0, 0);
+      if (now < target) return; // not time yet
+
+      const counts = useWorkspaceStore.getState().unreadCounts;
+      const values = Object.values(counts).filter((c) => c > 0);
+      const convos = values.length;
+      const total = values.reduce((a, c) => a + c, 0);
+      const body =
+        total > 0
+          ? `${total} unread message${total === 1 ? "" : "s"} across ${convos} conversation${convos === 1 ? "" : "s"}.`
+          : "You're all caught up. Have a great day!";
+
+      fireDesktopNotification("Good morning 👋", body, {
+        tag: "teamsly-morning-brief",
+        onclick: () => {
+          try {
+            window.focus();
+          } catch {
+            /* no-op */
+          }
+        },
+      });
+      prefs.setLastMorningBriefDay(todayKey);
+    }
+
+    check(); // immediate check covers the app being opened after the brief time
+    const id = window.setInterval(check, 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  return null;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -20,6 +20,7 @@ import { useToastStore } from "@/store/toasts";
 import { sendUnreadCount } from "@/lib/electron-bridge";
 import { getChatLabel } from "@/lib/utils/chat-label";
 import { RealtimeEventsMount } from "@/hooks/useRealtimeEvents";
+import { MorningBriefScheduler } from "@/components/MorningBriefScheduler";
 import { CatchUpPanel } from "@/components/ai/CatchUpPanel";
 import { useCatchUpStore } from "@/store/catchUp";
 import { useSearchStore } from "@/store/search";
@@ -440,6 +441,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <RealtimeEventsMount />
       <CatchUpPanel />
       <BootNudge />
+      <MorningBriefScheduler />
     </div>
   );
 }

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -111,6 +111,8 @@ export interface Preferences {
   /** Last day (YYYY-MM-DD) the boot nudge was shown. Used so each tip
    *  appears at most once per local day. */
   lastNudgeDay: string | null;
+  /** Last day (YYYY-MM-DD) the morning brief fired, so it shows at most once per local day. */
+  lastMorningBriefDay: string | null;
 }
 
 interface PreferencesState extends Preferences {
@@ -147,6 +149,7 @@ interface PreferencesState extends Preferences {
   setMorningBriefEnabled: (v: boolean) => void;
   setMorningBriefTime: (t: string) => void;
   setLastNudgeDay: (day: string | null) => void;
+  setLastMorningBriefDay: (day: string | null) => void;
   reset: () => void;
 }
 
@@ -183,6 +186,7 @@ const DEFAULTS: Preferences = {
   morningBriefEnabled: false,
   morningBriefTime: "09:00",
   lastNudgeDay: null,
+  lastMorningBriefDay: null,
 };
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -237,6 +241,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       setMorningBriefEnabled: (morningBriefEnabled) => set({ morningBriefEnabled }),
       setMorningBriefTime: (morningBriefTime) => set({ morningBriefTime }),
       setLastNudgeDay: (lastNudgeDay) => set({ lastNudgeDay }),
+      setLastMorningBriefDay: (lastMorningBriefDay) => set({ lastMorningBriefDay }),
       reset: () => set(DEFAULTS),
     }),
     {


### PR DESCRIPTION
Implements #30. The opt-in morning-brief preference + time picker already shipped; this adds the missing background tick that actually fires it.

## How it works
- A 60s scheduler (`MorningBriefScheduler`, mounted in AppShell) checks the configured local time; once per local day (deduped via a new `lastMorningBriefDay` pref, mirroring `lastNudgeDay`) it fires a desktop notification summarizing unread messages ("N unread across M conversations", or "all caught up").
- Client-side: if the app isn't open at the brief time, it fires on the next launch that day.

Note: kept it to a simple unread summary (no `/tldr` AI digest) so it works without an ANTHROPIC key in prod. AI digest can be a later enhancement.

## Test plan (preview)
- [ ] Enable morning brief, set the time to ~1 min ahead → notification fires once
- [ ] It does not fire again the same day
- [ ] Disabled → never fires

Closes #30