### PR TITLE
fix(disappearing): delete expired messages via Graph softDelete

### DIFF
--- a/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
+++ b/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
@@ -51,21 +51,30 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
 
   const { chatId, messageId } = await params;
   try {
+    // Graph has no HTTP DELETE for chat messages — deletion is the softDelete
+    // action: POST with an empty body, delegated Chat.ReadWrite. Scoping it to
+    // /me limits it to the signed-in user, the only one Graph permits to delete
+    // their own message (others get 403). A plain HTTP DELETE here is rejected,
+    // which is why expired disappearing messages were vanishing locally but
+    // surviving in native Teams.
     const res = await fetch(
-      `https://graph.microsoft.com/v1.0/chats/${chatId}/messages/${messageId}`,
+      `https://graph.microsoft.com/v1.0/me/chats/${chatId}/messages/${messageId}/softDelete`,
       {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${session.accessToken}` },
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          "Content-Length": "0",
+        },
       }
     );
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      console.error("Graph delete chat message failed", res.status, body);
+      console.error("Graph softDelete chat message failed", res.status, body);
       return NextResponse.json({ error: "Graph delete failed" }, { status: 502 });
     }
     return new NextResponse(null, { status: 204 });
   } catch (err) {
-    console.error("Graph delete chat message error", err);
+    console.error("Graph softDelete chat message error", err);
     return NextResponse.json({ error: "Graph delete failed" }, { status: 502 });
   }
 }


### PR DESCRIPTION
## Problem

Disappearing DMs vanished from the Teamsly UI on expiry but **survived in native Teams** — the sender could still see them in the real Teams client.

## Root cause

Microsoft Graph has **no HTTP `DELETE` for chat messages**. The only deletion mechanism is the [`softDelete` action](https://learn.microsoft.com/en-us/graph/api/chatmessage-softdelete?view=graph-rest-1.0) (`POST .../messages/{id}/softDelete`, empty body, delegated `Chat.ReadWrite`).

The route at `src/app/api/chats/[chatId]/messages/[messageId]/route.ts` was issuing a plain `DELETE` to `/v1.0/chats/{chatId}/messages/{messageId}`, which Graph rejects. The 502 was swallowed by **both** delete call sites:

- `handleMessageExpire` in `ChatView` — fire-and-forget `void fetch` when the in-view countdown hits zero.
- `sweepExpired` — the 4s background sweep that catches messages expired while the chat was closed.

So the row disappeared locally (MessageItem hides on timer + the store tombstones it) while the encrypted blob lived on in Teams forever.

## Fix

Switch the route's `DELETE` handler to:

```
POST https://graph.microsoft.com/v1.0/me/chats/{chatId}/messages/{messageId}/softDelete
```

Scoping to `/me` limits deletion to the signed-in user — the only identity Graph permits to delete their own message (others get 403). Both delete paths funnel through this one route, so the single change fixes both.

The session-only `expiredMessageIds` set (not persisted) preserves a cross-reload retry backstop: if a `softDelete` ever fails transiently, the next page load re-fetches the still-present message and the normal expire path retries it.

## Verification

- `npm run build` — green.
- ⚠️ End-to-end confirmation (send a disappearing DM, wait for expiry, confirm it's gone from native Teams) needs a second account — this is exactly what #25 was blocked on. Worth running before/after merge to close #25.

Refs #25