### PR TITLE
Desktop local-first shell (Phase 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build Next standalone
+        run: npm run build
+
+      - name: Prepare standalone (copy static + public)
+        run: node scripts/prepare-standalone.mjs
+
       - name: Compile Electron main
         run: npm run electron:compile
 

--- a/docs/superpowers/plans/2026-06-10-desktop-local-first-shell.md
+++ b/docs/superpowers/plans/2026-06-10-desktop-local-first-shell.md
@@ -1,0 +1,768 @@
+# Desktop local-first shell (Phase 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the packaged desktop app load from a bundled Next standalone server on `127.0.0.1` (instant local shell) instead of the remote site, authenticating as a public client via loopback PKCE (no secret shipped), with AI/voice enabled by user-supplied BYO keys.
+
+**Architecture:** A `DESKTOP_MODE` env branch turns NextAuth into a public PKCE client. In packaged builds, Electron's main process spawns the bundled `.next/standalone/server.js` under its own Node on an ephemeral loopback port, injecting a per-install `AUTH_SECRET` + encrypted BYO keys as env, then loads that URL. The hosted/Vercel path is untouched.
+
+**Tech Stack:** Electron (main/preload, `safeStorage`, `child_process.fork`, `net`), Next.js standalone output, NextAuth v5 (Microsoft Entra, public client + PKCE), electron-builder.
+
+---
+
+## CRITICAL: this is risk-gated. Task 1 is a GATE.
+
+Task 1 proves NextAuth + Entra **public-client PKCE loopback** works against app `377aa8a2`. **Do not start Tasks 2+ until Task 1 passes.** If it cannot be made to work, STOP and report — the fallback is a device-code grant (as `mcp-server/index.ts` uses), which changes Tasks involving auth and needs a spec amendment.
+
+**Owner prerequisite (do first, manual):** In Azure portal → app `377aa8a2-24d1-4d6e-8eca-e347864c9880` → Authentication → Add platform → "Mobile and desktop applications" → add redirect URI `http://localhost`. ("Allow public client flows" is already enabled.) Without this, Task 1 cannot pass.
+
+## Testing note
+
+No test runner in this repo; the gate is the build + manual verification. Per task: `npx tsc --noEmit 2>&1 | grep -v "src/lib/auth/config.ts"` (expect empty) and `npm run electron:compile` (electron TS). Milestones run `npm run build`. The OAuth loopback and packaged-spawn paths are **only fully verifiable on a real packaged build / dev run on your machine** — each such step says so explicitly.
+
+**Commits:** Conventional Commit prefixes, **no AI/agent co-author trailer** (per `CLAUDE.md`). Branch `feat/desktop-local-first` (already created; the spec is committed there). Subagents: do NOT run `git checkout/switch/reset/branch`; confirm `git branch --show-current` is `feat/desktop-local-first` before each commit.
+
+---
+
+## File structure
+
+New:
+- `electron/server.ts` — spawn + manage the bundled Next standalone server (free port, fork, health-check, stop).
+- `electron/secrets.ts` — per-install `AUTH_SECRET` + encrypted BYO-key storage via `safeStorage`.
+- `scripts/prepare-standalone.mjs` — copy `.next/static` + `public` into `.next/standalone` after build (Next standalone gotcha).
+- `src/components/desktop/DesktopAiKeys.tsx` — desktop-only BYO-key settings panel.
+
+Modified:
+- `src/lib/auth/config.ts` — `DESKTOP_MODE` public-PKCE branch + secret-less refresh.
+- `next.config.ts` — `output: "standalone"`.
+- `electron/main.ts` — start local server in packaged mode; dynamic app URL; kill on quit; BYO IPC.
+- `electron/preload.ts` — expose `isDesktop` + `getByoKeys`/`setByoKeys`.
+- `electron-builder.json` — bundle standalone output via `extraResources`.
+- `.github/workflows/release.yml` — `next build` + `prepare-standalone` before `electron-builder`.
+- `electron/README.md` — document local-first + the Azure loopback redirect.
+- the settings/preferences modal — mount `DesktopAiKeys` when running in Electron.
+
+---
+
+## Task 1 (GATE): Auth spike — NextAuth public-client PKCE loopback
+
+**Files:**
+- Modify: `src/lib/auth/config.ts`
+
+- [ ] **Step 1: Add the `DESKTOP_MODE` branch to the provider + refresh**
+
+In `src/lib/auth/config.ts`, add near the top (after imports):
+
+```ts
+const DESKTOP = process.env.DESKTOP_MODE === "1";
+```
+
+Change the `refreshAccessToken` body's `params` so the secret is omitted in desktop mode:
+
+```ts
+  const params = new URLSearchParams({
+    client_id: process.env.AZURE_AD_CLIENT_ID!,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    scope: SCOPE,
+  });
+  if (!DESKTOP) {
+    params.set("client_secret", process.env.AZURE_AD_CLIENT_SECRET!);
+  }
+```
+
+Change the `MicrosoftEntraID({...})` provider config to:
+
+```ts
+    MicrosoftEntraID({
+      clientId: process.env.AZURE_AD_CLIENT_ID!,
+      ...(DESKTOP ? {} : { clientSecret: process.env.AZURE_AD_CLIENT_SECRET! }),
+      issuer: `https://login.microsoftonline.com/${process.env.AZURE_AD_TENANT_ID ?? "common"}/v2.0`,
+      authorization: { params: { scope: SCOPE } },
+      // Desktop is a public client: no secret, prove possession with PKCE.
+      ...(DESKTOP
+        ? { client: { token_endpoint_auth_method: "none" as const }, checks: ["pkce", "state"] as ("pkce" | "state")[] }
+        : {}),
+    }),
+```
+
+- [ ] **Step 2: Type/compile check**
+
+Run: `npx tsc --noEmit 2>&1 | grep -v "src/lib/auth/config.ts"`
+Expected: no output. (If the `client`/`checks` overrides don't type against the installed next-auth, adjust to the version's accepted shape — e.g. cast the provider options — and note what you changed. Do NOT proceed past the gate on a type error.)
+
+- [ ] **Step 3: MANUAL spike (your machine) — prove the flow**
+
+Ensure the Azure loopback redirect URI is added (owner prerequisite above). Then run the dev server in desktop mode:
+
+```bash
+DESKTOP_MODE=1 NEXTAUTH_URL=http://localhost:3000 npm run dev
+```
+
+Open `http://localhost:3000`, sign in with Microsoft. Expected: the OAuth round-trip completes and a session is established **without** a client secret (PKCE). Confirm by loading the workspace and seeing real Teams/chats (a Graph call succeeded with the delegated token). If you see `AADSTS` errors about client assertion/secret, the public-client config or the Azure redirect/platform is off.
+
+- [ ] **Step 4: GATE decision**
+
+- **Pass** (sign-in works, Graph loads) → commit and continue to Task 2.
+- **Fail** → STOP. Report the exact `AADSTS`/NextAuth error. Do not build the rest; we pivot to device-code (spec amendment).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/auth/config.ts
+git commit -m "feat(auth): desktop-mode public-client PKCE branch (no secret)"
+```
+
+---
+
+## Task 2: Next standalone output + post-build copy script
+
+**Files:**
+- Modify: `next.config.ts`
+- Create: `scripts/prepare-standalone.mjs`
+
+- [ ] **Step 1: Enable standalone output**
+
+In `next.config.ts`, add `output: "standalone"` to the config object (keep everything else):
+
+```ts
+const nextConfig: NextConfig = {
+  output: "standalone",
+  outputFileTracingRoot: process.cwd(),
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "**.microsoft.com" },
+      { protocol: "https", hostname: "**.microsoftonline.com" },
+    ],
+  },
+};
+```
+
+- [ ] **Step 2: Create the copy script**
+
+Next's standalone output omits `.next/static` and `public`; they must be copied next to `server.js`. Create `scripts/prepare-standalone.mjs`:
+
+```js
+import { cp, access } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = process.cwd();
+const standalone = join(root, ".next", "standalone");
+
+async function exists(p) {
+  try { await access(p); return true; } catch { return false; }
+}
+
+if (!(await exists(join(standalone, "server.js")))) {
+  console.error("[prepare-standalone] .next/standalone/server.js missing — run `next build` with output:'standalone' first.");
+  process.exit(1);
+}
+
+await cp(join(root, ".next", "static"), join(standalone, ".next", "static"), { recursive: true });
+if (await exists(join(root, "public"))) {
+  await cp(join(root, "public"), join(standalone, "public"), { recursive: true });
+}
+console.log("[prepare-standalone] copied static + public into .next/standalone");
+```
+
+- [ ] **Step 3: Build + verify standalone (milestone)**
+
+Run: `npm run build && node scripts/prepare-standalone.mjs`
+Expected: build exits 0; the script prints "copied static + public" and `.next/standalone/server.js`, `.next/standalone/.next/static`, `.next/standalone/public` exist.
+Also run `npx tsc --noEmit 2>&1 | grep -v "src/lib/auth/config.ts"` → empty.
+
+- [ ] **Step 4: Verify Vercel-path safety**
+
+`output: "standalone"` must not break the web build. The `npm run build` above is the same build Vercel runs; if it's green, the hosted build is fine. (If a future Vercel deploy ever objects, gate via `output: process.env.BUILD_STANDALONE ? "standalone" : undefined` — not needed unless it errors.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add next.config.ts scripts/prepare-standalone.mjs
+git commit -m "build(desktop): emit Next standalone + copy static/public"
+```
+
+---
+
+## Task 3: `electron/secrets.ts` — per-install AUTH_SECRET + BYO keys
+
+**Files:**
+- Create: `electron/secrets.ts`
+
+- [ ] **Step 1: Create the module**
+
+```ts
+import { app, safeStorage } from 'electron';
+import { randomBytes } from 'crypto';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import path from 'path';
+
+const userData = (): string => app.getPath('userData');
+const authSecretPath = (): string => path.join(userData(), 'auth-secret.bin');
+const byoPath = (): string => path.join(userData(), 'byo-keys.bin');
+
+// The env var names the bundled Next server reads. Keep in sync with the
+// settings UI and the spawn env in electron/server.ts.
+export const BYO_KEYS = [
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'LIVEKIT_API_KEY',
+  'LIVEKIT_API_SECRET',
+  'NEXT_PUBLIC_LIVEKIT_URL',
+] as const;
+export type ByoKey = (typeof BYO_KEYS)[number];
+
+function encryptToFile(file: string, plain: string): void {
+  const data = safeStorage.isEncryptionAvailable()
+    ? safeStorage.encryptString(plain)
+    : Buffer.from('PLAIN:' + plain, 'utf8'); // rare fallback (e.g. Linux w/o keyring)
+  writeFileSync(file, data);
+}
+
+function decryptFromFile(file: string): string | null {
+  if (!existsSync(file)) return null;
+  const buf = readFileSync(file);
+  if (buf.subarray(0, 6).toString('utf8') === 'PLAIN:') return buf.subarray(6).toString('utf8');
+  try {
+    return safeStorage.decryptString(buf);
+  } catch {
+    return null;
+  }
+}
+
+/** Read-or-generate a per-install NextAuth secret. Never shipped in the binary. */
+export function ensureAuthSecret(): string {
+  const existing = decryptFromFile(authSecretPath());
+  if (existing) return existing;
+  const secret = randomBytes(32).toString('base64');
+  encryptToFile(authSecretPath(), secret);
+  return secret;
+}
+
+/** All saved BYO keys (decrypted) as an env map. Empty when none set. */
+export function loadByoKeys(): Record<string, string> {
+  const raw = decryptFromFile(byoPath());
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, string>;
+    const out: Record<string, string> = {};
+    for (const k of BYO_KEYS) {
+      const v = parsed[k];
+      if (typeof v === 'string' && v.length > 0) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Merge + persist BYO keys. Empty-string values delete that key. */
+export function saveByoKeys(partial: Record<string, string>): void {
+  const current = loadByoKeys();
+  for (const k of BYO_KEYS) {
+    if (k in partial) {
+      const v = partial[k];
+      if (v) current[k] = v;
+      else delete current[k];
+    }
+  }
+  encryptToFile(byoPath(), JSON.stringify(current));
+}
+
+/** Which BYO keys are set (names only — never return values to the renderer). */
+export function byoKeyStatus(): Record<string, boolean> {
+  const set = loadByoKeys();
+  return Object.fromEntries(BYO_KEYS.map((k) => [k, Boolean(set[k])]));
+}
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `npm run electron:compile`
+Expected: exit 0 (compiles `electron/**/*.ts` → `electron/dist`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add electron/secrets.ts
+git commit -m "feat(desktop): per-install auth secret + encrypted BYO key store"
+```
+
+---
+
+## Task 4: `electron/server.ts` — spawn the bundled Next server
+
+**Files:**
+- Create: `electron/server.ts`
+
+- [ ] **Step 1: Create the module**
+
+```ts
+import { app } from 'electron';
+import { fork, type ChildProcess } from 'child_process';
+import { createServer } from 'net';
+import http from 'http';
+import path from 'path';
+
+export interface LocalServer {
+  baseUrl: string;
+  port: number;
+  stop: () => void;
+}
+
+// In a packaged app, extraResources land under process.resourcesPath. The
+// standalone server entry is server.js at the root of the copied standalone dir.
+function standaloneEntry(): string {
+  return path.join(process.resourcesPath, 'standalone', 'server.js');
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function healthCheck(baseUrl: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      const req = http.get(baseUrl, (res) => {
+        res.resume();
+        resolve();
+      });
+      req.on('error', () => {
+        if (Date.now() > deadline) reject(new Error('local server health-check timed out'));
+        else setTimeout(tick, 150);
+      });
+    };
+    tick();
+  });
+}
+
+/**
+ * Spawn the bundled Next standalone server on a free loopback port using
+ * Electron's own Node (ELECTRON_RUN_AS_NODE), then wait until it responds.
+ * `env` carries NEXTAUTH/AUTH_SECRET/Azure/BYO values.
+ */
+export async function startLocalServer(env: Record<string, string>): Promise<LocalServer> {
+  const port = await freePort();
+  const baseUrl = `http://localhost:${port}`;
+  const entry = standaloneEntry();
+
+  const child: ChildProcess = fork(entry, [], {
+    cwd: path.dirname(entry),
+    env: {
+      ...process.env,
+      ...env,
+      ELECTRON_RUN_AS_NODE: '1',
+      PORT: String(port),
+      HOSTNAME: '127.0.0.1',
+      NEXTAUTH_URL: baseUrl,
+      NODE_ENV: 'production',
+    },
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  });
+
+  child.on('exit', (code) => {
+    if (code && code !== 0) console.error(`[local-server] exited with code ${code}`);
+  });
+
+  await healthCheck(baseUrl, 20_000);
+
+  const stop = () => {
+    try { child.kill(); } catch { /* already gone */ }
+  };
+  app.on('before-quit', stop);
+  return { baseUrl, port, stop };
+}
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `npm run electron:compile`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add electron/server.ts
+git commit -m "feat(desktop): spawn bundled Next standalone on loopback"
+```
+
+---
+
+## Task 5: Wire `electron/main.ts` — start server in packaged mode + BYO IPC
+
+**Files:**
+- Modify: `electron/main.ts`
+
+Read the file first. Make these edits:
+
+- [ ] **Step 1: Imports**
+
+Add after the existing imports (line 3):
+
+```ts
+import { startLocalServer, type LocalServer } from './server';
+import { ensureAuthSecret, loadByoKeys, saveByoKeys, byoKeyStatus } from './secrets';
+```
+
+- [ ] **Step 2: Make the app URL dynamic**
+
+Replace the module-level `const TEAMSLY_URL = ...` (lines 10–11) with:
+
+```ts
+// Resolved at startup: dev → Next dev server; packaged → the local bundled
+// server we spawn (set in whenReady). An explicit TEAMSLY_URL still overrides
+// (e.g. to point a build at a hosted instance).
+let appUrl = process.env.TEAMSLY_URL || 'http://localhost:3000';
+let localServer: LocalServer | null = null;
+```
+
+In `createWindow()`, replace `void mainWindow.loadURL(TEAMSLY_URL);` (line 312) with `void mainWindow.loadURL(appUrl);`, and in the `did-fail-load` handler replace `offlineFallbackUrl(TEAMSLY_URL)` (line 308) with `offlineFallbackUrl(appUrl)`.
+
+- [ ] **Step 3: Start the local server before creating the window**
+
+Replace the `app.whenReady().then(() => { ... })` block (lines 404–416) with:
+
+```ts
+void app.whenReady().then(async () => {
+  buildAppMenu();
+  tray = buildTrayIcon();
+
+  // Packaged builds load from a locally-spawned Next server (local-first).
+  // Dev and explicit-TEAMSLY_URL builds keep their remote/dev URL.
+  if (!isDev && !process.env.TEAMSLY_URL) {
+    try {
+      localServer = await startLocalServer({
+        AUTH_SECRET: ensureAuthSecret(),
+        DESKTOP_MODE: '1',
+        AZURE_AD_CLIENT_ID: process.env.AZURE_AD_CLIENT_ID ?? '377aa8a2-24d1-4d6e-8eca-e347864c9880',
+        AZURE_AD_TENANT_ID: process.env.AZURE_AD_TENANT_ID ?? 'common',
+        ...loadByoKeys(),
+      });
+      appUrl = localServer.baseUrl;
+    } catch (err) {
+      console.error('[main] local server failed to start:', (err as Error).message);
+      // appUrl stays at its default; did-fail-load shows the offline page.
+    }
+  }
+
+  createWindow();
+  setupAutoUpdater();
+
+  if (!isDev) {
+    void autoUpdater.checkForUpdates().catch((err: Error) => {
+      console.error('[auto-updater] startup check failed:', err.message);
+    });
+  }
+});
+```
+
+- [ ] **Step 4: BYO IPC handlers**
+
+Add to the IPC section (after the existing `ipcMain.on(...)` handlers, ~line 400):
+
+```ts
+// BYO keys: the renderer only ever sees which keys are SET (booleans), never
+// the values. Saved keys take effect on the next app launch (server respawn).
+ipcMain.handle('byo:status', () => byoKeyStatus());
+ipcMain.handle('byo:set', (_event, partial: Record<string, string>) => {
+  saveByoKeys(partial ?? {});
+  return byoKeyStatus();
+});
+```
+
+- [ ] **Step 5: Kill the server on quit**
+
+The `startLocalServer` call already registers its `stop` on `before-quit`. Leave the existing `before-quit` handler (sets `isQuitting`) as-is.
+
+- [ ] **Step 6: Compile check**
+
+Run: `npm run electron:compile`
+Expected: exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(desktop): boot local server in packaged mode; BYO key IPC"
+```
+
+---
+
+## Task 6: Expose desktop bridge in `electron/preload.ts`
+
+**Files:**
+- Modify: `electron/preload.ts`
+
+- [ ] **Step 1: Add the BYO + desktop API to the exposed object**
+
+In the `contextBridge.exposeInMainWorld('electron', { ... })` object, add these members (alongside the existing ones, before the closing `})`):
+
+```ts
+  /** True when running in the packaged/desktop app (always true here). */
+  isDesktop: (): true => true,
+  /** Which BYO keys are currently set (names→boolean; never the values). */
+  getByoStatus: (): Promise<Record<string, boolean>> => ipcRenderer.invoke('byo:status'),
+  /** Save BYO keys (empty string deletes one). Returns the new status map. */
+  setByoKeys: (partial: Record<string, string>): Promise<Record<string, boolean>> =>
+    ipcRenderer.invoke('byo:set', partial),
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `npm run electron:compile`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add electron/preload.ts
+git commit -m "feat(desktop): expose isDesktop + BYO key bridge in preload"
+```
+
+---
+
+## Task 7: BYO-key settings panel (renderer)
+
+**Files:**
+- Create: `src/components/desktop/DesktopAiKeys.tsx`
+- Modify: the settings/preferences modal to mount it when in Electron.
+
+- [ ] **Step 1: Create the panel**
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Mirrors electron/secrets.ts BYO_KEYS. Each field is write-only from the UI;
+// we only learn whether a key is set, never its value.
+const FIELDS: { key: string; label: string; placeholder: string }[] = [
+  { key: "OPENAI_API_KEY", label: "OpenAI / Azure key", placeholder: "sk-… or Azure key" },
+  { key: "OPENAI_BASE_URL", label: "OpenAI base URL (optional)", placeholder: "https://….openai.azure.com/openai/v1/" },
+  { key: "LIVEKIT_API_KEY", label: "LiveKit API key", placeholder: "API…" },
+  { key: "LIVEKIT_API_SECRET", label: "LiveKit API secret", placeholder: "secret…" },
+  { key: "NEXT_PUBLIC_LIVEKIT_URL", label: "LiveKit URL", placeholder: "wss://….livekit.cloud" },
+];
+
+type DesktopApi = {
+  getByoStatus: () => Promise<Record<string, boolean>>;
+  setByoKeys: (partial: Record<string, string>) => Promise<Record<string, boolean>>;
+};
+
+function desktopApi(): DesktopApi | null {
+  const w = window as unknown as { electron?: Partial<DesktopApi> & { isDesktop?: () => boolean } };
+  if (!w.electron?.isDesktop?.() || !w.electron.getByoStatus || !w.electron.setByoKeys) return null;
+  return w.electron as DesktopApi;
+}
+
+export function DesktopAiKeys() {
+  const api = desktopApi();
+  const [status, setStatus] = useState<Record<string, boolean>>({});
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!api) return;
+    void api.getByoStatus().then(setStatus);
+  }, [api]);
+
+  if (!api) return null; // web build / non-desktop: render nothing
+
+  async function save() {
+    const next = await api!.setByoKeys(draft);
+    setStatus(next);
+    setDraft({});
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div>
+        <h3 className="text-[14px] font-semibold text-[var(--text-primary)]">AI &amp; voice keys</h3>
+        <p className="text-[12px] text-[var(--text-muted)]">
+          Stored encrypted on this device and used only by the local app. Changes apply on next launch.
+        </p>
+      </div>
+      {FIELDS.map((f) => (
+        <label key={f.key} className="flex flex-col gap-1 text-[12px] text-[var(--text-secondary)]">
+          <span>
+            {f.label} {status[f.key] ? <span className="text-[var(--accent)]">• set</span> : null}
+          </span>
+          <input
+            type="password"
+            autoComplete="off"
+            placeholder={status[f.key] ? "•••••••• (leave blank to keep)" : f.placeholder}
+            value={draft[f.key] ?? ""}
+            onChange={(e) => setDraft((d) => ({ ...d, [f.key]: e.target.value }))}
+            className="rounded border border-[var(--border)] bg-[var(--message-bg)] px-2 py-1.5 text-[13px] text-[var(--text-primary)]"
+          />
+        </label>
+      ))}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void save()}
+          className="rounded bg-[var(--accent)] px-3 py-1.5 text-[12px] font-medium text-white"
+        >
+          Save keys
+        </button>
+        {saved && <span className="text-[12px] text-[var(--text-muted)]">Saved — relaunch to apply</span>}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Mount it in the settings UI (desktop-only)**
+
+Find the preferences/settings modal (search: `grep -rl "PreferencesModal\|SettingsModal" src/components`). Import and render `<DesktopAiKeys />` in an appropriate section/tab. The component self-hides on web (returns `null` when not in Electron), so it's safe to mount unconditionally.
+
+```tsx
+import { DesktopAiKeys } from "@/components/desktop/DesktopAiKeys";
+// …inside the modal body / an "Advanced" or "Desktop" section:
+<DesktopAiKeys />
+```
+
+- [ ] **Step 3: Build check (milestone)**
+
+Run: `npm run build`
+Expected: exit 0 (the component compiles in the web build and renders nothing there).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/desktop/DesktopAiKeys.tsx <the-modified-settings-file>
+git commit -m "feat(desktop): BYO AI/voice key settings panel (desktop-only)"
+```
+
+---
+
+## Task 8: Package the standalone server with electron-builder
+
+**Files:**
+- Modify: `electron-builder.json`
+
+- [ ] **Step 1: Bundle the standalone output as a resource**
+
+Add an `extraResources` entry so the prepared `.next/standalone` dir ships under `process.resourcesPath/standalone` (matching `standaloneEntry()` in `electron/server.ts`). Insert at the top level of `electron-builder.json` (sibling of `files`):
+
+```json
+  "extraResources": [
+    { "from": ".next/standalone", "to": "standalone" }
+  ],
+```
+
+- [ ] **Step 2: Verify the JSON is valid**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('electron-builder.json','utf8')); console.log('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add electron-builder.json
+git commit -m "build(desktop): bundle Next standalone via extraResources"
+```
+
+---
+
+## Task 9: Release pipeline — build standalone before packaging
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add build + prepare steps before electron-builder**
+
+Read `release.yml`. The build job already does `npm ci`. After install and before the electron-builder/`electron:build` step, add:
+
+```yaml
+      - name: Build Next standalone
+        run: npm run build
+
+      - name: Prepare standalone (copy static + public)
+        run: node scripts/prepare-standalone.mjs
+```
+
+(Keep the existing `electron:compile`/electron-builder steps. The order must be: install → next build → prepare-standalone → electron:compile → electron-builder.)
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run: `node -e "require('js-yaml')" 2>/dev/null && npx --yes js-yaml .github/workflows/release.yml >/dev/null && echo "yaml ok" || python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(desktop): build + prepare Next standalone before electron-builder"
+```
+
+---
+
+## Task 10: Docs + final verification
+
+**Files:**
+- Modify: `electron/README.md`
+
+- [ ] **Step 1: Update the README**
+
+Replace the "Bundling the server … not implemented yet" section with the local-first description: packaged builds spawn the bundled `.next/standalone` server on a loopback port and authenticate as a public PKCE client; AI/voice use BYO keys entered in settings; the owner must add an `http://localhost` redirect URI to Azure app `377aa8a2` (Mobile and desktop platform).
+
+- [ ] **Step 2: Final build + electron compile (milestone)**
+
+Run: `npm run build && node scripts/prepare-standalone.mjs && npm run electron:compile`
+Expected: all exit 0.
+
+- [ ] **Step 3: MANUAL packaged smoke test (your machine)**
+
+```bash
+npm run electron:build   # electron-builder --publish never
+```
+Install/run the produced artifact and verify:
+- App launches and shows the UI from the **local** server (no network needed for the shell; check it loads with Wi-Fi briefly off after sign-in).
+- "Sign in" opens the system browser, completes Microsoft auth, returns to the app; real Teams/chats load.
+- Settings → enter your Azure-OpenAI key → relaunch → the Catch-up/AI panels work.
+- Quitting via tray fully exits (no orphaned node process: `ps aux | grep server.js`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add electron/README.md
+git commit -m "docs(desktop): document local-first server + Azure loopback redirect"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Bundled standalone on loopback → Tasks 2, 4, 5, 8. ✓
+- Public-client PKCE loopback auth, no secret → Task 1 (gate). ✓
+- Graph-core local (no app secret) → works via Task 1 auth + the existing routes (the user's delegated token); no new task needed. ✓
+- BYO keys (safeStorage, env injection) → Tasks 3, 5, 6, 7. ✓
+- Per-install AUTH_SECRET → Task 3 + injected in Task 5. ✓
+- Hosted untouched (DESKTOP_MODE branch, Vercel build green) → Task 1 (guarded branch) + Task 2 Step 4. ✓
+- Packaging + release pipeline → Tasks 8, 9. ✓
+- Realtime = polling fallback in desktop → inherent (no webhook target); no task needed. ✓
+- Auth-spike-first gate → Task 1 is the explicit gate. ✓
+- Owner Azure step → called out at top + Task 10 README. ✓
+
+**Placeholder scan:** No TBD/TODO; complete code in each code step. The settings-modal mount point (Task 7 Step 2) is a `grep`-then-insert because the exact modal file isn't pinned here — that's a concrete instruction, not a placeholder.
+
+**Type/name consistency:** `startLocalServer(env)`/`LocalServer` (Task 4) used in Task 5. `ensureAuthSecret`/`loadByoKeys`/`saveByoKeys`/`byoKeyStatus` + `BYO_KEYS` (Task 3) used in Tasks 5/6. IPC channels `byo:status`/`byo:set` consistent across Tasks 5/6/7. `DESKTOP_MODE` consistent across Tasks 1/5. `standaloneEntry()` path (`resourcesPath/standalone`) matches `extraResources` `"to": "standalone"` (Tasks 4/8). `appUrl`/`localServer` consistent in Task 5.
+
+**Risk note:** Task 1 is load-bearing. If it fails, Tasks 5's `DESKTOP_MODE`/auth env and the auth branch change to a device-code design — stop and amend the spec rather than proceeding.

--- a/docs/superpowers/specs/2026-06-10-desktop-local-first-shell-design.md
+++ b/docs/superpowers/specs/2026-06-10-desktop-local-first-shell-design.md
@@ -1,0 +1,161 @@
+# Desktop local-first shell (Phase 1) — Design
+
+**Date:** 2026-06-10
+**Status:** Approved (design)
+**Issue:** #70 (Electron: bundle Next standalone for local-first load) — Phase 1.
+**Stage:** Phase 1 of the "native feel" track. Later phases (realtime-push refinement, window-chrome polish, motion) are out of scope here.
+
+## Problem
+
+The Electron desktop app loads the **remote** site (`electron/main.ts` → `loadURL('https://teamsly.vercel.app')`). Every shell interaction is a network round-trip, so the desktop app feels like "a website in a window": slow cold start, blank loads, and a hard dependency on connectivity. VSCode (also Electron) feels native because its shell loads from local disk. We want the same: load the app from a **local Next server bundled inside the app**.
+
+The blocker is auth: the hosted app is a **confidential** OAuth client using `AZURE_AD_CLIENT_SECRET`. A locally-bundled server would need that secret inside a distributed binary — extractable, a real security hole. So local-first requires the desktop to authenticate as a **public client** (PKCE, no secret).
+
+## Goal & success criteria (Phase 1)
+
+A packaged desktop build that:
+- Boots a **bundled Next standalone server on `127.0.0.1:<ephemeral-port>`** and loads the UI from it (no remote round-trip for the shell).
+- Authenticates via **loopback authorization-code + PKCE** as a **public client** — sign-in opens in the system browser and redirects back to the local server. **No secret ships in the binary.**
+- Runs the **Graph-backed core locally**: messages, channels, chats, files, presence, search — all using the user's delegated token.
+- Lets the user enable **AI and voice via BYO keys** entered in desktop settings (stored encrypted locally, injected into the server as env).
+- **Does not change the hosted web app's behavior** (Vercel path is env-branched and untouched) and ships **no new secrets** to the open-source repo.
+- `npm run build` (standalone) and `npm run electron:compile` pass.
+
+## Non-goals (deferred)
+
+- Realtime **push** in desktop (Graph webhooks need a public URL) — desktop uses the existing **polling** fallback.
+- Window-chrome polish (#71 Windows title bar, motion #72) and reactivity (B2/B3) — separate items.
+- macOS notarization (#73, owner-gated).
+- Auto-migrating existing remote-mode installs' state — desktop starts fresh local session.
+
+## Key facts established during brainstorming
+
+- **One Azure app registration already serves everything**: `377aa8a2-24d1-4d6e-8eca-e347864c9880`. It is already a confidential client (web/Vercel, with secret) **and** has "Allow public client flows" enabled (MCP device-code). The desktop adds a third usage of the **same** app as a public/PKCE client. Same client ID; the existing secret stays hosted-only; desktop never uses it.
+- **Only Azure change needed (owner step):** add a `http://localhost` redirect URI under a "Mobile and desktop applications" platform on that app. Azure matches any port for public-client loopback, so one entry covers the dynamic port. Purely additive — does not affect the hosted Web-platform redirect.
+- The MCP server (`mcp-server/index.ts`) already proves public-client auth against this app (device-code). The loopback-PKCE flow is the same public client, different grant.
+
+## Decisions
+
+### A. Auth: env-branched public client + PKCE (`DESKTOP_MODE`)
+`src/lib/auth/config.ts` gains a `DESKTOP_MODE` branch. When set (only in the bundled desktop server):
+- Configure the Microsoft Entra provider as a **public client**: same `clientId`, **no `clientSecret`**, `client: { token_endpoint_auth_method: "none" }`, `checks: ["pkce", "state"]`.
+- The token-**refresh** path (`refreshAccessToken`) omits `client_secret` (public clients refresh without one).
+- `NEXTAUTH_URL` is set dynamically to `http://localhost:<port>` at server spawn so the callback resolves to the local server.
+The Vercel/web path is byte-for-byte unchanged (confidential client, secret, existing refresh).
+
+### B. Process model: bundled standalone server spawned by Electron
+- `next.config.ts`: `output: "standalone"`.
+- Packaging copies `.next/standalone`, `.next/static`, and `public` into app resources (electron-builder `extraResources`).
+- New `electron/server.ts`: pick a free port; `fork` the standalone `server.js` under Electron's own Node (`ELECTRON_RUN_AS_NODE=1`, no separate node binary) with the right `cwd` + env (`PORT`, `HOSTNAME=127.0.0.1`, `NEXTAUTH_URL`, `AUTH_SECRET`, `AZURE_AD_CLIENT_ID`, `AZURE_AD_TENANT_ID`, `DESKTOP_MODE=1`, plus any BYO keys); health-check `GET /` until ready; return the base URL. Terminate the child on app quit (`before-quit`).
+- `electron/main.ts`: dev → `http://localhost:3000` (unchanged); packaged → `await startLocalServer()` then `loadURL(baseUrl)`. The existing `did-fail-load` offline-fallback covers spawn/health failures.
+
+### C. No shipped secrets — per-install secret + BYO keys via `safeStorage`
+- **`AUTH_SECRET`**: generated on first run (`crypto.randomBytes`), persisted encrypted via Electron `safeStorage` in `app.getPath('userData')`. Used to encrypt the local NextAuth session. Per-install, never shipped.
+- **BYO keys** (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, `NEXT_PUBLIC_LIVEKIT_URL`): entered in a desktop-only settings panel → IPC → main persists encrypted (`safeStorage`) → injected as env vars when the server is spawned. Unset → the existing "not configured" cards show. Graph-core needs none of these.
+
+### D. Risk-gated sequencing: auth spike first
+The load-bearing bet is "NextAuth v5 + Entra public client + PKCE + loopback works against `377aa8a2`." The plan will **prove this in a minimal harness first** (a dev run with `DESKTOP_MODE` + a localhost callback, real sign-in) before building packaging/spawn. If NextAuth's Entra provider can't do public-PKCE cleanly, the fallback is the **device-code** grant (as MCP uses) feeding a custom local session — decided at the spike, not after building everything.
+
+## Architecture & data flow
+
+```
+Electron main (packaged)
+  ├─ ensureAuthSecret()            [safeStorage in userData]
+  ├─ loadByoKeys()                 [safeStorage] → env
+  ├─ startLocalServer():
+  │     port = freePort()
+  │     fork(standalone/server.js, { ELECTRON_RUN_AS_NODE:1,
+  │            env: { PORT, HOSTNAME:127.0.0.1, NEXTAUTH_URL:http://localhost:port,
+  │                   AUTH_SECRET, AZURE_AD_CLIENT_ID, AZURE_AD_TENANT_ID,
+  │                   DESKTOP_MODE:1, ...byoKeys } })
+  │     await healthCheck(http://localhost:port)
+  │     return baseUrl
+  └─ mainWindow.loadURL(baseUrl)
+        │
+        ▼  (renderer = the real Next app, served locally)
+  Sign in → shell.openExternal(authorize URL, PKCE) → system browser → Microsoft
+        → redirect http://localhost:port/api/auth/callback/microsoft-entra-id
+        → local NextAuth exchanges code+verifier (no secret) → session cookie (local)
+        │
+        ▼
+  API routes run locally; Graph calls use the user's delegated token.
+  AI/voice routes read BYO keys from env (if provided).
+```
+
+## Components & interfaces
+
+### `next.config.ts` (modify)
+Add `output: "standalone"`. (Vercel ignores this for its own build tracing; verify the Vercel build stays green. If any friction, gate behind `process.env.BUILD_STANDALONE`.)
+
+### `electron/server.ts` (new)
+```ts
+export interface LocalServer { baseUrl: string; port: number; stop(): void; }
+export async function startLocalServer(env: Record<string,string>): Promise<LocalServer>
+```
+- `freePort()` via a transient `net.Server` listen on 0.
+- `fork(serverEntry, { env: { ...process.env, ...env, ELECTRON_RUN_AS_NODE: "1" }, cwd: standaloneDir })`.
+- `healthCheck(baseUrl, timeoutMs)` polling until a 200/redirect.
+- `stop()` kills the child; called from `before-quit`.
+
+### `electron/main.ts` (modify)
+- Import `startLocalServer`; in packaged mode build the env (auth secret + BYO + Azure client/tenant + `DESKTOP_MODE`), start the server, `loadURL` the returned base URL. Keep dev path. Kill child on quit. Keep the offline-fallback handler.
+
+### `electron/secrets.ts` (new)
+- `ensureAuthSecret(): string` — read-or-generate, encrypted via `safeStorage`, persisted in `userData/auth-secret.bin`.
+- `loadByoKeys(): Record<string,string>` / `saveByoKeys(partial)` — encrypted JSON in `userData/byo-keys.bin`. IPC handlers (`byo:get` masked, `byo:set`) wired in main.
+
+### `src/lib/auth/config.ts` (modify)
+- `const DESKTOP = process.env.DESKTOP_MODE === "1";` Branch the provider config (public/PKCE/no-secret when `DESKTOP`) and `refreshAccessToken` (no `client_secret` when `DESKTOP`). Web path unchanged.
+
+### Desktop settings UI (new, desktop-only)
+- A settings panel (gated on an "is desktop" signal, e.g. a `window.teamsly?.isDesktop` exposed by preload) to enter BYO keys → IPC `byo:set`. Lives alongside existing settings/preferences UI. Web build never shows it.
+
+### `electron-builder.json` (modify)
+- Add `extraResources` for `.next/standalone`, `.next/static`, `public` (mapped into the resources dir the server reads).
+
+### `.github/workflows/release.yml` (modify)
+- Before `electron-builder`: `npm run build` then a copy step (`.next/static` + `public` into `.next/standalone`). Across all three OSes.
+
+### `electron/README.md` (modify)
+- Replace "Bundling the server … not implemented yet" with the real local-first description + the Azure loopback-redirect owner step.
+
+## Error handling & edge cases
+
+| Condition | Behavior |
+|---|---|
+| Server spawn fails / port busy | retry once on a new port → else offline-fallback page |
+| Health-check timeout | offline-fallback page + visible window |
+| Auth (loopback) fails | existing NextAuth error surface; user can retry sign-in |
+| Missing BYO key | existing "AI/voice not configured" cards |
+| App quit | child server killed in `before-quit` |
+| Dev mode | unchanged — loads the Next dev server, no spawn |
+| `safeStorage` unavailable | fall back to an obfuscated-but-unencrypted file + warn (rare; Linux without a keyring) |
+
+## What works in desktop Phase 1
+- ✅ Local + instant: shell, messages, channels, chats, files, presence, search (Graph-core).
+- ✅ AI + voice **with BYO keys**.
+- ⚠️ Realtime falls back to polling (webhooks need a public URL).
+
+## Hosted-version safety (hard requirement)
+- The Vercel app never sets `DESKTOP_MODE`, so it runs today's exact confidential-client + remote path. Same Azure app, same secret, unchanged Web redirect.
+- The only shared-file changes are the env-guarded `auth/config.ts` branch and `next.config.ts` `output`. Both verified by `npm run build` + the PR CI; the web behavior must remain identical.
+
+## Testing / verification (honest)
+- `npm run build` (produces `.next/standalone`) and `npm run electron:compile` green.
+- **Auth spike** (gate): dev run with `DESKTOP_MODE=1` + localhost callback completes a real Microsoft sign-in via PKCE (no secret) and loads Graph data.
+- **Packaged build (your machine):** app launches, spawns the local server, signs in via loopback in the system browser, lists real Teams/chats; AI works after entering a BYO key; quitting kills the server.
+- Much of this is **only verifiable on a real packaged build on your machine** — the plan will state exactly what to test; CI covers build/compile, not the OAuth/packaged-spawn path.
+
+## Risks
+1. **NextAuth public-PKCE with Entra** (load-bearing) — mitigated by the auth-spike-first gate; device-code fallback if needed.
+2. **Standalone packaging gaps** (static/public copy, cwd, Node resolution under `ELECTRON_RUN_AS_NODE`) — standard Next-standalone-in-Electron gotchas; validated on a packaged build.
+3. **App size** grows (ships the Next server + minimal node_modules) — expected.
+4. **`output: "standalone"` on Vercel** — low risk; gate behind an env flag if it interferes.
+
+## File-change summary
+New: `electron/server.ts`, `electron/secrets.ts`, desktop BYO-settings UI (+ preload `isDesktop` flag + IPC).
+Modified: `electron/main.ts`, `next.config.ts`, `src/lib/auth/config.ts`, `electron-builder.json`, `.github/workflows/release.yml`, `electron/README.md`, preload script.
+
+## Owner steps (not code)
+1. Azure portal → app `377aa8a2` → Authentication → add platform "Mobile and desktop applications" → redirect URI `http://localhost`. (Public client flows already enabled.)
+2. Nothing else: same client ID, same secret (hosted-only), same scopes/consent.

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -12,6 +12,9 @@
     "electron/build-resources/**/*",
     "package.json"
   ],
+  "extraResources": [
+    { "from": ".next/standalone", "to": "standalone" }
+  ],
   "extraMetadata": {
     "main": "electron/dist/main.js"
   },

--- a/electron/README.md
+++ b/electron/README.md
@@ -12,12 +12,12 @@ The wrapper loads its UI from `TEAMSLY_URL`:
 | Mode | Default | Override |
 |---|---|---|
 | Development | `http://localhost:3000` | `TEAMSLY_URL=...` |
-| Production | `https://teamsly.vercel.app` | `TEAMSLY_URL=...` |
+| Production | `http://127.0.0.1:<dynamic port>` (bundled standalone) | `TEAMSLY_URL=...` |
 
-In production, set `TEAMSLY_URL` to your hosted instance (Vercel, self-hosted,
-etc.). For a single-binary self-hosted build that ships the Next.js server
-inside the app, see *Bundling the server* below — that path is not implemented
-yet.
+In packaged (production) builds the app spawns the bundled `.next/standalone`
+server on a free loopback port (`127.0.0.1`) and the renderer window loads from
+it — no internet connection or hosted instance is required for the UI itself.
+The dynamic port is chosen at launch and is never exposed outside the machine.
 
 ## Desktop features
 
@@ -114,15 +114,45 @@ and need to right-click → Open the first time; Windows users will see a
 SmartScreen warning. For an OSS project this is acceptable until you have a
 real budget for certificates.
 
-## Bundling the server (TODO)
+## Local-first server (packaged builds)
 
-To ship a true single-binary that doesn't require a hosted instance:
+Packaged builds ship the compiled Next.js app as a bundled standalone server
+inside `resources/standalone/`. At launch `electron/server.ts` resolves
+`process.resourcesPath/standalone/server.js`, spawns it as a child process on a
+dynamically chosen loopback port (`127.0.0.1:<port>`), and loads that URL in
+the renderer once the server responds. Nothing is fetched from a remote host for
+the UI.
 
-1. Add `output: 'standalone'` to `next.config.ts`.
-2. Run `next build` and copy `.next/standalone/` into the Electron app
-   resources.
-3. In `main.ts`, spawn the standalone server as a child process on a free port
-   and load `http://127.0.0.1:<port>` once it responds.
+### Auth — PKCE public client
 
-This is the path most desktop apps that wrap a web stack take. It is not
-implemented in this scaffold; it is a separate piece of work.
+Microsoft sign-in uses the Authorization Code + PKCE flow with no client
+secret. The OAuth redirect is handled by a custom `teamsly://` deep-link URI
+registered at install time. For the packaged dynamic-port loopback flow to work
+you must also add an `http://localhost` redirect URI to the Azure app
+registration under **Authentication → Mobile and desktop applications** (the
+"Mobile & desktop platform" section). The exact port does not need to be
+specified — Azure accepts any port on `http://localhost` for native clients.
+
+### AI features — BYO keys
+
+AI capabilities (meeting summaries, TL;DR, action-item extraction) and voice
+memo transcription rely on keys you supply yourself. Enter them in
+**Preferences → Advanced** inside the app:
+
+- **OpenAI API key** — powers all AI/LLM features.
+- **Azure Speech key** (optional) — required for voice memo transcription.
+
+Keys are stored in the OS keychain / Electron `safeStorage` and are never sent
+anywhere except the respective provider APIs.
+
+### Release build process
+
+The CI release workflow (`release.yml`) follows this order:
+
+1. `npm ci` — install dependencies.
+2. `npm run build` — run `next build` (produces `.next/standalone`).
+3. `node scripts/prepare-standalone.mjs` — copies `.next/static` and `public/`
+   into `.next/standalone` so the server can serve static assets.
+4. `npm run electron:compile` — TypeScript-compile the Electron main process.
+5. `electron-builder` — packages everything; `extraResources` maps
+   `.next/standalone` → `resources/standalone` inside the app bundle.

--- a/electron/README.md
+++ b/electron/README.md
@@ -126,24 +126,25 @@ the UI.
 ### Auth — PKCE public client
 
 Microsoft sign-in uses the Authorization Code + PKCE flow with no client
-secret. The OAuth redirect is handled by a custom `teamsly://` deep-link URI
-registered at install time. For the packaged dynamic-port loopback flow to work
-you must also add an `http://localhost` redirect URI to the Azure app
-registration under **Authentication → Mobile and desktop applications** (the
-"Mobile & desktop platform" section). The exact port does not need to be
-specified — Azure accepts any port on `http://localhost` for native clients.
+secret. Sign-in opens in the system browser and redirects back to the local
+server's loopback callback (`http://localhost:<port>/api/auth/callback/microsoft-entra-id`).
+For this to work you must add an `http://localhost` redirect URI to the Azure
+app registration under **Authentication → Mobile and desktop applications**. The
+exact port does not need to be specified — Azure accepts any port on
+`http://localhost` for public/native clients.
 
 ### AI features — BYO keys
 
-AI capabilities (meeting summaries, TL;DR, action-item extraction) and voice
-memo transcription rely on keys you supply yourself. Enter them in
-**Preferences → Advanced** inside the app:
+AI capabilities (catch-up digests, TL;DR, action-item extraction) and voice
+rooms rely on keys you supply yourself. Enter them in **Preferences → Advanced**
+inside the app:
 
-- **OpenAI API key** — powers all AI/LLM features.
-- **Azure Speech key** (optional) — required for voice memo transcription.
+- **OpenAI / Azure key** (+ optional base URL) — powers the AI features.
+- **LiveKit** API key, secret, and URL — power voice rooms.
 
-Keys are stored in the OS keychain / Electron `safeStorage` and are never sent
-anywhere except the respective provider APIs.
+Keys are stored via Electron `safeStorage` (OS keychain) and are injected only
+into the local server process; they are never sent anywhere except the
+respective provider APIs.
 
 ### Release build process
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,14 +1,15 @@
 import { app, BrowserWindow, Menu, Tray, ipcMain, nativeImage, shell } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import path from 'path';
+import { startLocalServer, type LocalServer } from './server';
+import { ensureAuthSecret, loadByoKeys, saveByoKeys, byoKeyStatus } from './secrets';
 
 const isDev = !app.isPackaged;
 
-// Where the renderer loads from. In dev, point at the Next.js dev server.
-// In production, set TEAMSLY_URL to your hosted instance, or bundle a Next.js
-// standalone build and spawn it locally (see electron/README.md).
-const TEAMSLY_URL =
-  process.env.TEAMSLY_URL || (isDev ? 'http://localhost:3000' : 'https://teamsly.vercel.app');
+// Resolved at startup: dev → Next dev server; packaged → the local bundled
+// server we spawn (set in whenReady). An explicit TEAMSLY_URL still overrides.
+let appUrl = process.env.TEAMSLY_URL || 'http://localhost:3000';
+let localServer: LocalServer | null = null;
 
 // In dev the app name defaults to "Electron" (the name of the dev binary), so
 // the macOS menu bar, About panel, and notification source all read "Electron".
@@ -305,11 +306,11 @@ function createWindow(): void {
   mainWindow.webContents.on('did-fail-load', (_event, errorCode, _desc, _url, isMainFrame) => {
     // ERR_ABORTED (-3) fires on ordinary in-app navigations; ignore it + subframes.
     if (!isMainFrame || errorCode === -3) return;
-    void mainWindow?.loadURL(offlineFallbackUrl(TEAMSLY_URL));
+    void mainWindow?.loadURL(offlineFallbackUrl(appUrl));
     mainWindow?.show();
   });
 
-  void mainWindow.loadURL(TEAMSLY_URL);
+  void mainWindow.loadURL(appUrl);
 
   // Native right-click menu: spelling suggestions + Cut/Copy/Paste/Select All,
   // with DevTools only in dev. Packaged builds previously suppressed the menu
@@ -399,15 +400,40 @@ ipcMain.on('window-is-focused', (event) => {
   event.returnValue = mainWindow?.isFocused() ?? false;
 });
 
+// BYO keys: the renderer only ever sees which keys are SET (booleans), never
+// the values. Saved keys take effect on the next app launch (server respawn).
+ipcMain.handle('byo:status', () => byoKeyStatus());
+ipcMain.handle('byo:set', (_event, partial: Record<string, string>) => {
+  saveByoKeys(partial ?? {});
+  return byoKeyStatus();
+});
+
 // ─── App lifecycle ────────────────────────────────────────────────────────────
 
-void app.whenReady().then(() => {
+void app.whenReady().then(async () => {
   buildAppMenu();
   tray = buildTrayIcon();
+
+  // Packaged builds load from a locally-spawned Next server (local-first).
+  // Dev and explicit-TEAMSLY_URL builds keep their remote/dev URL.
+  if (!isDev && !process.env.TEAMSLY_URL) {
+    try {
+      localServer = await startLocalServer({
+        AUTH_SECRET: ensureAuthSecret(),
+        DESKTOP_MODE: '1',
+        AZURE_AD_CLIENT_ID: process.env.AZURE_AD_CLIENT_ID ?? '377aa8a2-24d1-4d6e-8eca-e347864c9880',
+        AZURE_AD_TENANT_ID: process.env.AZURE_AD_TENANT_ID ?? 'common',
+        ...loadByoKeys(),
+      });
+      appUrl = localServer.baseUrl;
+    } catch (err) {
+      console.error('[main] local server failed to start:', (err as Error).message);
+    }
+  }
+
   createWindow();
   setupAutoUpdater();
 
-  // Silent startup check — do not block the window from loading.
   if (!isDev) {
     void autoUpdater.checkForUpdates().catch((err: Error) => {
       console.error('[auto-updater] startup check failed:', err.message);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -100,4 +100,11 @@ contextBridge.exposeInMainWorld('electron', {
   },
   /** Whether this platform supports silent auto-install (false on unsigned macOS). */
   isAutoInstallSupported: (): boolean => AUTO_INSTALL_SUPPORTED,
+  /** True when running in the packaged/desktop app (always true here). */
+  isDesktop: (): true => true,
+  /** Which BYO keys are currently set (names→boolean; never the values). */
+  getByoStatus: (): Promise<Record<string, boolean>> => ipcRenderer.invoke('byo:status'),
+  /** Save BYO keys (empty string deletes one). Returns the new status map. */
+  setByoKeys: (partial: Record<string, string>): Promise<Record<string, boolean>> =>
+    ipcRenderer.invoke('byo:set', partial),
 });

--- a/electron/secrets.ts
+++ b/electron/secrets.ts
@@ -1,0 +1,82 @@
+import { app, safeStorage } from 'electron';
+import { randomBytes } from 'crypto';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import path from 'path';
+
+const userData = (): string => app.getPath('userData');
+const authSecretPath = (): string => path.join(userData(), 'auth-secret.bin');
+const byoPath = (): string => path.join(userData(), 'byo-keys.bin');
+
+// The env var names the bundled Next server reads. Keep in sync with the
+// settings UI and the spawn env in electron/server.ts.
+export const BYO_KEYS = [
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'LIVEKIT_API_KEY',
+  'LIVEKIT_API_SECRET',
+  'NEXT_PUBLIC_LIVEKIT_URL',
+] as const;
+export type ByoKey = (typeof BYO_KEYS)[number];
+
+function encryptToFile(file: string, plain: string): void {
+  const data = safeStorage.isEncryptionAvailable()
+    ? safeStorage.encryptString(plain)
+    : Buffer.from('PLAIN:' + plain, 'utf8'); // rare fallback (e.g. Linux w/o keyring)
+  writeFileSync(file, data);
+}
+
+function decryptFromFile(file: string): string | null {
+  if (!existsSync(file)) return null;
+  const buf = readFileSync(file);
+  if (buf.subarray(0, 6).toString('utf8') === 'PLAIN:') return buf.subarray(6).toString('utf8');
+  try {
+    return safeStorage.decryptString(buf);
+  } catch {
+    return null;
+  }
+}
+
+/** Read-or-generate a per-install NextAuth secret. Never shipped in the binary. */
+export function ensureAuthSecret(): string {
+  const existing = decryptFromFile(authSecretPath());
+  if (existing) return existing;
+  const secret = randomBytes(32).toString('base64');
+  encryptToFile(authSecretPath(), secret);
+  return secret;
+}
+
+/** All saved BYO keys (decrypted) as an env map. Empty when none set. */
+export function loadByoKeys(): Record<string, string> {
+  const raw = decryptFromFile(byoPath());
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, string>;
+    const out: Record<string, string> = {};
+    for (const k of BYO_KEYS) {
+      const v = parsed[k];
+      if (typeof v === 'string' && v.length > 0) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Merge + persist BYO keys. Empty-string values delete that key. */
+export function saveByoKeys(partial: Record<string, string>): void {
+  const current = loadByoKeys();
+  for (const k of BYO_KEYS) {
+    if (k in partial) {
+      const v = partial[k];
+      if (v) current[k] = v;
+      else delete current[k];
+    }
+  }
+  encryptToFile(byoPath(), JSON.stringify(current));
+}
+
+/** Which BYO keys are set (names only — never return values to the renderer). */
+export function byoKeyStatus(): Record<string, boolean> {
+  const set = loadByoKeys();
+  return Object.fromEntries(BYO_KEYS.map((k) => [k, Boolean(set[k])]));
+}

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -1,0 +1,84 @@
+import { app } from 'electron';
+import { fork, type ChildProcess } from 'child_process';
+import { createServer } from 'net';
+import http from 'http';
+import path from 'path';
+
+export interface LocalServer {
+  baseUrl: string;
+  port: number;
+  stop: () => void;
+}
+
+// In a packaged app, extraResources land under process.resourcesPath. The
+// standalone server entry is server.js at the root of the copied standalone dir.
+function standaloneEntry(): string {
+  return path.join(process.resourcesPath, 'standalone', 'server.js');
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function healthCheck(baseUrl: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      const req = http.get(baseUrl, (res) => {
+        res.resume();
+        resolve();
+      });
+      req.on('error', () => {
+        if (Date.now() > deadline) reject(new Error('local server health-check timed out'));
+        else setTimeout(tick, 150);
+      });
+    };
+    tick();
+  });
+}
+
+/**
+ * Spawn the bundled Next standalone server on a free loopback port using
+ * Electron's own Node (ELECTRON_RUN_AS_NODE), then wait until it responds.
+ * `env` carries NEXTAUTH/AUTH_SECRET/Azure/BYO values.
+ */
+export async function startLocalServer(env: Record<string, string>): Promise<LocalServer> {
+  const port = await freePort();
+  const baseUrl = `http://localhost:${port}`;
+  const entry = standaloneEntry();
+
+  const child: ChildProcess = fork(entry, [], {
+    cwd: path.dirname(entry),
+    env: {
+      ...process.env,
+      ...env,
+      ELECTRON_RUN_AS_NODE: '1',
+      PORT: String(port),
+      HOSTNAME: '127.0.0.1',
+      NEXTAUTH_URL: baseUrl,
+      NODE_ENV: 'production',
+    },
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  });
+
+  child.on('exit', (code) => {
+    if (code && code !== 0) console.error(`[local-server] exited with code ${code}`);
+  });
+
+  await healthCheck(baseUrl, 20_000);
+
+  const stop = () => {
+    try { child.kill(); } catch { /* already gone */ }
+  };
+  app.on('before-quit', stop);
+  return { baseUrl, port, stop };
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import pkg from "./package.json";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   outputFileTracingRoot: process.cwd(),
   env: {
     NEXT_PUBLIC_APP_VERSION: pkg.version,

--- a/scripts/prepare-standalone.mjs
+++ b/scripts/prepare-standalone.mjs
@@ -1,0 +1,20 @@
+import { cp, access } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = process.cwd();
+const standalone = join(root, ".next", "standalone");
+
+async function exists(p) {
+  try { await access(p); return true; } catch { return false; }
+}
+
+if (!(await exists(join(standalone, "server.js")))) {
+  console.error("[prepare-standalone] .next/standalone/server.js missing — run `next build` with output:'standalone' first.");
+  process.exit(1);
+}
+
+await cp(join(root, ".next", "static"), join(standalone, ".next", "static"), { recursive: true });
+if (await exists(join(root, "public"))) {
+  await cp(join(root, "public"), join(standalone, "public"), { recursive: true });
+}
+console.log("[prepare-standalone] copied static + public into .next/standalone");

--- a/src/components/desktop/DesktopAiKeys.tsx
+++ b/src/components/desktop/DesktopAiKeys.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Mirrors electron/secrets.ts BYO_KEYS. Each field is write-only from the UI;
+// we only learn whether a key is set, never its value.
+const FIELDS: { key: string; label: string; placeholder: string }[] = [
+  { key: "OPENAI_API_KEY", label: "OpenAI / Azure key", placeholder: "sk-… or Azure key" },
+  { key: "OPENAI_BASE_URL", label: "OpenAI base URL (optional)", placeholder: "https://….openai.azure.com/openai/v1/" },
+  { key: "LIVEKIT_API_KEY", label: "LiveKit API key", placeholder: "API…" },
+  { key: "LIVEKIT_API_SECRET", label: "LiveKit API secret", placeholder: "secret…" },
+  { key: "NEXT_PUBLIC_LIVEKIT_URL", label: "LiveKit URL", placeholder: "wss://….livekit.cloud" },
+];
+
+type DesktopApi = {
+  getByoStatus: () => Promise<Record<string, boolean>>;
+  setByoKeys: (partial: Record<string, string>) => Promise<Record<string, boolean>>;
+};
+
+function desktopApi(): DesktopApi | null {
+  const w = window as unknown as { electron?: Partial<DesktopApi> & { isDesktop?: () => boolean } };
+  if (!w.electron?.isDesktop?.() || !w.electron.getByoStatus || !w.electron.setByoKeys) return null;
+  return w.electron as DesktopApi;
+}
+
+export function DesktopAiKeys() {
+  const [api, setApi] = useState<DesktopApi | null>(null);
+  const [status, setStatus] = useState<Record<string, boolean>>({});
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const a = desktopApi();
+    setApi(a);
+    if (a) void a.getByoStatus().then(setStatus);
+  }, []);
+
+  if (!api) return null; // web build / non-desktop: render nothing
+
+  async function save() {
+    const next = await api!.setByoKeys(draft);
+    setStatus(next);
+    setDraft({});
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div>
+        <h3 className="text-[14px] font-semibold text-[var(--text-primary)]">AI &amp; voice keys</h3>
+        <p className="text-[12px] text-[var(--text-muted)]">
+          Stored encrypted on this device and used only by the local app. Changes apply on next launch.
+        </p>
+      </div>
+      {FIELDS.map((f) => (
+        <label key={f.key} className="flex flex-col gap-1 text-[12px] text-[var(--text-secondary)]">
+          <span>
+            {f.label} {status[f.key] ? <span className="text-[var(--accent)]">• set</span> : null}
+          </span>
+          <input
+            type="password"
+            autoComplete="off"
+            placeholder={status[f.key] ? "•••••••• (leave blank to keep)" : f.placeholder}
+            value={draft[f.key] ?? ""}
+            onChange={(e) => setDraft((d) => ({ ...d, [f.key]: e.target.value }))}
+            className="rounded border border-[var(--border)] bg-[var(--message-bg)] px-2 py-1.5 text-[13px] text-[var(--text-primary)]"
+          />
+        </label>
+      ))}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void save()}
+          className="rounded bg-[var(--accent)] px-3 py-1.5 text-[12px] font-medium text-white"
+        >
+          Save keys
+        </button>
+        {saved && <span className="text-[12px] text-[var(--text-muted)]">Saved — relaunch to apply</span>}
+      </div>
+    </section>
+  );
+}

--- a/src/components/modals/PreferencesModal.tsx
+++ b/src/components/modals/PreferencesModal.tsx
@@ -40,6 +40,7 @@ import {
   type Density,
 } from "@/store/preferences";
 import { playNotificationTone } from "@/lib/utils/sound";
+import { DesktopAiKeys } from "@/components/desktop/DesktopAiKeys";
 
 // ─── Nav sections ────────────────────────────────────────────────────────────
 
@@ -982,6 +983,7 @@ function AdvancedPanel() {
           Reset to defaults
         </button>
       </FieldGroup>
+      <DesktopAiKeys />
     </div>
   );
 }

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -1,6 +1,8 @@
 import NextAuth from "next-auth";
 import MicrosoftEntraID from "next-auth/providers/microsoft-entra-id";
 
+const DESKTOP = process.env.DESKTOP_MODE === "1";
+
 const SCOPE = [
   "openid",
   "profile",
@@ -25,11 +27,13 @@ async function refreshAccessToken(refreshToken: string) {
   const url = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
   const params = new URLSearchParams({
     client_id: process.env.AZURE_AD_CLIENT_ID!,
-    client_secret: process.env.AZURE_AD_CLIENT_SECRET!,
     grant_type: "refresh_token",
     refresh_token: refreshToken,
     scope: SCOPE,
   });
+  if (!DESKTOP) {
+    params.set("client_secret", process.env.AZURE_AD_CLIENT_SECRET!);
+  }
 
   const response = await fetch(url, {
     method: "POST",
@@ -60,9 +64,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
     MicrosoftEntraID({
       clientId: process.env.AZURE_AD_CLIENT_ID!,
-      clientSecret: process.env.AZURE_AD_CLIENT_SECRET!,
+      ...(DESKTOP ? {} : { clientSecret: process.env.AZURE_AD_CLIENT_SECRET! }),
       issuer: `https://login.microsoftonline.com/${process.env.AZURE_AD_TENANT_ID ?? "common"}/v2.0`,
       authorization: { params: { scope: SCOPE } },
+      // Desktop is a public client: no secret; prove possession via PKCE.
+      ...(DESKTOP
+        ? {
+            client: { token_endpoint_auth_method: "none" as const },
+            checks: ["pkce", "state"] as ("pkce" | "state")[],
+          }
+        : {}),
     }),
   ],
   callbacks: {

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -61,6 +61,12 @@ async function refreshAccessToken(refreshToken: string) {
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  // The bundled desktop server runs on a loopback host under NODE_ENV=production
+  // with no VERCEL/AUTH_URL, so NextAuth would otherwise default trustHost to
+  // false and reject every /api/auth request (UntrustedHost). Trust the host
+  // only in desktop mode — on web this key is absent, so Vercel's own
+  // env-based detection (VERCEL=1 → true) is preserved unchanged.
+  ...(DESKTOP ? { trustHost: true } : {}),
   providers: [
     MicrosoftEntraID({
       clientId: process.env.AZURE_AD_CLIENT_ID!,


### PR DESCRIPTION
**Status: code-complete + runtime/packaging-validated. Draft pending the interactive Microsoft sign-in test (needs real creds — can't be automated).** Phase 1 of the local-first desktop epic (#70).

## What this does
Packaged desktop builds spawn a **bundled Next standalone server on a loopback port** and load the UI from it — instant local shell, no remote round-trip. Auth is a **public client (PKCE, no secret)**; AI/voice use **BYO keys** (Preferences → Advanced), encrypted via `safeStorage`.

## Validated (no creds / GUI needed)
- ✅ `npm run build`, `electron:compile`, PR CI, **Vercel preview build** all green → **hosted app unaffected** (everything is build-time or gated behind `DESKTOP_MODE=1`, which Vercel never sets).
- ✅ **Standalone server runs in desktop mode**: ran `.next/standalone/server.js` with the exact spawn env — home `200`, `/api/auth/providers` loads the Entra config, `/api/auth/csrf` returns `200 + token` (**proves the `trustHost` fix** — would be `UntrustedHost` without it), `/api/auth/signin` `200`, no errors.
- ✅ **Packaging**: a `dir` build produced `Teamsly.app` with `Contents/Resources/standalone/server.js` (+ static + public) — the bundle path matches what `electron/server.ts` resolves.

## Key fix from review
`trustHost`: the packaged server runs `NODE_ENV=production` with no `VERCEL`, so NextAuth would default `trustHost=false` → `UntrustedHost`. Fixed by `trustHost: true` **only in desktop mode** (web path keeps its own env detection — deliberately not `trustHost: DESKTOP`, which would pass `false` on web and break Vercel). Runtime-confirmed above.

## Remaining before merge (your machine)
1. **Interactive sign-in on the packaged app** — launch `release/mac-arm64/Teamsly.app`, complete Microsoft sign-in via the loopback browser flow, confirm Teams/chats load and a token refresh succeeds (the earlier `AADSTS7000218` was a stale confidential-session artifact; needs a clean test).
2. **Azure**: add the portless `http://localhost` redirect URI (Mobile & desktop platform) for the packaged dynamic port.

(The one link not auto-verifiable besides OAuth: Electron's `fork`-under-`ELECTRON_RUN_AS_NODE` spawn at launch — exercised by step 1.)

## Known follow-up (Minor)
`electron/server.ts` dials `localhost` while binding `127.0.0.1`; align if an IPv6-preferring resolver causes a connect failure in the packaged test.

Phase 2 (out of scope): realtime push refinement, window-chrome polish, motion.