### PR TITLE
feat(reactivity): per-context loading + route prefetch + scroll-to-latest fix

### DIFF
--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -24,7 +24,6 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     teams,
     channels,
     getMessages,
-    isLoadingMessages,
     currentUserId,
     currentUserName,
     setMessages,
@@ -32,10 +31,14 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     replaceMessage,
     markMessageFailed,
     removeMessage,
-    setLoadingMessages,
+    setContextLoading,
     toggleReaction,
   } = useWorkspaceStore();
   const isHydrated = useWorkspaceStore((s) => s.isHydrated);
+  // First-load flag for THIS channel only — a cached channel never shows the skeleton.
+  const loadingThisChannel = useWorkspaceStore(
+    (s) => s.loadingContexts[`${teamId}:${channelId}`] ?? false,
+  );
   const [threadMessage, setThreadMessage] = useState<MSMessage | null>(null);
   const [forwardMessage, setForwardMessage] = useState<MSMessage | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("messages");
@@ -77,7 +80,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     const cached = getMessages(contextId);
     const isFirstLoad = cached.length === 0 && isHydrated;
 
-    if (isFirstLoad) setLoadingMessages(true);
+    if (isFirstLoad) setContextLoading(contextId, true);
 
     async function load() {
       try {
@@ -88,7 +91,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
       } catch {
         if (isFirstLoad && !cancelled) showToast({ title: "Could not load messages", tone: "error" });
       } finally {
-        if (!cancelled) setLoadingMessages(false);
+        if (!cancelled) setContextLoading(contextId, false);
       }
     }
 
@@ -122,7 +125,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamId, channelId, contextId, isHydrated, setLoadingMessages, setMessages, showToast]);
+  }, [teamId, channelId, contextId, isHydrated, setContextLoading, setMessages, showToast]);
 
   useRealtimeEvents(
     useCallback(
@@ -381,7 +384,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
         <>
           <MessageFeed
             messages={messages}
-            loading={isLoadingMessages}
+            loading={loadingThisChannel}
             contextName={channel?.displayName ? `#${channel.displayName}` : "Channel"}
             bookmarkContextId={contextId}
             contextLabel={channel?.displayName ? `#${channel.displayName}` : "Channel"}

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -25,7 +25,6 @@ export function ChatView({ chatId }: { chatId: string }) {
   const {
     chats,
     getMessages,
-    isLoadingMessages,
     currentUserId,
     currentUserName,
     setMessages,
@@ -34,7 +33,7 @@ export function ChatView({ chatId }: { chatId: string }) {
     markMessageFailed,
     removeMessage,
     expireMessage,
-    setLoadingMessages,
+    setContextLoading,
     toggleReaction,
     deleteMessage,
     restoreMessage,
@@ -44,6 +43,8 @@ export function ChatView({ chatId }: { chatId: string }) {
     patchChatMembers,
   } = useWorkspaceStore();
   const isHydrated = useWorkspaceStore((s) => s.isHydrated);
+  // First-load flag for THIS chat only — a cached chat never shows the skeleton.
+  const loadingThisChat = useWorkspaceStore((s) => s.loadingContexts[chatId] ?? false);
   const scheduledMessages = useScheduledStore((s) => s.scheduled);
   const addScheduled = useScheduledStore((s) => s.addScheduled);
   const removeScheduled = useScheduledStore((s) => s.removeScheduled);
@@ -229,7 +230,7 @@ export function ChatView({ chatId }: { chatId: string }) {
     const cached = getMessages(chatId);
     const isFirstLoad = cached.length === 0 && isHydrated;
 
-    if (isFirstLoad) setLoadingMessages(true);
+    if (isFirstLoad) setContextLoading(chatId, true);
 
     async function load() {
       try {
@@ -244,7 +245,7 @@ export function ChatView({ chatId }: { chatId: string }) {
       } catch {
         if (isFirstLoad && !cancelled) showToast({ title: "Could not load messages", tone: "error" });
       } finally {
-        if (!cancelled) setLoadingMessages(false);
+        if (!cancelled) setContextLoading(chatId, false);
       }
     }
 
@@ -291,7 +292,7 @@ export function ChatView({ chatId }: { chatId: string }) {
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatId, isHydrated, setLoadingMessages, setMessages, showToast, sweepExpired, sweepScheduled]);
+  }, [chatId, isHydrated, setContextLoading, setMessages, showToast, sweepExpired, sweepScheduled]);
 
   useRealtimeEvents(
     useCallback(
@@ -759,7 +760,7 @@ export function ChatView({ chatId }: { chatId: string }) {
           )}
           <MessageFeed
             messages={messages}
-            loading={isLoadingMessages}
+            loading={loadingThisChat}
             contextName={label}
             bookmarkContextId={chatId}
             contextLabel={label}

--- a/src/components/messages/MessageFeed.tsx
+++ b/src/components/messages/MessageFeed.tsx
@@ -99,8 +99,21 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
     setNewMessagesCount(0);
   }, []);
 
-  // On initial load or when the context changes (new channel/DM opened):
-  // always scroll to bottom immediately and reset counters.
+  // Reset scroll state whenever the open context changes (channel/DM switch).
+  // We key on contextId rather than the `loading` flag because a *cached*
+  // context never flips loading true — so relying on loading meant opening a
+  // cached chat left the feed wherever it was instead of pinned to the latest
+  // message. Defined before the scroll-to-bottom effect so the ref is reset
+  // first within the same commit.
+  useEffect(() => {
+    isInitialLoad.current = true;
+    prevMessageCountRef.current = 0;
+    setIsNearBottom(true);
+    setNewMessagesCount(0);
+  }, [contextId]);
+
+  // On initial load or context change: once messages are present and not
+  // loading, scroll straight to the latest message.
   useEffect(() => {
     if (loading) return;
     if (isInitialLoad.current && messages.length > 0) {
@@ -108,17 +121,7 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
       prevMessageCountRef.current = messages.length;
       scrollToBottom("instant");
     }
-  }, [loading, messages.length, scrollToBottom]);
-
-  // Reset state when a new context loads (loading flips back to true).
-  useEffect(() => {
-    if (loading) {
-      isInitialLoad.current = true;
-      prevMessageCountRef.current = 0;
-      setIsNearBottom(true);
-      setNewMessagesCount(0);
-    }
-  }, [loading]);
+  }, [loading, messages.length, scrollToBottom, contextId]);
 
   // React to new messages arriving after initial load.
   useEffect(() => {

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -273,7 +273,12 @@ export function MessageInput({
   allowSchedule,
   whenFreeTarget,
 }: Props) {
-  const [value, setValue] = useState("");
+  // Lazy-init from the saved draft so a context with a draft paints filled on
+  // first render instead of flashing empty for a frame before the seed effect
+  // below runs. The effect still handles in-place contextId changes.
+  const [value, setValue] = useState(() =>
+    contextId ? (useDraftsStore.getState().drafts[contextId] ?? "") : "",
+  );
   const [sending, setSending] = useState(false);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [emojiOpen, setEmojiOpen] = useState(false);

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -405,6 +405,16 @@ export function Sidebar() {
     router.push(`/workspace/dm/${chatId}`);
   }
 
+  // Warm the RSC route on hover/focus so the click feels instant — the message
+  // body already paints from the IDB cache, but the page-level navigation
+  // otherwise pays a server round-trip on first visit to each route.
+  function prefetchChannel(channelId: string) {
+    if (activeTeamId) router.prefetch(`/workspace/t/${activeTeamId}/${channelId}`);
+  }
+  function prefetchChat(chatId: string) {
+    router.prefetch(`/workspace/dm/${chatId}`);
+  }
+
   function switchTeam(teamId: string) {
     if (teamId === activeTeamId) return;
     setActiveTeam(teamId);
@@ -651,6 +661,7 @@ export function Sidebar() {
                   unreadCount={unreadCounts[ch.id] ?? 0}
                   voiceCount={voiceCounts[ch.id] ?? 0}
                   onClick={() => goToChannel(ch.id)}
+                  onHover={() => prefetchChannel(ch.id)}
                   contextId={activeTeamId ? `${activeTeamId}:${ch.id}` : undefined}
                   unreadId={ch.id}
                 />
@@ -664,6 +675,7 @@ export function Sidebar() {
                   unreadCount={unreadCounts[chat.id] ?? 0}
                   voiceCount={voiceCounts[chat.id] ?? 0}
                   onClick={() => goToChat(chat.id)}
+                  onHover={() => prefetchChat(chat.id)}
                   contextId={chat.id}
                   unreadId={chat.id}
                 />
@@ -727,6 +739,7 @@ export function Sidebar() {
                   unreadCount={unreadCounts[ch.id] ?? 0}
                   voiceCount={voiceCounts[ch.id] ?? 0}
                   onClick={() => goToChannel(ch.id)}
+                  onHover={() => prefetchChannel(ch.id)}
                   contextId={activeTeamId ? `${activeTeamId}:${ch.id}` : undefined}
                   unreadId={ch.id}
                 />
@@ -740,6 +753,7 @@ export function Sidebar() {
                   unreadCount={unreadCounts[chat.id] ?? 0}
                   voiceCount={voiceCounts[chat.id] ?? 0}
                   onClick={() => goToChat(chat.id)}
+                  onHover={() => prefetchChat(chat.id)}
                   contextId={chat.id}
                   unreadId={chat.id}
                 />
@@ -807,6 +821,7 @@ export function Sidebar() {
                   unreadCount={unreadCounts[ch.id] ?? 0}
                   voiceCount={voiceCounts[ch.id] ?? 0}
                   onClick={() => goToChannel(ch.id)}
+                  onHover={() => prefetchChannel(ch.id)}
                   contextId={activeTeamId ? `${activeTeamId}:${ch.id}` : undefined}
                   unreadId={ch.id}
                 />
@@ -863,6 +878,7 @@ export function Sidebar() {
                   unreadCount={unreadCounts[chat.id] ?? 0}
                   voiceCount={voiceCounts[chat.id] ?? 0}
                   onClick={() => goToChat(chat.id)}
+                  onHover={() => prefetchChat(chat.id)}
                   contextId={chat.id}
                   unreadId={chat.id}
                 />
@@ -934,6 +950,7 @@ function SidebarItem({
   unreadCount = 0,
   voiceCount = 0,
   onClick,
+  onHover,
   contextId,
   unreadId,
 }: {
@@ -943,6 +960,8 @@ function SidebarItem({
   unreadCount?: number;
   voiceCount?: number;
   onClick: () => void;
+  /** Fired on hover/focus — used to prefetch the row's route so the click is instant. */
+  onHover?: () => void;
   /** Key used for snooze (`teamId:channelId` for channels, `chatId` for DMs). */
   contextId?: string;
   /** Key used for unread counts (`channelId` for channels, `chatId` for DMs). */
@@ -984,6 +1003,8 @@ function SidebarItem({
       )}
       <button
         onClick={onClick}
+        onMouseEnter={onHover}
+        onFocus={onHover}
         style={{
           paddingTop: "var(--density-sidebar-row-py)",
           paddingBottom: "var(--density-sidebar-row-py)",

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -29,7 +29,10 @@ interface WorkspaceState {
   // Per-context message cache: keyed by chatId or channelId.
   // Preserved across navigation so re-visiting a context doesn't show a spinner.
   messagesByContext: Record<string, MSMessage[]>;
-  isLoadingMessages: boolean;
+  // Per-context first-load flag. A single global boolean made every channel
+  // switch flash a skeleton / reset scroll even when the target was cached;
+  // keying by context means only an actually-uncached context shows loading.
+  loadingContexts: Record<string, boolean>;
   presenceMap: Record<string, MSPresence["availability"]>;
   statusMessageMap: Record<string, MSPresence["statusMessage"]>;
   unreadCounts: Record<string, number>;
@@ -99,7 +102,7 @@ interface WorkspaceState {
   restoreMessage: (contextId: string, message: MSMessage, index: number) => void;
   editMessage: (contextId: string, messageId: string, newContent: string) => { previousContent: string; previousContentType: MSMessage["body"]["contentType"]; index: number } | null;
   revertMessageEdit: (contextId: string, messageId: string, previousContent: string, previousContentType: MSMessage["body"]["contentType"]) => void;
-  setLoadingMessages: (v: boolean) => void;
+  setContextLoading: (contextId: string, v: boolean) => void;
   setPresenceMap: (presenceMap: Record<string, MSPresence["availability"]>) => void;
   setStatusMessage: (userId: string, statusMessage: MSPresence["statusMessage"]) => void;
   setCurrentUser: (user: { id: string; displayName: string }) => void;
@@ -130,7 +133,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       chatsNextLink: null,
       activeChatId: null,
       messagesByContext: {},
-      isLoadingMessages: false,
+      loadingContexts: {},
       presenceMap: {},
       statusMessageMap: {},
       unreadCounts: {},
@@ -399,7 +402,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           };
         }),
 
-      setLoadingMessages: (v) => set({ isLoadingMessages: v }),
+      setContextLoading: (contextId, v) =>
+        set((s) => {
+          if (v) return { loadingContexts: { ...s.loadingContexts, [contextId]: true } };
+          if (!s.loadingContexts[contextId]) return s;
+          const next = { ...s.loadingContexts };
+          delete next[contextId];
+          return { loadingContexts: next };
+        }),
       setPresenceMap: (presenceMap) => set({ presenceMap }),
       setStatusMessage: (userId, statusMessage) =>
         set((s) => ({ statusMessageMap: { ...s.statusMessageMap, [userId]: statusMessage } })),


### PR DESCRIPTION
Native-feel **reactivity** pass (audit track B1) + a scroll bug you reported.

## Bug fix: chat doesn't scroll to the latest message on open
`MessageFeed` persists across DM/channel switches (same route segment) and only reset its scroll state when the `loading` flag flipped **true**. But `loading` never flips true for a **cached** context — so opening a cached chat left the feed wherever it happened to be instead of pinned to the newest message. Now it resets scroll state on **`contextId` change**, so every open/switch lands at the latest message (cached or not).

## Reactivity (B1)
- **Per-context loading** — replaced the single global `isLoadingMessages` boolean with `loadingContexts[contextId]`. The global flag made *every* switch flash a skeleton + reset scroll even for cached contexts; now only an uncached context shows loading. (This is also what made the scroll bug worse, so the two fixes belong together.)
- **Route prefetch** — `router.prefetch` the channel/DM route on sidebar row hover/focus, so the page-level RSC navigation is warm before the click.
- **Composer draft** — lazy-init the composer value from the saved draft so a context with a draft paints filled instead of flashing empty for one frame.

## Verification
- `npm run build` — exit 0.
- Manual: switch between cached chats → each opens pinned to the latest message, no skeleton flash; hovering a row warms its route; a chat with a draft shows it immediately.

Note: the **unread-indicator** issue you also flagged is a separate, currently-unimplemented feature (the store's `setUnreadCount` is never called — nothing computes unread from Graph). Filing + building that next.