### PR TITLE
feat(polls): anonymous polls via reactions-as-votes

### DIFF
--- a/docs/superpowers/specs/2026-06-03-anonymous-polls-design.md
+++ b/docs/superpowers/specs/2026-06-03-anonymous-polls-design.md
@@ -1,0 +1,52 @@
+# Anonymous polls — design (#37)
+
+**Date:** 2026-06-03
+**Scope:** Medium. Reactions-as-votes (shared, live). Single-choice. `/poll` slash command.
+
+## Mechanism
+
+Teams/Graph has no poll primitive. A poll is a normal chat message whose body
+lists each option prefixed by a distinct **reaction emoji**; people vote by
+adding that reaction. The 6 Graph reaction types (👍❤️😂😮😢😡) map positionally
+to up to **6 options** (min 2). Works in native Teams too — the message text
+says which emoji = which option — and Teamsly renders it as a rich card.
+
+### Anonymity caveat (documented, accepted)
+Reactions are **not** truly anonymous: Graph records the reactor and native Teams
+shows reaction authors on hover. Teamsly's PollCard shows **counts only, never
+voter names**, so it is "anonymous *in Teamsly*". The card footer states this.
+
+## Pieces
+
+### 1. `src/lib/polls/index.ts` (pure, no React)
+- `MAX_POLL_OPTIONS = 6`, `MIN_POLL_OPTIONS = 2`.
+- `parsePollCommand(args)` → `{question, options[]}` | `{error}` from `Question | A | B`.
+- `buildPollBody(question, options)` → the emoji-prefixed plain-text body that gets sent.
+- `isPoll(content)` / `parsePoll(content)` → detect + parse back (HTML-tolerant: strips
+  `<p>`/`<br>`/tags, unescapes entities). Sentinel: first line starts with `📊 Poll:`.
+- `tallyVotes(message, options, currentUserId)` → `{counts[], total, myVotes[]}`,
+  matching reactions stored as either type name (`"like"`) or emoji (`"👍"`).
+- Build and parse share the `REACTION_EMOJI`/`REACTION_TYPES` constants so option↔type
+  mapping is consistent.
+
+### 2. `src/components/messages/PollCard.tsx`
+Question + one row per option (emoji · text · % bar · count · highlight if you voted) +
+footer (`N votes · anonymous in Teamsly`). Row click → `onVote(reactionType)`. Disabled
+for pending/failed messages.
+
+### 3. MessageItem integration
+Compute `poll = isPoll(raw) ? parsePoll(raw) : null` once. In **both** render branches
+(group-head + continuation): when `poll`, render `<PollCard>` in place of the body and
+**suppress** the normal `ReactionsRow` + link/GitHub cards (reactions are the votes).
+`handlePollVote(reactionType)` enforces single-choice: unset any other option the user
+voted, then toggle the chosen one — reusing the existing `onToggleReaction` toggle.
+
+### 4. `/poll` slash command (`src/lib/slash-commands/index.ts`)
+`requiresArgs: true`, usage `/poll Question | Option A | Option B`. Parses via
+`parsePollCommand`; returns `{kind:"error"}` on bad input, else `{kind:"text", text:
+buildPollBody(...)}`, which flows through the normal send path (`doSend`).
+
+## Verification
+`npm run build` green. Manual: `/poll Lunch? | Tacos | Sushi` → card renders; click an
+option → reaction fires, count updates, switching options moves the vote (single-choice);
+counts-only, no names.

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -12,6 +12,8 @@ import { AddReactionPill, ReactionPill } from "./ReactionPill";
 import { formatMessageTime, formatFullTimestamp } from "@/lib/utils/dates";
 import { messagePlainText, renderMessageBody } from "@/lib/utils/render-message";
 import { isDisappearing, unwrapMessage } from "@/lib/utils/disappear";
+import { isPoll, parsePoll } from "@/lib/polls";
+import { PollCard } from "./PollCard";
 import type { ReactionType } from "@/lib/utils/reactions";
 import { useWorkspaceStore } from "@/store/workspace";
 import { useBookmarksStore } from "@/store/bookmarks";
@@ -184,6 +186,9 @@ export function MessageItem({
 
   const rawContent = message.body.content;
   const disappearing = isDisappearing(rawContent);
+  // Polls render as an interactive card in place of the body; their reactions
+  // are the votes, so the normal reaction row is suppressed for them.
+  const poll = !disappearing && isPoll(rawContent) ? parsePoll(rawContent) : null;
   const [decoded, setDecoded] = useState<{ body: string; disappearAt: number } | null>(null);
   const [decodeFailed, setDecodeFailed] = useState(false);
   // true once the disappear timer fires — hides the row immediately
@@ -234,6 +239,30 @@ export function MessageItem({
   const deleteHandler = isOwn && !message.__pending && !message.__failed ? onDelete : undefined;
   const editHandler = isOwn && !message.__pending && !message.__failed ? onEdit : undefined;
   const content = messagePlainText(message.body.content, message.body.contentType);
+
+  const pollVotingDisabled = Boolean(message.__pending || message.__failed) || !onToggleReaction;
+  // Single-choice voting: toggling an option you've already picked clears it;
+  // picking a new one first clears any other option you'd voted, then sets it.
+  const handlePollVote = (reactionType: ReactionType) => {
+    if (!poll || !onToggleReaction) return;
+    const reactions = message.reactions ?? [];
+    const votedOption = (opt: { reactionType: ReactionType; emoji: string }) =>
+      reactions.some(
+        (r) => r.user.id === currentUserId && (r.reactionType === opt.reactionType || r.reactionType === opt.emoji),
+      );
+    const chosen = poll.options.find((o) => o.reactionType === reactionType);
+    if (!chosen) return;
+    if (votedOption(chosen)) {
+      onToggleReaction(message.id, reactionType); // toggle this choice off
+      return;
+    }
+    for (const opt of poll.options) {
+      if (opt.reactionType !== reactionType && votedOption(opt)) {
+        onToggleReaction(message.id, opt.reactionType); // clear the previous choice
+      }
+    }
+    onToggleReaction(message.id, reactionType); // set the new choice
+  };
 
   const allAttachments = message.attachments ?? [];
   const referenceAttachments = allAttachments.filter((a) => isMessageReference(a.contentType));
@@ -386,6 +415,14 @@ export function MessageItem({
           <MessageReferences attachments={referenceAttachments} />
           {isEditing ? (
             editingArea
+          ) : poll ? (
+            <PollCard
+              poll={poll}
+              message={message}
+              currentUserId={currentUserId}
+              onVote={handlePollVote}
+              disabled={pollVotingDisabled}
+            />
           ) : (
             hasBody && (
               <>
@@ -410,7 +447,7 @@ export function MessageItem({
             )
           )}
           <Attachments attachments={otherAttachments} />
-          {!message.__pending && !message.__failed && (
+          {!poll && !message.__pending && !message.__failed && (
             <ReactionsRow
               messageId={message.id}
               reactions={message.reactions ?? []}
@@ -473,6 +510,14 @@ export function MessageItem({
         <MessageReferences attachments={referenceAttachments} />
         {isEditing ? (
           editingArea
+        ) : poll ? (
+          <PollCard
+            poll={poll}
+            message={message}
+            currentUserId={currentUserId}
+            onVote={handlePollVote}
+            disabled={pollVotingDisabled}
+          />
         ) : (
           hasBody && (
             <>
@@ -493,7 +538,7 @@ export function MessageItem({
           )
         )}
         <Attachments attachments={otherAttachments} />
-        {!message.__pending && !message.__failed && (
+        {!poll && !message.__pending && !message.__failed && (
           <ReactionsRow
             messageId={message.id}
             reactions={message.reactions ?? []}

--- a/src/components/messages/PollCard.tsx
+++ b/src/components/messages/PollCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * PollCard — renders a reactions-as-votes poll inside the message list. Votes
+ * are real Graph reactions (shared + live), but the card shows aggregate counts
+ * only, never voter names — the "anonymous in Teamsly" presentation. The footer
+ * states the caveat so nobody mistakes it for true anonymity.
+ */
+
+import { BarChart3 } from "lucide-react";
+import type { ReactionType } from "@/lib/utils/reactions";
+import { tallyVotes, type ParsedPoll } from "@/lib/polls";
+
+// MSMessage is an ambient global type (see src/types/graph.ts), not a module export.
+
+export function PollCard({
+  poll,
+  message,
+  currentUserId,
+  onVote,
+  disabled,
+}: {
+  poll: ParsedPoll;
+  message: MSMessage;
+  currentUserId: string;
+  onVote: (reactionType: ReactionType) => void;
+  disabled?: boolean;
+}) {
+  const { counts, total, myVotes } = tallyVotes(message, poll.options, currentUserId);
+
+  return (
+    <div className="mt-1 max-w-[440px] overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--surface)]">
+      <div className="flex items-start gap-2 border-b border-[var(--border)] px-3 py-2.5">
+        <BarChart3 className="mt-[1px] h-4 w-4 flex-shrink-0 text-[var(--accent)]" aria-hidden />
+        <p className="text-[13.5px] font-bold leading-snug text-[var(--text-primary)]">
+          {poll.question}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-1.5 p-2.5">
+        {poll.options.map((opt, i) => {
+          const pct = total ? Math.round((counts[i] / total) * 100) : 0;
+          const voted = myVotes[i];
+          return (
+            <button
+              key={i}
+              type="button"
+              disabled={disabled}
+              onClick={() => onVote(opt.reactionType)}
+              aria-pressed={voted}
+              className={`group relative flex w-full items-center gap-2.5 overflow-hidden rounded-md border px-2.5 py-1.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 focus-ring ${
+                voted
+                  ? "border-[var(--accent)] bg-[var(--accent)]/10"
+                  : "border-[var(--border)] bg-[var(--surface-raised)] hover:border-[var(--border-input)]"
+              }`}
+            >
+              {/* Fill bar behind the row content. */}
+              <span
+                aria-hidden
+                className="absolute inset-y-0 left-0 bg-[var(--accent)]/15 transition-[width] duration-300"
+                style={{ width: `${pct}%` }}
+              />
+              <span className="relative z-[1] text-[15px] leading-none">{opt.emoji}</span>
+              <span className="relative z-[1] flex-1 truncate text-[13px] text-[var(--text-primary)]">
+                {opt.text}
+              </span>
+              <span className="relative z-[1] flex-shrink-0 tabular-nums text-[12px] text-[var(--text-muted)]">
+                {pct}% · {counts[i]}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <p className="px-3 pb-2.5 text-[11px] text-[var(--text-muted)]">
+        {total} {total === 1 ? "vote" : "votes"} · anonymous in Teamsly
+      </p>
+    </div>
+  );
+}

--- a/src/lib/polls/index.ts
+++ b/src/lib/polls/index.ts
@@ -1,0 +1,126 @@
+// Anonymous polls — reactions-as-votes. A poll is an ordinary chat message
+// whose body lists each option prefixed by a distinct reaction emoji; people
+// vote by adding that reaction. The 6 Graph reaction types map positionally to
+// up to 6 options, so this works in native Teams too (the text tells voters
+// which emoji is which). Teamsly renders the same message as a PollCard.
+//
+// NOT truly anonymous: Graph records who reacted and native Teams shows it. The
+// PollCard only ever shows aggregate counts, so it's "anonymous in Teamsly".
+
+import { REACTION_EMOJI, REACTION_TYPES, type ReactionType } from "@/lib/utils/reactions";
+
+// MSMessage is an ambient global type (see src/types/graph.ts), not a module export.
+
+export const MIN_POLL_OPTIONS = 2;
+export const MAX_POLL_OPTIONS = REACTION_TYPES.length; // 6 — the Graph reaction cap
+
+const POLL_PREFIX = "📊 Poll:";
+const VOTE_HINT = "React with an option's emoji to vote.";
+
+export interface PollOption {
+  text: string;
+  reactionType: ReactionType;
+  emoji: string;
+}
+
+export interface ParsedPoll {
+  question: string;
+  options: PollOption[];
+}
+
+export interface PollTally {
+  /** Vote count per option, index-aligned with the poll's options. */
+  counts: number[];
+  /** Total votes cast across all options. */
+  total: number;
+  /** Whether the current user has voted each option (index-aligned). */
+  myVotes: boolean[];
+}
+
+/** Parse `/poll Question | Option A | Option B` into its parts. */
+export function parsePollCommand(
+  args: string,
+): { question: string; options: string[] } | { error: string } {
+  const parts = args.split("|").map((p) => p.trim()).filter(Boolean);
+  const [question, ...options] = parts;
+  if (!question) {
+    return { error: "Add a question, e.g. /poll Lunch where? | Tacos | Sushi" };
+  }
+  if (options.length < MIN_POLL_OPTIONS) {
+    return { error: `Polls need at least ${MIN_POLL_OPTIONS} options, separated by " | ".` };
+  }
+  if (options.length > MAX_POLL_OPTIONS) {
+    return { error: `Polls support up to ${MAX_POLL_OPTIONS} options.` };
+  }
+  return { question, options };
+}
+
+/** Build the plain-text message body that carries the poll (sent as usual). */
+export function buildPollBody(question: string, options: string[]): string {
+  const lines = [`${POLL_PREFIX} ${question}`];
+  options.slice(0, MAX_POLL_OPTIONS).forEach((opt, i) => {
+    lines.push(`${REACTION_EMOJI[REACTION_TYPES[i]]} ${opt}`);
+  });
+  lines.push(VOTE_HINT);
+  return lines.join("\n");
+}
+
+/** Strip Graph's HTML wrapper to trimmed, non-empty plain-text lines. */
+function toLines(content: string): string[] {
+  return content
+    .replace(/<\/(p|div)>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+export function isPoll(content: string): boolean {
+  const lines = toLines(content);
+  return lines.length > 0 && lines[0].startsWith(POLL_PREFIX);
+}
+
+export function parsePoll(content: string): ParsedPoll | null {
+  const lines = toLines(content);
+  if (lines.length === 0 || !lines[0].startsWith(POLL_PREFIX)) return null;
+
+  const question = lines[0].slice(POLL_PREFIX.length).trim();
+  const options: PollOption[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    const typeIdx = REACTION_TYPES.findIndex((t) => line.startsWith(REACTION_EMOJI[t]));
+    if (typeIdx === -1) continue; // hint line or anything unexpected
+    const reactionType = REACTION_TYPES[typeIdx];
+    const emoji = REACTION_EMOJI[reactionType];
+    options.push({ text: line.slice(emoji.length).trim(), reactionType, emoji });
+  }
+
+  if (options.length < MIN_POLL_OPTIONS) return null;
+  return { question, options };
+}
+
+/** Does a reaction record match this option? Graph stores either the type
+ *  name ("like") or the unicode emoji ("👍"), so accept both. */
+function reactionMatchesOption(reactionType: string, option: PollOption): boolean {
+  return reactionType === option.reactionType || reactionType === option.emoji;
+}
+
+export function tallyVotes(
+  message: MSMessage,
+  options: PollOption[],
+  currentUserId: string,
+): PollTally {
+  const reactions = message.reactions ?? [];
+  const counts = options.map(
+    (opt) => reactions.filter((r) => reactionMatchesOption(r.reactionType, opt)).length,
+  );
+  const myVotes = options.map((opt) =>
+    reactions.some((r) => r.user.id === currentUserId && reactionMatchesOption(r.reactionType, opt)),
+  );
+  return { counts, total: counts.reduce((a, b) => a + b, 0), myVotes };
+}

--- a/src/lib/slash-commands/index.ts
+++ b/src/lib/slash-commands/index.ts
@@ -1,3 +1,5 @@
+import { parsePollCommand, buildPollBody } from "@/lib/polls";
+
 export interface SlashCommandContext {
   currentUserName: string;
   currentUserId: string;
@@ -201,6 +203,19 @@ export const SLASH_COMMANDS: SlashCommand[] = [
         return { kind: "error", message: "Provide a search term: /giphy <query>" };
       }
       return { kind: "gif", query };
+    },
+  },
+  {
+    name: "poll",
+    description: "Post a quick poll",
+    usage: "/poll Question | Option A | Option B",
+    requiresArgs: true,
+    execute(args) {
+      const parsed = parsePollCommand(args);
+      if ("error" in parsed) {
+        return { kind: "error", message: parsed.error };
+      }
+      return { kind: "text", text: buildPollBody(parsed.question, parsed.options) };
     },
   },
   {


### PR DESCRIPTION
Closes #37

## What

A `/poll` command that posts a poll as an ordinary chat message. Each option is prefixed by a distinct reaction emoji (👍❤️😂😮😢😡); people vote by reacting. Teamsly renders the message as an interactive **PollCard** with live counts + bars. Because the emoji↔option mapping lives in the message text, **polls work in native Teams too** — those users just react to vote.

```
/poll Lunch where? | Tacos | Sushi | Pizza
```

## How

- **`lib/polls/index.ts`** — pure: `parsePollCommand`, `buildPollBody`, `isPoll`/`parsePoll` (HTML-tolerant parse-back), `tallyVotes` (matches reactions stored as either `"like"` or `"👍"`). 2–6 options (the Graph reaction cap).
- **`PollCard.tsx`** — question + per-option rows (emoji · text · % bar · count · your-vote highlight) + footer. **Counts only, never voter names.**
- **`MessageItem`** — renders `PollCard` in place of the body for poll messages in both render branches, and **suppresses the normal reaction row** (reactions *are* the votes). `handlePollVote` enforces **single-choice** by clearing any previous pick, reusing the existing reaction-toggle.
- **`/poll` slash command** — parses input, returns the poll body through the normal send path.

## ⚠️ Anonymity caveat (by design, documented)

Reactions-as-votes gives shared, live counts but is **not truly anonymous**: Microsoft Graph records who reacted and **native Teams shows reaction authors on hover**. Teamsly's card hides identities (counts only) and the footer says *"anonymous in Teamsly"*. This was a deliberate tradeoff for shared live tallies over local-only privacy. Minor known gap: the hover reaction toolbar can still add a reaction directly (bypassing single-choice) — acceptable for v1.

## Verification

- `npm run build` — green (exit 0), no new warnings.
- Design spec: `docs/superpowers/specs/2026-06-03-anonymous-polls-design.md`.
- Manual: `/poll Lunch? | Tacos | Sushi` → card renders; click an option → reaction fires, count updates; switching options moves the single vote; counts-only, no names.