### PR TITLE
feat(electron): no-flash launch + offline fallback (C1)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -215,6 +215,32 @@ function buildAppMenu(): void {
 
 // ─── Main window ──────────────────────────────────────────────────────────────
 
+// Branded offline page (as a data: URL) shown when the renderer can't reach the
+// app. The Retry button re-navigates to the real app URL; if it's still
+// unreachable, did-fail-load fires again and brings the user back here.
+function offlineFallbackUrl(targetUrl: string): string {
+  const safeUrl = targetUrl.replace(/'/g, '%27');
+  const html = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  html,body{height:100%;margin:0}
+  body{display:flex;align-items:center;justify-content:center;
+    font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+    background:#0B0F1A;color:#d1d2d3}
+  .box{text-align:center;max-width:340px;padding:24px}
+  h1{font-size:16px;font-weight:600;margin:0 0 8px}
+  p{font-size:13px;color:#6c6f75;margin:0 0 20px;line-height:1.5}
+  button{font:inherit;font-size:13px;font-weight:600;color:#fff;background:#6366F1;
+    border:0;border-radius:6px;padding:9px 20px;cursor:pointer}
+  button:hover{background:#4F46E5}
+</style></head><body><div class="box">
+  <h1>Can&rsquo;t reach Teamsly</h1>
+  <p>Check your internet connection and try again.</p>
+  <button onclick="location.href='${safeUrl}'">Retry</button>
+</div></body></html>`;
+  return 'data:text/html;charset=utf-8,' + encodeURIComponent(html);
+}
+
 function createWindow(): void {
   const appIcon = nativeImage.createFromPath(
     path.join(__dirname, '..', 'build-resources', 'icon.png')
@@ -234,12 +260,31 @@ function createWindow(): void {
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     // icon is used by Windows/Linux; macOS reads it from the .app bundle
     icon: appIcon,
+    // Start hidden and reveal on first paint so launch shows the rendered app
+    // instead of an empty window while the renderer loads (no startup flash).
+    show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
+      // Keep timers/notifications alive when the window is backgrounded (e.g.
+      // hidden to tray) so realtime updates and unread counts don't stall.
+      backgroundThrottling: false,
     },
+  });
+
+  // Reveal once the first frame is painted — the no-flash launch.
+  mainWindow.once('ready-to-show', () => mainWindow?.show());
+
+  // If the app URL can't be reached (offline / host down), show a branded retry
+  // page instead of a raw Chromium error, and make sure the window is visible
+  // (ready-to-show may never fire when the very first load fails).
+  mainWindow.webContents.on('did-fail-load', (_event, errorCode, _desc, _url, isMainFrame) => {
+    // ERR_ABORTED (-3) fires on ordinary in-app navigations; ignore it + subframes.
+    if (!isMainFrame || errorCode === -3) return;
+    void mainWindow?.loadURL(offlineFallbackUrl(TEAMSLY_URL));
+    mainWindow?.show();
   });
 
   void mainWindow.loadURL(TEAMSLY_URL);


### PR DESCRIPTION
Electron native-feel pass, informed by the teams-for-linux / Ferdium review.

## Changes (`electron/main.ts`)

- **No-flash launch** — the window is created `show: false` and revealed on `ready-to-show`, so launch shows the painted app instead of an empty rectangle while the renderer loads. The biggest "this is just a web view" startup tell.
- **Offline fallback** — on `did-fail-load` (main frame, ignoring `ERR_ABORTED`), load a branded *"Can't reach Teamsly"* page with a **Retry** button (re-navigates to the app URL) instead of the raw Chromium error page. Also force-shows the window, since `ready-to-show` never fires when the very first load fails.
- **`backgroundThrottling: false`** — keeps timers / realtime updates / unread counts alive when the window is hidden to tray. (The wrapper review flagged this as something even teams-for-linux omits.)

## Verification

- `npm run electron:compile` — green (exit 0).
- Manual (desktop): launch shows no empty-window flash; kill network → Retry page appears, restore network + Retry → app loads.

## Next in the Electron track
- **C2** — native notification **click-to-focus-and-route** (open the conversation), and decouple desktop notifications from the Pro gate in Electron — a differentiation opportunity (even teams-for-linux only does `show()` on click, not routing).
- **C3/C4** — Windows custom title bar, context-menu + spellcheck, single-instance + `msteams://` deep links, Windows taskbar unread badge.