### PR TITLE
feat(disappearing): per-conversation default duration (#33)

### DIFF
--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -29,6 +29,7 @@ import { GifPicker } from "./GifPicker";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
 import { parseSlashCommand, type SlashCommand } from "@/lib/slash-commands";
 import { useCatchUpStore } from "@/store/catchUp";
+import { usePreferencesStore } from "@/store/preferences";
 import { DISAPPEAR_DURATIONS } from "@/lib/utils/disappear";
 
 // emoji-mart ships a heavy data bundle — load lazily to keep the initial JS small
@@ -282,7 +283,14 @@ export function MessageInput({
   const [sending, setSending] = useState(false);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [emojiOpen, setEmojiOpen] = useState(false);
-  const [disappearMs, setDisappearMs] = useState<number | null>(null);
+  // Disappearing timer, pre-armed from this conversation's saved default (if any).
+  const setDisappearDefault = usePreferencesStore((s) => s.setDisappearDefault);
+  const convoDisappearDefault = usePreferencesStore((s) =>
+    contextId ? (s.disappearDefaults[contextId] ?? null) : null,
+  );
+  const [disappearMs, setDisappearMs] = useState<number | null>(() =>
+    contextId ? (usePreferencesStore.getState().disappearDefaults[contextId] ?? null) : null,
+  );
   const [showDisappearMenu, setShowDisappearMenu] = useState(false);
   const [scheduleTime, setScheduleTime] = useState<number | null>(null);
   const [showScheduleMenu, setShowScheduleMenu] = useState(false);
@@ -312,10 +320,13 @@ export function MessageInput({
     setShowScheduleMenu(false);
     if (!contextId) {
       setValue("");
+      setDisappearMs(null);
       return;
     }
     const existing = useDraftsStore.getState().drafts[contextId] ?? "";
     setValue(existing);
+    // Arm the disappearing timer from this conversation's saved default.
+    setDisappearMs(usePreferencesStore.getState().disappearDefaults[contextId] ?? null);
     // We intentionally reset on every contextId change so switching chats
     // doesn't leak the previous chat's typing into the new one.
   }, [contextId]);
@@ -1328,6 +1339,32 @@ export function MessageInput({
                         {d.label}
                       </button>
                     ))}
+                    {contextId && (
+                      <>
+                        <div className="my-1 h-px bg-[var(--border)]" />
+                        <button
+                          type="button"
+                          role="checkbox"
+                          aria-checked={convoDisappearDefault != null}
+                          onClick={() => {
+                            if (convoDisappearDefault != null) {
+                              setDisappearDefault(contextId, null);
+                            } else {
+                              // Save the current pick (default to 1h if none selected).
+                              const ms = disappearMs ?? 60 * 60_000;
+                              setDisappearMs(ms);
+                              setDisappearDefault(contextId, ms);
+                            }
+                          }}
+                          className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
+                        >
+                          <span className={`flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center rounded-[3px] border ${convoDisappearDefault != null ? "border-[var(--accent)] bg-[var(--accent)] text-white" : "border-[var(--border-input)]"}`}>
+                            {convoDisappearDefault != null ? "✓" : ""}
+                          </span>
+                          Default for this conversation
+                        </button>
+                      </>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -88,6 +88,10 @@ export interface Preferences {
   /** Epoch ms; the office-hours banner stays hidden while now < this. Set on
    *  dismiss to the next boundary so it won't re-nag during the same off-period. */
   officeHoursDismissedUntil: number | null;
+  /** Per-conversation disappearing-message default. contextId (chatId or
+   *  `teamId:channelId`) → duration ms. When set, the composer opens with the
+   *  ⏱ timer pre-armed at that duration for that conversation. */
+  disappearDefaults: Record<string, number>;
   colorMode: ColorMode;
   /** Background + neutrals choice. Orthogonal to accent. Some palettes
    *  force a specific color mode (see PALETTES.lockedMode). */
@@ -144,6 +148,7 @@ interface PreferencesState extends Preferences {
   setOfficeHoursEnd: (v: string) => void;
   setOfficeHoursDays: (days: number[]) => void;
   setOfficeHoursDismissedUntil: (ts: number | null) => void;
+  setDisappearDefault: (contextId: string, ms: number | null) => void;
   setColorMode: (m: ColorMode) => void;
   setPalette: (p: Palette) => void;
   setAccent: (a: AccentTheme) => void;
@@ -187,6 +192,7 @@ const DEFAULTS: Preferences = {
   officeHoursEnd: "17:00",
   officeHoursDays: [1, 2, 3, 4, 5],
   officeHoursDismissedUntil: null,
+  disappearDefaults: {},
   colorMode: "dark",
   palette: "slate",
   accent: "slate",
@@ -232,6 +238,13 @@ export const usePreferencesStore = create<PreferencesState>()(
       setOfficeHoursDays: (officeHoursDays) =>
         set({ officeHoursDays: [...officeHoursDays].sort((a, b) => a - b) }),
       setOfficeHoursDismissedUntil: (officeHoursDismissedUntil) => set({ officeHoursDismissedUntil }),
+      setDisappearDefault: (contextId, ms) =>
+        set((s) => {
+          const next = { ...s.disappearDefaults };
+          if (ms == null) delete next[contextId];
+          else next[contextId] = ms;
+          return { disappearDefaults: next };
+        }),
       setColorMode: (colorMode) => set({ colorMode }),
       setPalette: (palette) => set({ palette }),
       setAccent: (accent) => set({ accent }),
@@ -286,7 +299,9 @@ export const usePreferencesStore = create<PreferencesState>()(
       // the wider union.
       // v4 (2026-06-03): adds officeHours* (enabled/start/end/days/dismissedUntil).
       // Default-merge grafts them from DEFAULTS; no explicit migrate needed.
-      version: 4,
+      // v5 (2026-06-04): adds disappearDefaults (per-conversation disappearing
+      // default). Same default-merge graft; no migrate needed.
+      version: 5,
       storage: createJSONStorage(() => (typeof window !== "undefined" ? localStorage : undefined as unknown as Storage)),
     },
   ),


### PR DESCRIPTION
Addresses the **per-conversation default** part of #33. (Disappearing-attachments dropped by decision; edit-interaction left as a minor follow-up.)

## What
A conversation can default to disappearing messages at a chosen duration — the composer opens with the ⏱ timer pre-armed.

- **prefs**: `disappearDefaults` map (contextId → ms) + `setDisappearDefault`; persist v4 → v5 (default-merge, no migrate).
- **MessageInput**: `disappearMs` lazy-inits from the conversation's saved default and re-applies on context change; the ⏱ menu gains a **"Default for this conversation"** checkbox that saves the current duration (or 1h if none selected) as the default, or clears it.

Works in DMs now, and channels once #78 lands (both pass `allowDisappearing`). Independent of #78 (different files) — merges cleanly alongside it.

## Verification
- `npm run build` — exit 0.
- Manual: pick a duration → check 'Default for this conversation' → reopen the chat → composer opens with ⏱ armed at that duration; uncheck clears it.