### PR TITLE
feat(unread): unread indicators for DMs

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -103,6 +103,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { PresenceDot } from "@/components/ui/PresenceDot";
 import { useToastStore } from "@/store/toasts";
 import { getChatLabel } from "@/lib/utils/chat-label";
+import { isChatUnread } from "@/lib/utils/chat-unread";
 import { useSearchStore } from "@/store/search";
 import { usePreferencesStore } from "@/store/preferences";
 
@@ -209,6 +210,13 @@ export function Sidebar() {
         const data = (await response.json()) as { chats: MSChat[]; nextLink: string | null };
         setChats(data.chats, data.nextLink);
         const ws = useWorkspaceStore.getState();
+        // Surface unread DMs. The poll only *adds* unread (a message newer than
+        // you've seen, from someone other than you); clearing is markRead's job
+        // (on open / mark-read), so a chat you've read doesn't re-flag here.
+        data.chats.forEach((c) => {
+          if (ws.unreadCounts[c.id]) return;
+          if (isChatUnread(c, ws.currentUserId, ws.chatReadAt[c.id])) ws.markUnread(c.id);
+        });
         void sweepAllDms(
           data.chats.map((c) => c.id),
           ws.getMessages,

--- a/src/lib/graph/client.ts
+++ b/src/lib/graph/client.ts
@@ -100,7 +100,7 @@ export async function getChats(
     ? await client.api(nextLink).get()
     : await client
         .api("/me/chats")
-        .select("id,chatType,topic,lastUpdatedDateTime,lastMessagePreview")
+        .select("id,chatType,topic,lastUpdatedDateTime,lastMessagePreview,viewpoint")
         .top(pageSize)
         .get();
 

--- a/src/lib/utils/chat-unread.ts
+++ b/src/lib/utils/chat-unread.ts
@@ -1,0 +1,31 @@
+// Compute whether a DM/group chat has unread messages, from the chat-list data
+// Graph returns. Graph gives no per-chat unread *count*, so this is a boolean
+// "has unread" used to show an indicator.
+//
+// A chat is unread when its last message is newer than what the user has seen,
+// and that last message isn't the user's own. "Seen" = the later of Graph's
+// viewpoint.lastMessageReadDateTime (advances only in official Teams) and the
+// local read time recorded when the user opens/marks the chat read here.
+
+function toMs(value: string | null | undefined): number {
+  if (!value) return 0;
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+export function isChatUnread(
+  chat: MSChat,
+  currentUserId: string,
+  localReadAt: number | undefined,
+): boolean {
+  const preview = chat.lastMessagePreview;
+  const lastMessageAt = toMs(preview?.createdDateTime);
+  if (!lastMessageAt) return false;
+
+  // Our own last message never counts as unread.
+  const fromId = preview?.from?.user?.id;
+  if (fromId && fromId === currentUserId) return false;
+
+  const seenAt = Math.max(toMs(chat.viewpoint?.lastMessageReadDateTime), localReadAt ?? 0);
+  return lastMessageAt > seenAt;
+}

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -33,6 +33,10 @@ interface WorkspaceState {
   presenceMap: Record<string, MSPresence["availability"]>;
   statusMessageMap: Record<string, MSPresence["statusMessage"]>;
   unreadCounts: Record<string, number>;
+  /** Epoch ms the user last read each chat locally. Set on open/mark-read.
+   *  Graph's viewpoint doesn't advance from this app, so this is what stops a
+   *  chat from re-marking itself unread on the next poll after you've read it. */
+  chatReadAt: Record<string, number>;
   currentUserId: string;
   currentUserName: string;
   starredIds: string[];
@@ -134,6 +138,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       presenceMap: {},
       statusMessageMap: {},
       unreadCounts: {},
+      chatReadAt: {},
       currentUserId: "you",
       currentUserName: "You",
       starredIds: [],
@@ -418,11 +423,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         }),
       markRead: (id) =>
         set((s) => {
-          if (!s.unreadCounts[id]) return s;
+          // Always record the local read time so the unread poll doesn't
+          // re-flag this chat until a newer message arrives.
+          const chatReadAt = { ...s.chatReadAt, [id]: Date.now() };
+          if (!s.unreadCounts[id]) return { chatReadAt };
           const next = { ...s.unreadCounts };
           delete next[id];
           writeUnreadCounts(next);
-          return { unreadCounts: next };
+          return { unreadCounts: next, chatReadAt };
         }),
       markUnread: (id) =>
         set((s) => {
@@ -462,6 +470,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         currentUserId: state.currentUserId,
         currentUserName: state.currentUserName,
         starredIds: state.starredIds,
+        chatReadAt: state.chatReadAt,
       }),
     }
   )

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -76,7 +76,12 @@ interface MSChat {
   lastUpdatedDateTime: string;
   lastMessagePreview?: {
     createdDateTime?: string;
+    from?: { user?: { id?: string } | null } | null;
   };
+  /** Per-user read state. lastMessageReadDateTime advances when the user reads
+   *  the chat in official Teams; this app doesn't write it, so unread is also
+   *  gated by a local read timestamp. */
+  viewpoint?: { lastMessageReadDateTime?: string } | null;
   members?: MSChatMember[];
 }
 


### PR DESCRIPTION
Closes #76. Fixes the 'no indication of unread messages' report.

## Root cause
The sidebar badges read `unreadCounts[chat.id]`, but **nothing ever computed unread state from Graph** — only `markRead` (which clears) was wired, so every count was 0 and no badge showed.

## Fix (DMs)
- Select Graph chat **`viewpoint`** + **`lastMessagePreview.from`** (client.ts, MSChat type).
- **isChatUnread()** — unread when the last message is newer than what you've seen AND isn't your own. 'Seen' = later of Graph `viewpoint.lastMessageReadDateTime` and a **local read time**.
- **Local read time** (`chatReadAt`, persisted) set in `markRead` — Graph's viewpoint doesn't advance from this app, so without it a chat would re-flag unread every poll.
- The 15s poll **only adds** unread; `markRead` (open / mark-read) clears it. Coexists with the manual mark-read/unread row menu.

Channels deferred (no cheap per-channel unread in Graph).

## Verification
- `npm run build` exit 0.
- Needs real-account QA (like #25): new DM shows a badge; opening clears it and it stays cleared across polls/reloads; your own last message shows none.