### PR TITLE
feat(disappearing): extend disappearing messages to channels (#32)

### DIFF
--- a/src/app/api/messages/[teamId]/[channelId]/[messageId]/route.ts
+++ b/src/app/api/messages/[teamId]/[channelId]/[messageId]/route.ts
@@ -1,0 +1,23 @@
+import { auth } from "@/lib/auth/config";
+import { softDeleteChannelMessage } from "@/lib/graph/client";
+import { NextResponse } from "next/server";
+
+type Params = Promise<{ teamId: string; channelId: string; messageId: string }>;
+
+// Delete a channel message. Graph has no HTTP DELETE for chat/channel messages
+// — deletion is the softDelete action (POST, empty body). Used by the
+// disappearing-message sweep to remove the sender's own expired messages.
+// Only the author may delete; Graph returns 403 for anyone else.
+export async function DELETE(_req: Request, { params }: { params: Params }) {
+  const session = await auth();
+  if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { teamId, channelId, messageId } = await params;
+  try {
+    await softDeleteChannelMessage(session.accessToken, teamId, channelId, messageId);
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    console.error("Graph softDelete channel message failed", err);
+    return NextResponse.json({ error: "Graph delete failed" }, { status: 502 });
+  }
+}

--- a/src/app/api/messages/[teamId]/[channelId]/route.ts
+++ b/src/app/api/messages/[teamId]/[channelId]/route.ts
@@ -25,8 +25,15 @@ export async function POST(req: Request, { params }: { params: Params }) {
   const session = await auth();
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { teamId, channelId } = await params;
-  const body = (await req.json()) as { content?: string; mentions?: ClientMention[] };
+  const body = (await req.json()) as {
+    content?: string;
+    mentions?: ClientMention[];
+    contentType?: "html" | "text";
+  };
   const { content, mentions } = body;
+  // Disappearing messages send the pre-wrapped blob as "text" so Graph doesn't
+  // HTML-escape it; everything else is "html".
+  const contentType = body.contentType === "text" ? "text" : "html";
   if (!content?.trim()) return NextResponse.json({ error: "Empty message" }, { status: 400 });
 
   // Translate client mentions into Graph's `mentions[]` shape and wrap each
@@ -51,7 +58,8 @@ export async function POST(req: Request, { params }: { params: Params }) {
       teamId,
       channelId,
       finalContent,
-      graphMentions
+      graphMentions,
+      contentType
     );
     return NextResponse.json(msg);
   } catch {
@@ -59,7 +67,7 @@ export async function POST(req: Request, { params }: { params: Params }) {
     // so we still ship the `<at>` markup even if Graph rejects the shape.
     if (graphMentions) {
       try {
-        const msg = await sendMessage(session.accessToken, teamId, channelId, finalContent);
+        const msg = await sendMessage(session.accessToken, teamId, channelId, finalContent, undefined, contentType);
         return NextResponse.json(msg);
       } catch {
         return NextResponse.json({ error: "Graph send failed" }, { status: 502 });

--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -18,6 +18,7 @@ import { openTeamsChannelMeeting } from "@/lib/utils/teams-deeplink";
 import { markdownToHtml } from "@/lib/utils/markdown-to-html";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
 import { useRealtimeEvents } from "@/hooks/useRealtimeEvents";
+import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 
 export function ChannelView({ teamId, channelId }: { teamId: string; channelId: string }) {
   const {
@@ -31,6 +32,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     replaceMessage,
     markMessageFailed,
     removeMessage,
+    expireMessage,
     setContextLoading,
     toggleReaction,
   } = useWorkspaceStore();
@@ -75,6 +77,34 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
   // dependency of the SSE event callback (which would re-register on every render).
   const loadRef = useRef<() => Promise<void>>(async () => {});
 
+  // Sweep expired disappearing messages we sent — only the author can
+  // softDelete a channel message (Graph 403s otherwise). Receivers just hide
+  // them locally via the per-message timer (onExpire below). Defined before the
+  // load effect that calls it.
+  const sweepExpired = useCallback(async (msgs: MSMessage[]) => {
+    const now = Date.now();
+    for (const m of msgs) {
+      if (m.__pending || m.__failed) continue;
+      if (m.from?.user?.id !== currentUserId) continue;
+      if (!isDisappearing(m.body.content)) continue;
+      const payload = await unwrapMessage(contextId, m.body.content);
+      if (payload) {
+        if (payload.disappearAt > now) continue;
+      } else if (now - new Date(m.createdDateTime).getTime() < UNDECODABLE_BLOB_GRACE_MS) {
+        continue;
+      }
+      try {
+        const res = await fetch(
+          `/api/messages/${teamId}/${channelId}/${encodeURIComponent(m.id)}`,
+          { method: "DELETE" }
+        );
+        if (res.ok) removeMessage(contextId, m.id);
+      } catch {
+        /* best-effort; retried on next sweep */
+      }
+    }
+  }, [teamId, channelId, contextId, currentUserId, removeMessage]);
+
   useEffect(() => {
     let cancelled = false;
     const cached = getMessages(contextId);
@@ -87,7 +117,11 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
         const response = await fetch(`/api/messages/${teamId}/${channelId}`);
         if (!response.ok) throw new Error("Failed to load messages");
         const data = (await response.json()) as MSMessage[];
-        if (!cancelled) setMessages(contextId, sortByCreated(data));
+        if (!cancelled) {
+          const sorted = sortByCreated(data);
+          setMessages(contextId, sorted);
+          void sweepExpired(sorted);
+        }
       } catch {
         if (isFirstLoad && !cancelled) showToast({ title: "Could not load messages", tone: "error" });
       } finally {
@@ -100,6 +134,10 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
 
     // Webhook push is primary; poll kept at 30s as safety net for missed events.
     const interval = setInterval(load, 30_000);
+
+    // Disappearing-message sweep on a fast cadence (network-free unless one of
+    // our own messages has actually expired) — matches the DM view's behavior.
+    const sweep = setInterval(() => void sweepExpired(getMessages(contextId)), 4000);
 
     // Fire-and-forget: create a Graph change notification subscription so the
     // webhook endpoint can push new messages via SSE instead of waiting for poll.
@@ -121,11 +159,12 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     return () => {
       cancelled = true;
       clearInterval(interval);
+      clearInterval(sweep);
       clearInterval(resubscribe);
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamId, channelId, contextId, isHydrated, setContextLoading, setMessages, showToast]);
+  }, [teamId, channelId, contextId, isHydrated, setContextLoading, setMessages, showToast, sweepExpired]);
 
   useRealtimeEvents(
     useCallback(
@@ -144,14 +183,22 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
 
   async function handleSend(
     content: string,
-    options?: { mentions?: { id: string; name: string }[] }
+    options?: { mentions?: { id: string; name: string }[]; disappearMs?: number }
   ) {
     const tempId = `temp-${crypto.randomUUID()}`;
     const now = new Date().toISOString();
+    // Disappearing messages: wrap the body into the opaque blob and send it as
+    // "text" so Graph stores it verbatim (same as DMs). The contextId key must
+    // match what MessageItem decodes with (bookmarkContextId = contextId).
+    const outgoing = options?.disappearMs
+      ? await wrapMessage(contextId, content, Date.now() + options.disappearMs)
+      : content;
     const optimistic: MSMessage = {
       id: tempId,
       createdDateTime: now,
-      body: { contentType: "html", content: textToHtml(content) },
+      body: options?.disappearMs
+        ? { contentType: "text", content: outgoing }
+        : { contentType: "html", content: textToHtml(content) },
       from: { user: { id: currentUserId, displayName: currentUserName } },
       reactions: [],
       attachments: [],
@@ -165,10 +212,11 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          content,
+          content: outgoing,
           // Server route turns this into Graph's `mentions[]` array and
           // wraps each `@Name` in the body with `<at id="i">…</at>` markup.
           ...(options?.mentions?.length ? { mentions: options.mentions } : {}),
+          ...(options?.disappearMs ? { contentType: "text" } : {}),
         }),
       });
       if (!res.ok) throw new Error("Failed to send message");
@@ -179,6 +227,19 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
       showToast({ title: "Could not send message", tone: "error" });
     }
   }
+
+  // Called by MessageItem when a disappearing message's countdown hits zero:
+  // hide it locally now, and softDelete server-side for our own messages.
+  const handleMessageExpire = useCallback((messageId: string) => {
+    const msg = getMessages(contextId).find((m) => m.id === messageId);
+    const isOwn = msg?.from?.user?.id === currentUserId;
+    expireMessage(contextId, messageId);
+    if (isOwn) {
+      void fetch(`/api/messages/${teamId}/${channelId}/${encodeURIComponent(messageId)}`, {
+        method: "DELETE",
+      });
+    }
+  }, [teamId, channelId, contextId, currentUserId, getMessages, expireMessage]);
 
   function handleAttachAndSend(content: string, file: File): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -399,6 +460,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
             onToggleReaction={handleToggleReaction}
             onRetry={handleRetry}
             onDiscard={handleDiscard}
+            onExpire={handleMessageExpire}
           />
           <MessageInput
             placeholder={`Message #${channel?.displayName ?? "channel"}`}
@@ -407,6 +469,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
             uploading={uploading}
             contextId={contextId}
             allowEveryone
+            allowDisappearing
             currentUserId={currentUserId}
             currentUserName={currentUserName}
           />

--- a/src/lib/graph/client.ts
+++ b/src/lib/graph/client.ts
@@ -55,16 +55,33 @@ export async function sendMessage(
    * markup; otherwise Graph errors with `Mention id X must be referenced in
    * the message body`.
    */
-  mentions?: unknown[]
+  mentions?: unknown[],
+  /** Graph body contentType. Use "text" for disappearing messages so the
+   *  encrypted blob isn't HTML-wrapped/escaped (mirrors sendChatMessage). */
+  contentType: "html" | "text" = "html"
 ) {
   const client = getGraphClient(accessToken);
   const payload: Record<string, unknown> = {
-    body: { content, contentType: "html" },
+    body: { content, contentType },
   };
   if (mentions?.length) {
     payload.mentions = mentions;
   }
   return client.api(`/teams/${teamId}/channels/${channelId}/messages`).post(payload);
+}
+
+/** Soft-delete a channel message (Graph has no HTTP DELETE — only the
+ *  softDelete action). Only the author may delete; others get 403. */
+export async function softDeleteChannelMessage(
+  accessToken: string,
+  teamId: string,
+  channelId: string,
+  messageId: string
+) {
+  const client = getGraphClient(accessToken);
+  return client
+    .api(`/teams/${teamId}/channels/${channelId}/messages/${messageId}/softDelete`)
+    .post({});
 }
 
 export async function sendChannelReply(


### PR DESCRIPTION
Closes #32. Disappearing messages were DM-only; this brings them to channels by mirroring the DM implementation with channel-scoped Graph endpoints.

## Changes
- **graph client**: `sendMessage` gains a `contentType` param so the wrapped blob is sent as `"text"` (verbatim, not HTML-escaped) — same as `sendChatMessage`. New `softDeleteChannelMessage()` (Graph has no HTTP DELETE — only the `softDelete` action; channels use `/teams/{teamId}/channels/{channelId}/messages/{id}/softDelete`).
- **channel POST route**: accepts `contentType`. **New channel `[messageId]` route**: `DELETE` → channel `softDelete`.
- **ChannelView**:
  - `handleSend` wraps the body when `disappearMs` is set, keyed by the same `teamId:channelId` contextId that `MessageItem` decodes with.
  - A 4s sweep that softDeletes our own expired messages; an `onExpire` handler that hides locally + softDeletes for own messages — mirroring the DM view.
  - Enables the composer ⏱ picker in channels (`allowDisappearing`).

`MessageItem` already decodes/counts down generically by `contextId`, so no render changes were needed.

## Verification
- `npm run build` — exit 0.
- ⚠️ Real-account QA (like #25): send a disappearing message in a channel → it shows a countdown + vanishes locally on expiry, and (as author) is softDeleted from the channel in native Teams. Receivers on Teamsly see it hide; native-Teams users see the opaque blob (by design).

## #33 (attachments / edit / per-conversation default) — separate
Not in this PR. The attachment piece (deleting the SharePoint/OneDrive file too, not just the message) is materially more complex; "per-conversation default" is the tractable sub-part. Worth its own scoped PR.