### PR TITLE
Disappearing: clean up orphaned undecodable blobs

### DIFF
--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -17,7 +17,7 @@ import { useToastStore } from "@/store/toasts";
 import { openTeamsCall } from "@/lib/utils/teams-deeplink";
 import { getChatLabel } from "@/lib/utils/chat-label";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
-import { isDisappearing, unwrapMessage, wrapMessage } from "@/lib/utils/disappear";
+import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 import { useRealtimeEvents } from "@/hooks/useRealtimeEvents";
 import { useScheduledStore } from "@/store/scheduled";
 
@@ -101,7 +101,11 @@ export function ChatView({ chatId }: { chatId: string }) {
       if (m.from?.user?.id !== currentUserId) continue; // only delete our own (Graph 403s otherwise)
       if (!isDisappearing(m.body.content)) continue;
       const payload = await unwrapMessage(chatId, m.body.content);
-      if (!payload || payload.disappearAt > now) continue;
+      if (payload) {
+        if (payload.disappearAt > now) continue; // decoded but not yet expired
+      } else if (now - new Date(m.createdDateTime).getTime() < UNDECODABLE_BLOB_GRACE_MS) {
+        continue; // undecodable but recent — skip until it's clearly orphaned
+      }
       try {
         const res = await fetch(
           `/api/chats/${chatId}/messages/${encodeURIComponent(m.id)}`,

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -11,7 +11,7 @@ import { clearAll as clearDraftsCache } from "@/lib/storage/drafts";
 import { clearAll as clearBookmarksCache } from "@/lib/storage/bookmarks";
 import { clearAllScheduled } from "@/lib/storage/scheduled-messages";
 import { cn } from "@/lib/utils";
-import { isDisappearing, unwrapMessage, wrapMessage } from "@/lib/utils/disappear";
+import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 import { useScheduledStore } from "@/store/scheduled";
 
 async function sweepAllDms(
@@ -27,7 +27,11 @@ async function sweepAllDms(
       if (m.from?.user?.id !== currentUserId) continue; // only delete our own (Graph 403s otherwise)
       if (!isDisappearing(m.body.content)) continue;
       const payload = await unwrapMessage(chatId, m.body.content);
-      if (!payload || payload.disappearAt > now) continue;
+      if (payload) {
+        if (payload.disappearAt > now) continue; // decoded but not yet expired
+      } else if (now - new Date(m.createdDateTime).getTime() < UNDECODABLE_BLOB_GRACE_MS) {
+        continue; // undecodable but recent — skip until it's clearly orphaned
+      }
       try {
         const res = await fetch(
           `/api/chats/${chatId}/messages/${encodeURIComponent(m.id)}`,

--- a/src/lib/utils/disappear.ts
+++ b/src/lib/utils/disappear.ts
@@ -16,6 +16,12 @@ export interface DisappearPayload {
   disappearAt: number; // epoch ms
 }
 
+// How long to leave an undecodable disappearing blob (one of OUR OWN messages
+// that fails to decode) before the sweep deletes it as orphaned. Well beyond
+// the 1-hour max duration so a transient decode failure never deletes a valid
+// message — only clearly-stranded blobs the sender can no longer read.
+export const UNDECODABLE_BLOB_GRACE_MS = 24 * 60 * 60 * 1000;
+
 const keyCache = new Map<string, Promise<CryptoKey>>();
 
 export function getContextKey(contextId: string): Promise<CryptoKey> {


### PR DESCRIPTION
Implements #31. A disappearing-message blob that fails to decode was previously skipped by the sweep forever, leaving the sender's own unreadable blob sitting in the chat.

## Fix
Both sweeps (in-chat + sidebar) now delete the sender's OWN undecodable disappearing blobs once they're older than a 24h grace window. The grace is well beyond the 1h max duration, so a transient/temporary decode failure never deletes a still-valid message — only clearly-orphaned blobs the sender can no longer read. Shared `UNDECODABLE_BLOB_GRACE_MS` constant in `disappear.ts`.

Only ever targets the current user's own messages (Graph 403s on others), unchanged.

## Test plan
- [ ] A normal disappearing message still vanishes on expiry as before
- [ ] A valid (decodable) message is never deleted early
- [ ] (Hard to repro naturally) an old undecodable blob gets cleaned up after 24h

Closes #31