### PR TITLE
feat(ui): Teams-style message-row proportions (A2)

### DIFF
--- a/src/components/messages/MessageHeader.tsx
+++ b/src/components/messages/MessageHeader.tsx
@@ -145,7 +145,7 @@ function MemberAvatarStack({
     >
       <div className="flex -space-x-1.5">
         {shown.map((m) => (
-          <div key={m.id} className="ring-2 ring-[var(--content-bg)]" style={{ borderRadius: 4 }}>
+          <div key={m.id} className="rounded-full ring-2 ring-[var(--content-bg)]">
             <Avatar
               userId={m.userId ?? m.id}
               displayName={m.displayName}

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -369,9 +369,10 @@ export function MessageItem({
             onDelete={deleteHandler}
           />
         )}
-        {/* Fixed-width gutter matching the head row's avatar column (w-9 + gap-2 = ~44px → rounded to 60px to include avatar margin) */}
+        {/* Gutter width = head row's avatar column: 32px avatar + gap-2 (8px) = 40px,
+            so continuation text aligns pixel-for-pixel under the group head's body. */}
         <span
-          className="flex w-[60px] flex-shrink-0 select-none items-start justify-end gap-0.5 pr-3 pt-[3px] text-right text-[11px] tabular-nums leading-[18px] text-[var(--text-muted)] opacity-0 transition-opacity duration-100 group-hover:opacity-100"
+          className="flex w-10 flex-shrink-0 select-none items-start justify-end gap-0.5 pr-2 pt-[3px] text-right text-[11px] tabular-nums leading-[18px] text-[var(--text-muted)] opacity-0 transition-opacity duration-100 group-hover:opacity-100"
           title={formatFullTimestamp(message.createdDateTime)}
         >
           {message.__pending && (
@@ -446,18 +447,18 @@ export function MessageItem({
         />
       )}
       <UserProfilePopover userId={userId} displayName={author}>
-        <button type="button" className="h-9 w-9 flex-shrink-0 rounded text-left focus-ring">
-          <Avatar userId={userId} displayName={author} size={36} />
+        <button type="button" className="h-8 w-8 flex-shrink-0 rounded-full text-left focus-ring">
+          <Avatar userId={userId} displayName={author} size={32} />
         </button>
       </UserProfilePopover>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
-          <span className="cursor-pointer text-[14px] font-bold text-[var(--text-primary)] hover:underline">
+          <span className="cursor-pointer text-[14px] font-semibold text-[var(--text-primary)] hover:underline">
             {author}
           </span>
           <span className="flex items-center gap-1">
             <span
-              className="text-xs text-[var(--text-muted)]"
+              className="text-[11px] text-[var(--text-muted)]"
               title={formatFullTimestamp(message.createdDateTime)}
             >
               {formatMessageTime(message.createdDateTime)}

--- a/src/components/messages/ReactionPill.tsx
+++ b/src/components/messages/ReactionPill.tsx
@@ -69,7 +69,7 @@ export function ReactionPill({ reactionType, count, active, onClick }: ReactionP
         type="button"
         onClick={handleClick}
         className={[
-          "inline-flex h-6 items-center gap-1 rounded-full border px-2.5 py-0.5 text-[12px] transition-colors duration-150 focus-ring",
+          "inline-flex h-6 items-center gap-1 rounded-md border px-2 py-0.5 text-[12px] transition-colors duration-150 focus-ring",
           bursting ? "react-burst" : "",
           active
             ? "border-[var(--accent)] bg-[var(--reaction-active-bg)] text-[var(--text-primary)]"
@@ -89,7 +89,7 @@ export function AddReactionPill({ onSelect }: { onSelect: (reaction: ReactionTyp
       <button
         type="button"
         aria-label="Add reaction"
-        className="inline-flex h-6 items-center rounded-full border border-[var(--reaction-border)] bg-[var(--reaction-bg)] px-2.5 py-0.5 text-[var(--text-secondary)] transition-colors duration-150 hover:border-[var(--accent)] hover:bg-[var(--reaction-active-bg)] hover:text-white focus-ring"
+        className="inline-flex h-6 items-center rounded-md border border-[var(--reaction-border)] bg-[var(--reaction-bg)] px-2 py-0.5 text-[var(--text-secondary)] transition-colors duration-150 hover:border-[var(--accent)] hover:bg-[var(--reaction-active-bg)] hover:text-[var(--text-primary)] focus-ring"
       >
         <Plus size={13} />
       </button>

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { avatarColor, avatarInitials } from "@/lib/utils/avatar";
 
-type AvatarSize = 18 | 20 | 24 | 36;
+type AvatarSize = 18 | 20 | 24 | 28 | 32 | 36;
 
 interface AvatarProps {
   userId: string;
@@ -17,15 +17,16 @@ const FONT_SIZE: Record<AvatarSize, number> = {
   18: 9,
   20: 10,
   24: 11,
+  28: 12,
+  32: 13,
   36: 14,
 };
 
-const RADIUS: Record<AvatarSize, number> = {
-  18: 3,
-  20: 3,
-  24: 4,
-  36: 4,
-};
+// People avatars are circular in Teams. Avatar is only ever used for people
+// (message authors, members, DMs, profile) — team/channel icons use their own
+// chrome — so a fixed circular radius is safe and size-independent (works even
+// when callers override the box size via className).
+const AVATAR_RADIUS = "50%";
 
 export function Avatar({ userId, displayName, size = 36, photoUrl, className }: AvatarProps) {
   const [imageError, setImageError] = useState(false);
@@ -40,7 +41,7 @@ export function Avatar({ userId, displayName, size = 36, photoUrl, className }: 
   const bg = avatarColor(userId);
   const initials = avatarInitials(displayName);
   const px = `${size}px`;
-  const radius = `${RADIUS[size]}px`;
+  const radius = AVATAR_RADIUS;
   const font = `${FONT_SIZE[size]}px`;
 
   const initialsEl = (


### PR DESCRIPTION
Second native-feel PR (after #62). Brings the message list to native Teams proportions.

## Changes

- **Avatars → 32px circular** (were 36px rounded-square). `Avatar` is only ever used for people (verified across all call sites — team/channel icons use separate chrome), so it now uses a size-independent `50%` radius. This also rounds the larger className-overridden avatars in the profile popover and member panel.
- **Continuation gutter → 40px** (= 32px avatar + 8px gap) so continuation lines align pixel-for-pixel under the group head's body. Was `60px` — ~16px too far right.
- **Author name → semibold** (was bold/black, which read Slack-like).
- **Timestamp → 11px** (was 12px) to match Teams' lighter header time.
- **Reaction chips → `rounded-md`** square-ish chips with tighter padding (were full pills). Also fixes the add-reaction hover from pure `white` → `--text-primary` (a light-mode contrast bug).
- **Member avatar stack → circular ring** to match the now-round avatars.

## Notes

- Added `28`/`32` to the `Avatar` size scale; existing sizes unchanged.
- Density-aware avatar sizing (smaller on compact) is a deferred nicety — message rows use a fixed 32px (Teams' default) for now.

## Verification

- `npm run build` — green (exit 0).
- Review in dev: message rows (round avatars, aligned continuation lines, lighter name/time), reactions (square chips), light mode hover.

Part of the native-feel track. Next: C1 (no-flash Electron launch) — informed by the just-completed review of teams-for-linux / Ferdium.