### PR TITLE
chore(deps): upgrade to TypeScript 6

### DIFF
--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -3,6 +3,9 @@
     "target": "ES2022",
     "module": "CommonJS",
     "moduleResolution": "node",
+    // TS6 deprecates the node10/"node" resolver (errors without this). Silence
+    // for now; migrate this CJS config to node16/bundler before TS7.
+    "ignoreDeprecations": "6.0",
     "outDir": "./dist",
     "rootDir": ".",
     "strict": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "eslint-config-next": "15.5.18",
         "postcss": "8.5.15",
         "tailwindcss": "^4.3.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "wait-on": "^8.0.0"
       }
     },
@@ -11909,9 +11909,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-config-next": "15.5.18",
     "postcss": "8.5.15",
     "tailwindcss": "^4.3.0",
-    "typescript": "^5",
+    "typescript": "^6.0.3",
     "wait-on": "^8.0.0"
   },
   "overrides": {

--- a/src/types/styles.d.ts
+++ b/src/types/styles.d.ts
@@ -1,0 +1,5 @@
+// TypeScript 6 (TS2882) requires a module declaration for side-effect imports
+// of non-code assets like `import "./globals.css"`. Next.js resolves CSS via its
+// build pipeline, not the type system, so a bare ambient declaration is enough.
+// (No CSS Modules in this project, so a global `*.css` shape is safe.)
+declare module "*.css";


### PR DESCRIPTION
Unblocks #54 (held because TS6 broke the build).

## Two TS6 breaking changes, fixed
1. **TS2882** — side-effect imports of non-code assets (`import "./globals.css"` in `layout.tsx`) now require a module declaration. Added an ambient `declare module "*.css";` (`src/types/styles.d.ts`). No CSS Modules in the project, so a global shape is safe.
2. **`moduleResolution: "node"` (= node10) deprecation** errors under TS6 in `electron/tsconfig.json`. Added `ignoreDeprecations: "6.0"` with a note to migrate to `node16`/`bundler` before TS7.

## Verification
- `tsc --noEmit` (app) — clean (no cascade beyond the one CSS error).
- `npm run build` — exit 0.
- `npm run electron:compile` — exit 0.

Closes #54.