### PR TITLE
fix(ui): modals drift to top-left (double-translate)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -389,14 +389,20 @@ body {
   to   { opacity: 1; }
 }
 
+/* Entrance animates the standalone `scale` + `opacity` properties only —
+   NOT `transform`. The modals center with Tailwind's `-translate-x/y-1/2`,
+   which in Tailwind v4 compile to the `translate:` property; animating
+   `transform: translate(-50%,-50%)` here as well stacked a second translation
+   on top, shoving every modal to the top-left. `scale` is its own property and
+   composes cleanly with `translate`, so centering is preserved. */
 @keyframes search-modal-content-in {
   from {
     opacity: 0;
-    transform: translate(-50%, calc(-50% + 6px)) scale(0.97);
+    scale: 0.97;
   }
   to {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
+    scale: 1;
   }
 }
 


### PR DESCRIPTION
## Bug
The Preferences modal (and all modals using `search-modal-content`: Search, Jump-to, Feedback, Status, Settings) rendered in the **top-left corner** instead of centered, sliding into that wrong spot on open.

## Root cause
The modals center with Tailwind `-translate-x-1/2 -translate-y-1/2`. In **Tailwind v4** those compile to the standalone **`translate:`** property (`translate: -50% -50%`) — confirmed in the compiled CSS. But the `search-modal-content-in` entrance keyframe *also* set `transform: translate(-50%,-50%) scale(...)`. The `translate` property and the `transform` translate **stack**, so the centering offset was applied twice → the modal landed ~a full width/height up-and-left of center. Larger modals shift more, which is why Preferences looked the most broken; the entrance animation interpolating `transform` is the visible 'moving'.

## Fix
Animate the standalone **`scale`** + `opacity` properties in the keyframe instead of `transform`. `scale` composes cleanly with the `translate` property, so centering is preserved and the entrance still scales/fades in. One keyframe change fixes **all six modals**.

## Verification
- `npm run build` — exit 0; confirmed the compiled keyframe no longer contains `transform: translate`.
- Open Preferences / Search (⌘/) / Jump-to (⌘K) → each is centered, scales in from center, no drift.