### PR TITLE
feat(ui): Teams-style sidebar & chrome polish (A1)

### DIFF
--- a/docs/superpowers/specs/2026-06-03-native-teams-feel-audit.md
+++ b/docs/superpowers/specs/2026-06-03-native-teams-feel-audit.md
@@ -1,0 +1,56 @@
+# Native Microsoft Teams feel — audit & staged-PR plan
+
+**Date:** 2026-06-03
+**Goal:** Make Teamsly (web + Electron desktop) feel like the native Microsoft
+Teams client. Owner emphasis: detail polish, overall native feel, and
+**reactivity in the Electron desktop app**. Approach: full audit → staged PRs,
+recommended order, check-in between each. Segoe-UI default font and the two
+big-ticket Electron items (notarization, local-asset bundling) are **deferred**.
+
+## Track A — Visual native-feel (detail polish)
+- **A1 · Sidebar & chrome** *(this PR)* — active row = subtle accent tint + left
+  accent bar (was a solid violet block); sentence-case semibold section headers
+  (was ALL-CAPS); accent-colored unread badges via `--badge-unread` (was
+  mention-magenta); semibold unread text (was white-bold); full-strength leading
+  icons (drop `opacity-70`); unify header heights via `--chrome-header-h` (48px).
+- **A2 · Message rows** — 32px round avatars (was 36px rounded-square), continuation
+  gutter alignment, semibold author names, tighter line spacing, square-ish reaction
+  chips.
+- **A3 · Headers + composer** — 15px semibold conversation title (was 17px bold),
+  accent tab indicator, flat header (drop shadow), thin rule instead of `|` glyph;
+  composer accent send button (was presence-green), tighter radius/focus, fix
+  `hover:text-white` (light-mode bug), lucide icons for ⏱/📅.
+- **A4 · Motion / radii / elevation** — calmer ease-out (drop spring overshoots and
+  scale bounces), flatter shadows, consistent radius tokens, flatter date dividers.
+- *(A5 · Segoe UI default font — deferred per owner.)*
+
+## Track B — Web reactivity
+- **B1** — per-context loading flag (kill channel-switch skeleton flash + scroll
+  reset); `router.prefetch` on sidebar hover; fix draft-seed flicker.
+- **B2** — adaptive polling tied to SSE health (worst case 30s today); append-on-push
+  instead of full refetch; gate background timers on tab visibility.
+- **B3** — smooth new-message scroll; `React.memo` rows + memoized link detection;
+  header skeletons.
+
+## Track C — Electron native feel
+- **C0 · App icon** — the packaged app still shows the **default Electron logo**
+  (dock/taskbar/window). Set the brand icon in electron-builder + BrowserWindow.
+  Quick, high-visibility. (Owner-reported 2026-06-03.)
+- **C1** — no-flash launch (`show:false` + `ready-to-show`), offline retry page,
+  `backgroundThrottling:false`.
+- **C2** — native notification click → focus window + open conversation; stop gating
+  desktop notifications behind the Pro flag in Electron.
+- **C3** — Windows custom title bar, cross-platform menu, proper right-click context
+  menu + spellcheck (packaged builds currently kill the context menu).
+- **C4** — `teamsly://` deep links + single-instance lock + Windows taskbar badge.
+- **C5 (deferred, owner-gated)** — macOS notarization for silent auto-update.
+- **C6 (deferred, large)** — bundle Next `standalone` for local-first load (root fix
+  for the "website in a window" feel).
+
+## Recommended order
+A1 → A2 → C0 → C1 → B1 → C2 → A3 → A4 → B2 → C3/C4 → B3. (C0 promoted near the
+front since the owner flagged the Electron logo and it's a quick win.)
+
+## Verification
+Each PR: `npm run build` green. UI changes are CSS-var/Tailwind tweaks reviewable in
+the running dev server across palettes + light/dark.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,6 +69,15 @@ button:disabled,
   --reaction-active-bg: rgba(99, 102, 241, 0.2);
   --reaction-active-border: #6366F1;
 
+  /* Unread count badge fill. Teams tints these with the brand accent (not the
+     mention-text color). Tracks the runtime accent. */
+  --badge-unread: var(--accent);
+
+  /* Shared height for the top app header, team header, and conversation header
+     so the divider line is continuous across the rail/sidebar/content seam.
+     Teams' chrome header is ~48px. */
+  --chrome-header-h: 48px;
+
   /* Left-rail (56) + sidebar (260) = 316. Used by floating modals/popovers
      that want to be visually centered in the main content area rather than
      in the viewport. Update both numbers if either column resizes. */

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -370,7 +370,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </div>
       )}
       {/* Global top search bar */}
-      <header className="flex h-[50px] flex-shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--sidebar-bg)] px-4">
+      <header className="flex h-[var(--chrome-header-h)] flex-shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--sidebar-bg)] px-4">
         {/* Left: logomark */}
         <div className="flex w-[56px] flex-shrink-0 items-center justify-center">
           <Logo size={22} className="text-[var(--accent)]" />

--- a/src/components/layout/LeftRail.tsx
+++ b/src/components/layout/LeftRail.tsx
@@ -190,7 +190,7 @@ export function LeftRail() {
                 {showBadge && (
                   <span
                     aria-hidden="true"
-                    className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full bg-[var(--text-mention)] px-[3px] text-[9px] font-bold leading-none text-white"
+                    className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full bg-[var(--badge-unread)] px-[3px] text-[9px] font-bold leading-none text-white"
                   >
                     {badgeCount > 99 ? "99+" : badgeCount}
                   </span>

--- a/src/components/messages/MessageHeader.tsx
+++ b/src/components/messages/MessageHeader.tsx
@@ -179,7 +179,7 @@ export function ChannelMessageHeader({
   return (
     <div className="flex flex-col border-b border-[var(--border)] bg-[var(--content-bg)] px-4 shadow-sm">
       {/* Top row */}
-      <div className="flex h-[49px] items-center justify-between gap-4">
+      <div className="flex h-[var(--chrome-header-h)] items-center justify-between gap-4">
         {/* Left: icon + name + description */}
         <div className="flex min-w-0 items-center gap-2">
           <Hash className="h-4 w-4 flex-shrink-0 text-[var(--text-secondary)]" />
@@ -234,7 +234,7 @@ export function DmMessageHeader({
   return (
     <div className="flex flex-col border-b border-[var(--border)] bg-[var(--content-bg)] px-4 shadow-sm">
       {/* Top row */}
-      <div className="flex h-[49px] items-center justify-between gap-4">
+      <div className="flex h-[var(--chrome-header-h)] items-center justify-between gap-4">
         {/* Left: avatars + name */}
         <div className="flex min-w-0 items-center gap-2">
           {displayMembers.length > 0 ? (

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -458,7 +458,7 @@ export function Sidebar() {
         <DropdownMenu.Trigger asChild>
           <button
             type="button"
-            className="flex h-[49px] w-full items-center justify-between border-b border-[var(--border)] px-4 transition-colors duration-[80ms] ease-out hover:bg-[var(--sidebar-hover)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+            className="flex h-[var(--chrome-header-h)] w-full items-center justify-between border-b border-[var(--border)] px-4 transition-colors duration-[80ms] ease-out hover:bg-[var(--sidebar-hover)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
           >
             <span className="truncate text-[15px] font-black text-white">
               {activeTeam?.displayName ?? "Teamsly"}
@@ -475,7 +475,7 @@ export function Sidebar() {
           >
             {sortedTeams.length > 0 && (
               <>
-                <DropdownMenu.Label className="px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
+                <DropdownMenu.Label className="px-3 py-1 text-[12px] font-semibold text-[var(--text-muted)]">
                   Switch team
                 </DropdownMenu.Label>
                 <div className="max-h-[280px] overflow-y-auto">
@@ -755,7 +755,7 @@ export function Sidebar() {
 
         {/* Channels section */}
         <div className="mb-2">
-          <div className="group/section flex w-full items-center justify-between px-4 py-1 text-[11px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
+          <div className="group/section flex w-full items-center justify-between px-4 py-1 text-[12px] font-semibold text-[var(--text-muted)]">
             <button
               type="button"
               onClick={() => setChannelsOpen((v) => !v)}
@@ -817,7 +817,7 @@ export function Sidebar() {
 
         {/* DMs section */}
         <div className="mb-2">
-          <div className="group/section flex w-full items-center justify-between px-4 py-1 text-[11px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
+          <div className="group/section flex w-full items-center justify-between px-4 py-1 text-[12px] font-semibold text-[var(--text-muted)]">
             <button
               type="button"
               onClick={() => setDmsOpen((v) => !v)}
@@ -908,7 +908,7 @@ function SectionHeader({
     <button
       type="button"
       onClick={onToggle}
-      className="group/section flex w-full items-center gap-1.5 px-4 py-1 text-[11px] font-bold uppercase tracking-wider text-[var(--text-muted)] transition-colors duration-[80ms] ease-out hover:text-[var(--text-secondary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+      className="group/section flex w-full items-center gap-1.5 px-4 py-1 text-[12px] font-semibold text-[var(--text-muted)] transition-colors duration-[80ms] ease-out hover:text-[var(--text-secondary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
     >
       <ChevronRight
         className={cn(
@@ -916,10 +916,10 @@ function SectionHeader({
           open && "rotate-90"
         )}
       />
-      <span className="flex-shrink-0 opacity-70">{icon}</span>
+      <span className="flex-shrink-0">{icon}</span>
       <span className="truncate">{label}</span>
       {count > 0 && (
-        <span className="ml-auto flex h-[15px] min-w-[15px] flex-shrink-0 items-center justify-center rounded-full bg-[var(--text-mention)] px-[4px] text-[10px] font-bold text-white">
+        <span className="ml-auto flex h-[15px] min-w-[15px] flex-shrink-0 items-center justify-center rounded-full bg-[var(--badge-unread)] px-[4px] text-[10px] font-bold text-white">
           {count > 99 ? "99+" : count}
         </span>
       )}
@@ -976,6 +976,12 @@ function SidebarItem({
 
   return (
     <div className="group/row relative">
+      {active && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-[var(--accent)]"
+        />
+      )}
       <button
         onClick={onClick}
         style={{
@@ -986,12 +992,12 @@ function SidebarItem({
         className={cn(
           "press-snap mx-2 flex w-[calc(100%-16px)] items-center gap-2 rounded-md px-2 transition-colors [transition-duration:var(--motion-fast)] [transition-timing-function:var(--ease-out-soft)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]",
           active
-            ? "bg-[var(--accent)] text-[var(--text-white)]"
+            ? "bg-[var(--accent)]/15 font-semibold text-[var(--text-primary)]"
             : "text-[var(--text-secondary)] hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-primary)]"
         )}
       >
-        <span className="flex-shrink-0 opacity-70">{icon}</span>
-        <span className={cn("truncate", unread && "font-bold text-white")}>{label}</span>
+        <span className="flex-shrink-0">{icon}</span>
+        <span className={cn("truncate", unread && "font-semibold text-[var(--text-primary)]")}>{label}</span>
         {isSnoozed && (
           <BellOff
             className={cn(
@@ -1003,11 +1009,8 @@ function SidebarItem({
         )}
         {voiceCount > 0 && (
           <span className={cn(
-            "inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium",
-            isSnoozed ? "ml-1" : "ml-auto",
-            active
-              ? "bg-white/20 text-white"
-              : "bg-emerald-500/15 text-emerald-400"
+            "inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-emerald-500/15 text-emerald-400",
+            isSnoozed ? "ml-1" : "ml-auto"
           )}>
             🎙 {voiceCount}
           </span>
@@ -1015,7 +1018,7 @@ function SidebarItem({
         {unread && (
           <span
             className={cn(
-              "flex h-[16px] min-w-[16px] flex-shrink-0 items-center justify-center rounded-full bg-[var(--text-mention)] px-[4px] text-[10px] font-bold text-white",
+              "flex h-[16px] min-w-[16px] flex-shrink-0 items-center justify-center rounded-full bg-[var(--badge-unread)] px-[4px] text-[10px] font-bold text-white",
               voiceCount > 0 || isSnoozed ? "ml-1" : "ml-auto"
             )}
             style={pulsing ? { animation: 'badge-pulse 300ms ease-out' } : undefined}


### PR DESCRIPTION
First PR in the **native Teams feel** track (full audit + staged plan: `docs/superpowers/specs/2026-06-03-native-teams-feel-audit.md`).

## Why

The audit found the **selected sidebar row** — a solid saturated-violet block — was the single most "not-Teams" element in the chrome. Native Teams uses a subtle tint + a left accent indicator. A handful of other Slack-isms (ALL-CAPS headers, mention-magenta unread badges, pure-white bold text) added up.

## Changes (all CSS-var / Tailwind, themed across palettes + light/dark)

- **Selected sidebar row** → subtle `accent/15` tint + a 3px left accent bar + semibold primary text (was full accent fill + white text).
- **Section headers** → sentence-case `font-semibold` (was `uppercase tracking-wider font-bold`).
- **Unread badges** → new `--badge-unread` token (= accent) in sidebar rows, section headers, and the LeftRail (was `--text-mention`, the *mention text* color).
- **Unread row text** → `font-semibold text-primary` (was `text-white font-bold`).
- **Leading list icons** → full-strength (dropped `opacity-70`).
- **Header heights** → unified via new `--chrome-header-h: 48px` across app header, team header, and conversation header (were 50/49/49 — the 1px mismatch broke the divider seam).
- **Voice badge** → single emerald style (the old active-state white-on-accent no longer applies).

## Verification

- `npm run build` — green (exit 0).
- Review in dev server: switch channels (active tint + left bar), check unread badges are accent, headers align across the rail/sidebar/content seam, verify light mode + non-default palettes.

Part of #38-adjacent polish; tracked under the native-feel audit doc. Next: A2 (message-row proportions).