### PR TITLE
feat(availability): office hours mode

### DIFF
--- a/docs/superpowers/specs/2026-06-03-office-hours-design.md
+++ b/docs/superpowers/specs/2026-06-03-office-hours-design.md
@@ -1,0 +1,63 @@
+# Office Hours mode — design (#38)
+
+**Date:** 2026-06-03
+**Scope:** Small. Fully client-side. No API, no Graph, no status push.
+
+## What it is
+
+A personal work/life-balance feature. You define your working hours; when you're
+**outside** them, Teamsly shows you a dismissible banner reminding you you're off
+the clock. Purely self-facing — your office-hours prefs live in your browser's
+localStorage, so this is about *your* hours shown to *you*, not a teammate-visible
+status.
+
+Decided against (this iteration): auto-replies, pushing a status message to Teams,
+forcing presence, per-conversation overrides. Distinct from **quiet hours** (mutes
+notifications) and **calendar auto-status** (drives presence from Outlook).
+
+## Components
+
+### 1. Preferences (`src/store/preferences.ts`) — persist v3 → v4
+New fields + setters (mirroring the existing `quietHours*` shape):
+- `officeHoursEnabled: boolean` (default `false`)
+- `officeHoursStart: string` — `"HH:MM"` 24h (default `"09:00"`)
+- `officeHoursEnd: string` — `"HH:MM"` 24h (default `"17:00"`)
+- `officeHoursDays: number[]` — JS weekday indices 0=Sun..6=Sat (default `[1,2,3,4,5]` Mon–Fri)
+- `officeHoursDismissedUntil: number | null` — epoch ms; banner stays hidden while `now < this` (default `null`)
+
+Zustand persist default-merge grafts new fields, so no explicit `migrate`. Bump
+`version` to 4 and extend the version comment.
+
+### 2. `useOfficeHours()` (`src/hooks/useOfficeHours.ts`)
+Pure computation from prefs + a 60s clock tick (so state flips at boundaries even
+if the user leaves the tab open). Returns:
+- `enabled: boolean`
+- `withinHours: boolean` — true when today is an enabled day and `start ≤ now < end`
+  (same-day window; if `start ≥ end` the window is treated as never-within)
+- `nextBoundary: number | null` — epoch ms of the next transition (today's end if
+  within; otherwise the next enabled day's start, searched up to 7 days ahead)
+- `label: string` — e.g. `"9:00 AM – 5:00 PM · Mon–Fri"` (times via `Intl.DateTimeFormat`;
+  days rendered as "Every day" / "Mon–Fri" / an explicit short list)
+
+No network. `"use client"`.
+
+### 3. `OfficeHoursBanner` (`src/components/ui/OfficeHoursBanner.tsx`)
+Mounted in `AppShell` next to `<BootNudge />`. Visible when
+`enabled && !withinHours && !(dismissedUntil && now < dismissedUntil)`.
+Styled to match BootNudge but pinned **top-center** (BootNudge is bottom-center)
+to avoid overlap. Copy: *"You're outside your office hours · {label}"*. Dismiss
+sets `officeHoursDismissedUntil = nextBoundary` so it won't re-nag this off-period
+(survives reload), then naturally re-arms once you're back within hours.
+
+### 4. Preferences UI (`AvailabilityPanel` in `PreferencesModal.tsx`)
+Below the existing "Auto status from calendar" row, a new `FieldGroup` "Office hours":
+- enable `ToggleRow`
+- two `type="time"` inputs (start / end), disabled when off — same styling as the
+  morning-brief time input
+- a 7-chip day selector (S M T W T F S), toggling membership in `officeHoursDays`,
+  disabled when off
+
+## Testing / verification
+No test framework in repo. Bar = `npm run build` green (type + ESLint rules-of-hooks
++ Next page-export checks). Manual: set hours to exclude "now", confirm banner shows;
+dismiss → stays gone; set hours to include "now" → no banner.

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -27,6 +27,7 @@ import { useSearchStore } from "@/store/search";
 import { markVisit } from "@/lib/storage/visit-counter";
 import { warmTopVisited } from "@/lib/storage/prefetch";
 import { BootNudge } from "@/components/ui/BootNudge";
+import { OfficeHoursBanner } from "@/components/ui/OfficeHoursBanner";
 import { usePreferencesStore } from "@/store/preferences";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
@@ -441,6 +442,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <RealtimeEventsMount />
       <CatchUpPanel />
       <BootNudge />
+      <OfficeHoursBanner />
       <MorningBriefScheduler />
     </div>
   );

--- a/src/components/modals/PreferencesModal.tsx
+++ b/src/components/modals/PreferencesModal.tsx
@@ -694,18 +694,86 @@ function MessagesPanel() {
 
 // ─── Availability ────────────────────────────────────────────────────────────
 
+const DAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"];
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
 function AvailabilityPanel() {
   const autoStatusEnabled = usePreferencesStore((s) => s.autoStatusEnabled);
   const setAutoStatusEnabled = usePreferencesStore((s) => s.setAutoStatusEnabled);
+  const officeHoursEnabled = usePreferencesStore((s) => s.officeHoursEnabled);
+  const setOfficeHoursEnabled = usePreferencesStore((s) => s.setOfficeHoursEnabled);
+  const officeHoursStart = usePreferencesStore((s) => s.officeHoursStart);
+  const setOfficeHoursStart = usePreferencesStore((s) => s.setOfficeHoursStart);
+  const officeHoursEnd = usePreferencesStore((s) => s.officeHoursEnd);
+  const setOfficeHoursEnd = usePreferencesStore((s) => s.setOfficeHoursEnd);
+  const officeHoursDays = usePreferencesStore((s) => s.officeHoursDays);
+  const setOfficeHoursDays = usePreferencesStore((s) => s.setOfficeHoursDays);
+
+  function toggleDay(day: number) {
+    setOfficeHoursDays(
+      officeHoursDays.includes(day)
+        ? officeHoursDays.filter((d) => d !== day)
+        : [...officeHoursDays, day],
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-7">
       <ToggleRow
         label="Auto status from calendar"
         hint="Sets your status to 'In a meeting' / 'Heads-down' / 'Out of office' based on your Outlook calendar. Clears automatically when each event ends. Manual status changes pause auto-status for 1 hour."
         value={autoStatusEnabled}
         onChange={setAutoStatusEnabled}
       />
+
+      <FieldGroup
+        label="Office hours"
+        hint="A private reminder for you — when you're outside these hours, Teamsly shows a gentle 'you're off the clock' banner. Local only; teammates never see it."
+      >
+        <ToggleRow label="" value={officeHoursEnabled} onChange={setOfficeHoursEnabled} />
+        <div className="mt-1 flex items-center gap-2">
+          <input
+            type="time"
+            value={officeHoursStart}
+            onChange={(e) => setOfficeHoursStart(e.target.value)}
+            disabled={!officeHoursEnabled}
+            aria-label="Office hours start"
+            className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none disabled:opacity-50 focus:border-[var(--border-input)]"
+          />
+          <span className="text-[13px] text-[var(--text-muted)]">to</span>
+          <input
+            type="time"
+            value={officeHoursEnd}
+            onChange={(e) => setOfficeHoursEnd(e.target.value)}
+            disabled={!officeHoursEnabled}
+            aria-label="Office hours end"
+            className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none disabled:opacity-50 focus:border-[var(--border-input)]"
+          />
+        </div>
+        <div className="mt-2 flex gap-1.5">
+          {DAY_LABELS.map((label, day) => {
+            const active = officeHoursDays.includes(day);
+            return (
+              <button
+                key={day}
+                type="button"
+                disabled={!officeHoursEnabled}
+                onClick={() => toggleDay(day)}
+                aria-pressed={active}
+                aria-label={DAY_NAMES[day]}
+                title={DAY_NAMES[day]}
+                className={`h-7 w-7 rounded-full text-[12px] font-medium transition-colors disabled:opacity-50 focus-ring ${
+                  active
+                    ? "bg-[var(--accent)] text-white"
+                    : "border border-[var(--border)] bg-[var(--surface)] text-[var(--text-secondary)] hover:border-[var(--border-input)]"
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </FieldGroup>
     </div>
   );
 }

--- a/src/components/ui/OfficeHoursBanner.tsx
+++ b/src/components/ui/OfficeHoursBanner.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * OfficeHoursBanner — a self-facing nudge shown when the user is currently
+ * OUTSIDE their configured office hours. Pure work/life-balance play: a gentle
+ * "you're off the clock" reminder, never shown to teammates (office-hours prefs
+ * are local-only).
+ *
+ * Dismissal parks the banner until the next boundary (the next office-hours
+ * start) so it can't re-nag during the same off-period, and survives reloads
+ * via `officeHoursDismissedUntil` in prefs. It re-arms naturally once the user
+ * is back within hours.
+ */
+
+import { Moon, X } from "lucide-react";
+import { usePreferencesStore } from "@/store/preferences";
+import { useOfficeHours } from "@/hooks/useOfficeHours";
+
+export function OfficeHoursBanner() {
+  const { enabled, withinHours, nextBoundary, label } = useOfficeHours();
+  const dismissedUntil = usePreferencesStore((s) => s.officeHoursDismissedUntil);
+  const setDismissedUntil = usePreferencesStore((s) => s.setOfficeHoursDismissedUntil);
+
+  const dismissed = dismissedUntil !== null && Date.now() < dismissedUntil;
+  if (!enabled || withinHours || dismissed) return null;
+
+  function dismiss() {
+    // Park until we'd next be within hours; fall back to 1h if no boundary.
+    setDismissedUntil(nextBoundary ?? Date.now() + 60 * 60 * 1000);
+  }
+
+  return (
+    <div
+      role="status"
+      className="boot-nudge pointer-events-auto fixed top-4 left-1/2 z-40 flex max-w-[460px] -translate-x-1/2 items-start gap-2.5 rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3.5 py-2.5 shadow-[0_8px_32px_rgba(0,0,0,0.35)]"
+    >
+      <Moon className="mt-[2px] h-3.5 w-3.5 flex-shrink-0 text-[var(--accent)]" aria-hidden />
+      <p className="flex-1 text-[12.5px] leading-snug text-[var(--text-primary)]">
+        You&rsquo;re outside your office hours
+        <span className="text-[var(--text-muted)]"> · {label}</span>
+      </p>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss office-hours reminder"
+        className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useOfficeHours.ts
+++ b/src/hooks/useOfficeHours.ts
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * useOfficeHours — pure, client-only computation of the user's personal
+ * office-hours state from their prefs plus a 1-minute clock tick (so the
+ * `withinHours` flag flips at the window boundaries even while the tab stays
+ * open). No network, no Graph: office-hours prefs never leave the browser.
+ */
+
+import { useEffect, useState } from "react";
+import { usePreferencesStore } from "@/store/preferences";
+
+export interface OfficeHoursState {
+  enabled: boolean;
+  /** True when today is an enabled weekday and start ≤ now < end. */
+  withinHours: boolean;
+  /** Epoch ms of the next transition: today's end if within, else the next
+   *  enabled day's start (searched up to 7 days out). null if no enabled days. */
+  nextBoundary: number | null;
+  /** Human label, e.g. "9:00 AM – 5:00 PM · Mon–Fri". */
+  label: string;
+}
+
+const TICK_MS = 60_000;
+const SHORT_DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/** "HH:MM" → minutes since midnight, or null if malformed. */
+function parseHM(value: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  return h * 60 + min;
+}
+
+function formatHM(value: string): string {
+  const mins = parseHM(value);
+  if (mins === null) return value;
+  const d = new Date();
+  d.setHours(Math.floor(mins / 60), mins % 60, 0, 0);
+  return new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" }).format(d);
+}
+
+function formatDays(days: number[]): string {
+  const set = [...new Set(days)].sort((a, b) => a - b);
+  if (set.length === 0) return "No days";
+  if (set.length === 7) return "Every day";
+  if (set.length === 5 && set.join() === "1,2,3,4,5") return "Mon–Fri";
+  if (set.length === 2 && set.join() === "0,6") return "Weekends";
+  return set.map((d) => SHORT_DAYS[d]).join(", ");
+}
+
+/** epoch ms for the start-of-day `dayOffset` days from `from`, at `minutes`. */
+function dayAt(from: Date, dayOffset: number, minutes: number): number {
+  const d = new Date(from);
+  d.setDate(d.getDate() + dayOffset);
+  d.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+  return d.getTime();
+}
+
+function compute(
+  enabled: boolean,
+  start: string,
+  end: string,
+  days: number[],
+): OfficeHoursState {
+  const startMin = parseHM(start);
+  const endMin = parseHM(end);
+  const label = `${formatHM(start)} – ${formatHM(end)} · ${formatDays(days)}`;
+
+  // Malformed or zero-width/inverted window → never "within"; no boundary.
+  if (!enabled || startMin === null || endMin === null || startMin >= endMin) {
+    return { enabled, withinHours: false, nextBoundary: null, label };
+  }
+
+  const now = new Date();
+  const today = now.getDay();
+  const nowMin = now.getHours() * 60 + now.getMinutes();
+  const isWorkday = days.includes(today);
+  const withinHours = isWorkday && nowMin >= startMin && nowMin < endMin;
+
+  let nextBoundary: number | null = null;
+  if (withinHours) {
+    nextBoundary = dayAt(now, 0, endMin); // today's end
+  } else {
+    // Next enabled day's start, scanning today (if start still ahead) → +7 days.
+    for (let offset = 0; offset <= 7; offset++) {
+      const weekday = (today + offset) % 7;
+      if (!days.includes(weekday)) continue;
+      const candidate = dayAt(now, offset, startMin);
+      if (candidate > now.getTime()) {
+        nextBoundary = candidate;
+        break;
+      }
+    }
+  }
+
+  return { enabled, withinHours, nextBoundary, label };
+}
+
+export function useOfficeHours(): OfficeHoursState {
+  const enabled = usePreferencesStore((s) => s.officeHoursEnabled);
+  const start = usePreferencesStore((s) => s.officeHoursStart);
+  const end = usePreferencesStore((s) => s.officeHoursEnd);
+  const days = usePreferencesStore((s) => s.officeHoursDays);
+
+  const [state, setState] = useState<OfficeHoursState>(() =>
+    compute(enabled, start, end, days),
+  );
+
+  useEffect(() => {
+    setState(compute(enabled, start, end, days));
+    if (!enabled) return;
+    const id = setInterval(() => setState(compute(enabled, start, end, days)), TICK_MS);
+    return () => clearInterval(id);
+  }, [enabled, start, end, days]);
+
+  return state;
+}

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -74,6 +74,20 @@ export interface Preferences {
   quietHoursStart: string;
   /** HH:MM 24-hour. Wraps around midnight when start > end (e.g. 22:00 → 08:00). */
   quietHoursEnd: string;
+  /** Personal office-hours window. When enabled and the current time is OUTSIDE
+   *  the window, a self-facing banner nudges the user that they're off the clock.
+   *  Purely local (these prefs never leave the browser) — not a teammate-visible
+   *  status. Distinct from quietHours (notification muting) and autoStatus. */
+  officeHoursEnabled: boolean;
+  /** HH:MM 24-hour, same-day window (start < end). */
+  officeHoursStart: string;
+  /** HH:MM 24-hour. */
+  officeHoursEnd: string;
+  /** Enabled weekdays as JS day indices (0=Sun … 6=Sat). Default Mon–Fri. */
+  officeHoursDays: number[];
+  /** Epoch ms; the office-hours banner stays hidden while now < this. Set on
+   *  dismiss to the next boundary so it won't re-nag during the same off-period. */
+  officeHoursDismissedUntil: number | null;
   colorMode: ColorMode;
   /** Background + neutrals choice. Orthogonal to accent. Some palettes
    *  force a specific color mode (see PALETTES.lockedMode). */
@@ -125,6 +139,11 @@ interface PreferencesState extends Preferences {
   setQuietHoursEnabled: (v: boolean) => void;
   setQuietHoursStart: (v: string) => void;
   setQuietHoursEnd: (v: string) => void;
+  setOfficeHoursEnabled: (v: boolean) => void;
+  setOfficeHoursStart: (v: string) => void;
+  setOfficeHoursEnd: (v: string) => void;
+  setOfficeHoursDays: (days: number[]) => void;
+  setOfficeHoursDismissedUntil: (ts: number | null) => void;
   setColorMode: (m: ColorMode) => void;
   setPalette: (p: Palette) => void;
   setAccent: (a: AccentTheme) => void;
@@ -163,6 +182,11 @@ const DEFAULTS: Preferences = {
   quietHoursEnabled: false,
   quietHoursStart: "22:00",
   quietHoursEnd: "08:00",
+  officeHoursEnabled: false,
+  officeHoursStart: "09:00",
+  officeHoursEnd: "17:00",
+  officeHoursDays: [1, 2, 3, 4, 5],
+  officeHoursDismissedUntil: null,
   colorMode: "dark",
   palette: "slate",
   accent: "slate",
@@ -202,6 +226,12 @@ export const usePreferencesStore = create<PreferencesState>()(
       setQuietHoursEnabled: (quietHoursEnabled) => set({ quietHoursEnabled }),
       setQuietHoursStart: (quietHoursStart) => set({ quietHoursStart }),
       setQuietHoursEnd: (quietHoursEnd) => set({ quietHoursEnd }),
+      setOfficeHoursEnabled: (officeHoursEnabled) => set({ officeHoursEnabled }),
+      setOfficeHoursStart: (officeHoursStart) => set({ officeHoursStart }),
+      setOfficeHoursEnd: (officeHoursEnd) => set({ officeHoursEnd }),
+      setOfficeHoursDays: (officeHoursDays) =>
+        set({ officeHoursDays: [...officeHoursDays].sort((a, b) => a - b) }),
+      setOfficeHoursDismissedUntil: (officeHoursDismissedUntil) => set({ officeHoursDismissedUntil }),
       setColorMode: (colorMode) => set({ colorMode }),
       setPalette: (palette) => set({ palette }),
       setAccent: (accent) => set({ accent }),
@@ -254,7 +284,9 @@ export const usePreferencesStore = create<PreferencesState>()(
       // new fields from in-code DEFAULTS, so no explicit migrate is required;
       // existing `density: "comfortable" | "compact"` values remain valid under
       // the wider union.
-      version: 3,
+      // v4 (2026-06-03): adds officeHours* (enabled/start/end/days/dismissedUntil).
+      // Default-merge grafts them from DEFAULTS; no explicit migrate needed.
+      version: 4,
       storage: createJSONStorage(() => (typeof window !== "undefined" ? localStorage : undefined as unknown as Storage)),
     },
   ),


### PR DESCRIPTION
Closes #38

## What

A personal **office hours** window. When enabled and the current time is **outside** your hours, Teamsly shows a dismissible "you're off the clock" banner. Purely local — your office-hours prefs never leave the browser, so it's a self-facing work/life-balance nudge, not a teammate-visible status.

Deliberately distinct from the two adjacent features:
- **Quiet hours** mutes notifications by time.
- **Calendar auto-status** drives presence from Outlook.
- **Office hours** just nudges *you*.

## How

- **Prefs** (`store/preferences.ts`): `officeHours{Enabled,Start,End,Days,DismissedUntil}`; persist `v3 → v4` (default-merge, no migrate). Default window 9:00–17:00, Mon–Fri.
- **`useOfficeHours()`** (`hooks/useOfficeHours.ts`): pure within-window computation on a 1-min clock tick (flips at boundaries with the tab open), plus `nextBoundary` and a human label like `"9:00 AM – 5:00 PM · Mon–Fri"`. No network.
- **`OfficeHoursBanner`** (`components/ui/OfficeHoursBanner.tsx`): top-center nudge (BootNudge is bottom-center, so no overlap), mounted in `AppShell`. Dismiss parks it until the next boundary and survives reloads, then re-arms once you're back within hours.
- **Preferences → Availability**: enable toggle + start/end time pickers + a 7-chip day selector.

## Verification

- `npm run build` — green (exit 0), no new warnings.
- Design spec: `docs/superpowers/specs/2026-06-03-office-hours-design.md`.
- Manual: set hours to exclude now → banner shows; dismiss → stays gone; set hours to include now → no banner.