### PR TITLE
Native feel: in-place message updates + de-web-ify

### DIFF
--- a/docs/superpowers/plans/2026-06-11-reactivity-b2-b3.md
+++ b/docs/superpowers/plans/2026-06-11-reactivity-b2-b3.md
@@ -1,0 +1,467 @@
+# Reactivity B2/B3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the message feed update in place — push upserts the single changed message (no refetch/flash), an SSE-health-aware poll only reconciles, message rows are memoized, and long histories render a bounded slice — so it feels like a native app, not a refreshing web page.
+
+**Architecture:** Add a single-message GET route, an SSE health signal, an identity-preserving store (`upsertMessage` + reuse-on-unchanged `setMessages`), then rewire ChatView/ChannelView to upsert-on-push + poll adaptively, and make MessageItem memoized + MessageFeed render-capped.
+
+**Tech Stack:** Next.js route handlers, Microsoft Graph, React 19 (`React.memo`, `useMemo`, `useSyncExternalStore`), Zustand, the existing SSE transport (`useRealtimeEvents`).
+
+---
+
+## Testing note
+No test runner in this repo; the gate is the build. Per task: `npx tsc --noEmit 2>&1 | grep -v "src/lib/auth/config.ts"` (expect empty); `npm run build` at the milestones noted. Runtime behavior (two-account push, scroll) is verified manually — flagged where it applies. **Commits:** Conventional, **no AI/agent trailer** (per CLAUDE.md). Branch `feat/reactivity-b2-b3` (already created; spec committed). Subagents: stay on this branch, `git add`+`git commit` only, confirm `git branch --show-current` before each commit.
+
+## File structure
+New: `src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts` (single channel message GET).
+Modified: `src/app/api/chats/[chatId]/messages/[messageId]/route.ts` (+GET) · `src/hooks/useRealtimeEvents.ts` (health) · `src/store/workspace.ts` (`upsertMessage` + identity merge) · `src/components/messages/ChatView.tsx`, `ChannelView.tsx` (push→upsert, adaptive poll) · `src/components/messages/MessageItem.tsx` (memo) · `src/components/messages/MessageFeed.tsx` (render-cap).
+
+---
+
+## Task 1: Single-message GET routes
+
+**Files:**
+- Modify: `src/app/api/chats/[chatId]/messages/[messageId]/route.ts`
+- Create: `src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts`
+
+- [ ] **Step 1: Add a GET handler to the chat route**
+
+In `src/app/api/chats/[chatId]/messages/[messageId]/route.ts`, add (the file already imports `auth` and `NextResponse` and defines `type Params = Promise<{ chatId: string; messageId: string }>`):
+
+```ts
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const session = await auth();
+  if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { chatId, messageId } = await params;
+  try {
+    const res = await fetch(
+      `https://graph.microsoft.com/v1.0/chats/${chatId}/messages/${messageId}`,
+      { headers: { Authorization: `Bearer ${session.accessToken}` } }
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error("Graph get chat message failed", res.status, text);
+      return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+    }
+    return NextResponse.json(await res.json());
+  } catch (err) {
+    console.error("Graph get chat message error", err);
+    return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+  }
+}
+```
+
+- [ ] **Step 2: Create the channel single-message route**
+
+Create `src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts`:
+
+```ts
+import { auth } from "@/lib/auth/config";
+import { NextResponse } from "next/server";
+
+type Params = Promise<{ teamId: string; channelId: string; messageId: string }>;
+
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const session = await auth();
+  if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { teamId, channelId, messageId } = await params;
+  try {
+    const res = await fetch(
+      `https://graph.microsoft.com/v1.0/teams/${teamId}/channels/${channelId}/messages/${messageId}`,
+      { headers: { Authorization: `Bearer ${session.accessToken}` } }
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error("Graph get channel message failed", res.status, text);
+      return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+    }
+    return NextResponse.json(await res.json());
+  } catch (err) {
+    console.error("Graph get channel message error", err);
+    return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+  }
+}
+```
+
+- [ ] **Step 3: Verify** — `npx tsc --noEmit 2>&1 | grep -v "src/lib/auth/config.ts"` → no output.
+- [ ] **Step 4: Commit**
+```bash
+git add "src/app/api/chats/[chatId]/messages/[messageId]/route.ts" "src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts"
+git commit -m "feat(api): single-message GET for chats + channels"
+```
+
+---
+
+## Task 2: SSE health signal
+
+**Files:**
+- Modify: `src/hooks/useRealtimeEvents.ts`
+
+- [ ] **Step 1: Add connection-health tracking + `useRealtimeHealth`**
+
+Replace the contents of `src/hooks/useRealtimeEvents.ts` with:
+
+```ts
+"use client";
+
+import { useEffect, useSyncExternalStore } from "react";
+import type { RealtimeEvent } from "@/lib/realtime/pubsub";
+
+type Handler = (event: RealtimeEvent) => void;
+
+const handlers = new Set<Handler>();
+
+// ---- Health (so views can slow their reconcile poll when push is live) ------
+let connected = false;
+let lastEventAt = 0;
+const healthListeners = new Set<() => void>();
+
+function emitHealth() {
+  for (const l of healthListeners) l();
+}
+function setConnected(v: boolean) {
+  if (connected !== v) { connected = v; emitHealth(); }
+}
+
+// "Healthy" = SSE connection is open. (Push delivery is best-effort; the
+// reconcile poll is the backstop, so open-connection is a sufficient signal
+// to slow the poll.)
+function isHealthy(): boolean {
+  return connected;
+}
+
+export function useRealtimeHealth(): boolean {
+  return useSyncExternalStore(
+    (cb) => { healthListeners.add(cb); return () => healthListeners.delete(cb); },
+    isHealthy,
+    () => false, // SSR: assume unhealthy → views use the fast poll until hydrated
+  );
+}
+
+export function useRealtimeEvents(handler: Handler) {
+  useEffect(() => {
+    handlers.add(handler);
+    return () => { handlers.delete(handler); };
+  }, [handler]);
+}
+
+export function RealtimeEventsMount() {
+  useEffect(() => {
+    const es = new EventSource("/api/realtime/sse");
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false); // EventSource auto-reconnects; onopen flips back
+    es.onmessage = (e) => {
+      lastEventAt = Date.now();
+      let event: RealtimeEvent;
+      try {
+        event = JSON.parse(e.data as string) as RealtimeEvent;
+      } catch {
+        return;
+      }
+      for (const h of handlers) h(event);
+    };
+    return () => { es.close(); setConnected(false); };
+  }, []);
+  return null;
+}
+```
+(`lastEventAt` is recorded for future tuning; health is connection-based for now — simple and sufficient.)
+
+- [ ] **Step 2: Verify** — `npx tsc --noEmit 2>&1 | grep -v "src/lib/auth/config.ts"` → no output.
+- [ ] **Step 3: Commit**
+```bash
+git add src/hooks/useRealtimeEvents.ts
+git commit -m "feat(realtime): expose SSE connection health (useRealtimeHealth)"
+```
+
+---
+
+## Task 3: Store — `upsertMessage` + identity-preserving merge
+
+**Files:**
+- Modify: `src/store/workspace.ts`
+
+- [ ] **Step 1: Add `upsertMessage` to the interface**
+
+In the store's state interface (near `appendMessage: (contextId: string, message: MSMessage) => void;`), add:
+```ts
+  /** Add a single message if new, or replace it in place if it already exists
+   * (by id). Preserves the array slot + every other message's object identity
+   * so memoized rows don't re-render. Used by the realtime push path. */
+  upsertMessage: (contextId: string, message: MSMessage) => void;
+```
+
+- [ ] **Step 2: Make `setMessages` reuse unchanged objects**
+
+Replace the `merged` computation inside `setMessages` so unchanged incoming messages reuse the existing object reference. Replace this line:
+```ts
+          const merged = trimToMax(sortByCreatedDateTime([...filtered, ...uniquePending]));
+```
+with:
+```ts
+          // Reuse the existing object for any message whose id + lastModified
+          // are unchanged, so React.memo'd rows don't re-render on reconcile.
+          const byId = new Map(existing.map((m) => [m.id, m]));
+          const reused = filtered.map((m) => {
+            const prev = byId.get(m.id);
+            return prev && prev.lastModifiedDateTime === m.lastModifiedDateTime ? prev : m;
+          });
+          const merged = trimToMax(sortByCreatedDateTime([...reused, ...uniquePending]));
+```
+
+- [ ] **Step 3: Implement `upsertMessage`**
+
+Add the action next to `appendMessage`:
+```ts
+      upsertMessage: (contextId, message) =>
+        set((s) => {
+          if (s.expiredMessageIds.has(message.id)) return s;
+          const existing = s.messagesByContext[contextId] ?? [];
+          const idx = existing.findIndex((m) => m.id === message.id);
+          let next: MSMessage[];
+          if (idx >= 0) {
+            if (existing[idx].lastModifiedDateTime === message.lastModifiedDateTime) return s;
+            next = [...existing];
+            next[idx] = message;
+            next = sortByCreatedDateTime(next);
+          } else {
+            next = trimToMax(sortByCreatedDateTime([...existing, message]));
+          }
+          persistContext(contextId, next);
+          return { messagesByContext: { ...s.messagesByContext, [contextId]: next } };
+        }),
+```
+
+- [ ] **Step 4: Verify** — `npx tsc --noEmit 2>&1 | grep -v "src/lib/auth/config.ts"` → no output.
+- [ ] **Step 5: Commit**
+```bash
+git add src/store/workspace.ts
+git commit -m "feat(store): upsertMessage + identity-preserving setMessages merge"
+```
+
+---
+
+## Task 4: ChatView + ChannelView — push→upsert + adaptive poll
+
+**Files:**
+- Modify: `src/components/messages/ChatView.tsx`
+- Modify: `src/components/messages/ChannelView.tsx`
+
+Read both. They share the same shape: a `load()` full-refetch, `setInterval(load, 30_000)`, a `useRealtimeEvents` handler that calls `loadRef.current()` on a matching event, and a `loadRef`.
+
+- [ ] **Step 1 (ChatView): pull in `upsertMessage` + health**
+
+Add to the workspace-store destructure the `upsertMessage` action (alongside `setMessages`/`getMessages`):
+```ts
+  const upsertMessage = useWorkspaceStore((s) => s.upsertMessage);
+```
+Import the health hook (next to the `useRealtimeEvents` import):
+```ts
+import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
+```
+And read it in the component body:
+```ts
+  const sseHealthy = useRealtimeHealth();
+```
+
+- [ ] **Step 2 (ChatView): push → upsert single message (lossless fallback)**
+
+Replace the realtime handler body (the `if (event.type === "chat_message" && event.chatId === chatId) { void loadRef.current(); }`) with:
+```ts
+        if (event.type === "chat_message" && event.chatId === chatId) {
+          fetch(`/api/chats/${chatId}/messages/${event.messageId}`)
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+            .then((msg: MSMessage) => upsertMessage(chatId, msg))
+            .catch(() => void loadRef.current()); // fallback: full refetch, lossless
+        }
+```
+Add `upsertMessage` to that `useRealtimeEvents` callback's dependency array (so it's captured) — keep the handler wrapped in `useCallback` as it already is; add `upsertMessage` and `chatId` to its deps.
+
+- [ ] **Step 3 (ChatView): adaptive poll interval**
+
+Replace `const interval = setInterval(load, 30_000);` with:
+```ts
+    // Reconcile poll: slow when SSE push is live, fast when it isn't.
+    const interval = setInterval(load, sseHealthy ? 120_000 : 30_000);
+```
+Add `sseHealthy` to that effect's dependency array so the interval is recreated when health flips. (The effect already re-runs on `chatId`; adding `sseHealthy` is safe — `load` is re-created each run via `loadRef`.)
+
+- [ ] **Step 4 (ChannelView): mirror Steps 1–3**
+
+Apply the identical changes in `ChannelView.tsx`: import `useRealtimeHealth`, read `sseHealthy`, grab `upsertMessage`; in the realtime handler, on `event.type === "channel_message" && event.teamId === teamId && event.channelId === channelId`, fetch `/api/teams/${teamId}/channels/${channelId}/messages/${event.messageId}` → `upsertMessage(contextId, msg)` with the same `.catch(() => void loadRef.current())` fallback (`contextId` here is the `${teamId}:${channelId}` key already used by ChannelView); and make the poll interval `sseHealthy ? 120_000 : 30_000` with `sseHealthy` in deps.
+
+- [ ] **Step 5: Build check (milestone)** — `npm run build` → exit 0 (catches hooks-rules). Paste final lines.
+- [ ] **Step 6: Commit**
+```bash
+git add src/components/messages/ChatView.tsx src/components/messages/ChannelView.tsx
+git commit -m "feat(messages): upsert on realtime push; adaptive reconcile poll"
+```
+
+---
+
+## Task 5: Memoize MessageItem
+
+**Files:**
+- Modify: `src/components/messages/MessageItem.tsx`
+
+- [ ] **Step 1: Memoize the link/markdown detection**
+
+Inside the component, the GitHub/rich-link/body rendering currently runs every render. Wrap the detection in `useMemo` keyed on the body + id. Find where `detectGitHubLinks`, `detectRichLinks`, and `renderMessageBody`/`messagePlainText` are called and hoist them into:
+```ts
+  const content = message.body?.content ?? "";
+  const detection = useMemo(
+    () => ({
+      github: detectGitHubLinks(content),
+      richLinks: detectRichLinks(content),
+    }),
+    [content, message.id]
+  );
+```
+Then use `detection.github` / `detection.richLinks` at the call sites (replace the inline `detectGitHubLinks(...)` / `detectRichLinks(...)` calls). (`useMemo` is already importable from React — add it to the `import { ... } from "react"` line.)
+
+- [ ] **Step 2: Wrap the export in `React.memo` with an id+mtime comparator**
+
+Rename the function to `MessageItemImpl` (i.e., `function MessageItemImpl({ ... }: Props) {`), and at the bottom of the file add:
+```ts
+function propsEqual(a: Props, b: Props): boolean {
+  return (
+    a.message.id === b.message.id &&
+    a.message.lastModifiedDateTime === b.message.lastModifiedDateTime &&
+    a.message.__pending === b.message.__pending &&
+    a.message.__failed === b.message.__failed &&
+    a.isGroupHead === b.isGroupHead &&
+    a.contextId === b.contextId &&
+    a.contextLabel === b.contextLabel
+  );
+  // Callback props are intentionally ignored: their behavior is row-independent,
+  // so a new closure identity from the parent must not force a re-render.
+}
+
+export const MessageItem = memo(MessageItemImpl, propsEqual);
+```
+Add `memo` to the React import: `import { memo, useState, useEffect, useRef, useMemo, type KeyboardEvent } from "react";` (keep whatever else was imported). Remove the `export` keyword from the (now `Impl`) function declaration.
+
+- [ ] **Step 3: Build check** — `npm run build` → exit 0 (the `MessageItem` named export must still resolve in MessageFeed). Paste final lines.
+- [ ] **Step 4: Commit**
+```bash
+git add src/components/messages/MessageItem.tsx
+git commit -m "perf(messages): memoize MessageItem + link/markdown detection"
+```
+
+---
+
+## Task 6: MessageFeed — render-cap + load-older + smooth scroll
+
+**Files:**
+- Modify: `src/components/messages/MessageFeed.tsx`
+
+- [ ] **Step 1: Add a visible-count cap + the visible slice**
+
+After the existing `const [newMessagesCount, setNewMessagesCount] = useState(0);`, add:
+```ts
+  const INITIAL_CAP = 100;
+  const CAP_STEP = 100;
+  const [visibleCount, setVisibleCount] = useState(INITIAL_CAP);
+```
+Replace `const meta = useMemo(() => computeMeta(messages), [messages]);` with a slice + meta over the slice:
+```ts
+  const visible = useMemo(
+    () => (messages.length > visibleCount ? messages.slice(-visibleCount) : messages),
+    [messages, visibleCount]
+  );
+  const meta = useMemo(() => computeMeta(visible), [visible]);
+  const hasOlder = messages.length > visible.length;
+```
+
+- [ ] **Step 2: Render the slice + a "load older" control (with scroll preservation)**
+
+In the render, change `{messages.map((msg, idx) => (` to `{visible.map((msg, idx) => (`. Immediately before that map (after the `messages.length === 0` empty block), add the load-older button:
+```tsx
+        {hasOlder && (
+          <button
+            type="button"
+            onClick={() => {
+              const el = scrollRef.current;
+              const before = el?.scrollHeight ?? 0;
+              setVisibleCount((c) => c + CAP_STEP);
+              // Preserve scroll position: after the older rows mount, keep the
+              // previously-visible top in place instead of jumping.
+              requestAnimationFrame(() => {
+                const el2 = scrollRef.current;
+                if (el2) el2.scrollTop += el2.scrollHeight - before;
+              });
+            }}
+            className="mx-auto my-2 rounded-full border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-1 text-[12px] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+          >
+            Load older messages
+          </button>
+        )}
+```
+
+- [ ] **Step 3: Reset the cap on context change**
+
+In the existing `useEffect(() => { ... }, [contextId]);` that resets scroll state, add:
+```ts
+    setVisibleCount(INITIAL_CAP);
+```
+
+- [ ] **Step 4: Raise the cap when an anchored message is below it**
+
+In the anchor effect, before the `scroll.querySelector` lookup, ensure the anchored message is within the rendered slice — if it exists in `messages` but is older than the cap, raise the cap so the row mounts. Add right after `if (!scroll) return;`:
+```ts
+    const fullIdx = messages.findIndex((m) => m.id === anchorMessageId);
+    if (fullIdx >= 0 && messages.length - fullIdx > visibleCount) {
+      setVisibleCount(messages.length - fullIdx + 10);
+      return; // re-runs after the slice grows (messages.length dep) and the row mounts
+    }
+```
+Add `visibleCount` to that effect's dependency array.
+
+- [ ] **Step 5: Smooth scroll on live arrival**
+
+In the "React to new messages arriving" effect, change the near-bottom branch from `scrollToBottom("instant");` to `scrollToBottom("smooth");`. (Leave the initial-load scroll at `"instant"` — no animation on first open.)
+
+- [ ] **Step 6: Build check (milestone)** — `npm run build` → exit 0. Paste final lines.
+- [ ] **Step 7: Commit**
+```bash
+git add src/components/messages/MessageFeed.tsx
+git commit -m "perf(messages): render-cap long histories + load-older; smooth live scroll"
+```
+
+---
+
+## Task 7: Final integration
+
+- [ ] **Step 1: Full build + electron compile** — `npm run build && npm run electron:compile` → both exit 0.
+- [ ] **Step 2: Manual verification (two accounts / your machine)**
+  - B sends to a chat A has open → message appears **in place**, no skeleton flash; same for a channel.
+  - B edits a message → updates in place.
+  - Long history: scrolling stays smooth; "Load older messages" reveals history and holds scroll position.
+  - Block `/api/realtime/sse` (devtools) → the 30s poll still updates the feed (health falls back).
+  - Jump-to-message (search → result older than 100) scrolls to it (cap auto-raises).
+- [ ] **Step 3: Push + finish the branch** (`finishing-a-development-branch`).
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Push → upsert single message → Task 4 (Steps 2/4) + the GET routes (Task 1) + `upsertMessage` (Task 3). ✓
+- Identity-preserving merge → Task 3 Step 2. ✓
+- Adaptive poll (120s healthy / 30s unhealthy) → Task 2 (health) + Task 4 Steps 3/4. ✓
+- `React.memo` + memoized detection → Task 5. ✓
+- Render-cap (N=100) + load-older + scroll preservation → Task 6 Steps 1–3. ✓
+- Cap-raises-for-anchor → Task 6 Step 4. ✓
+- Smooth live scroll (#21) → Task 6 Step 5. ✓
+- Lossless push fallback → Task 4 Step 2 (`.catch(loadRef.current)`). ✓
+- Channel single-message route added → Task 1 Step 2. ✓ (chat GET added too — the chat route had only PATCH/DELETE.)
+- Correctness backstop (poll) unchanged in spirit → poll retained, only its cadence is health-gated. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code. The ChannelView mirror (Task 4 Step 4) describes exact changes referencing the ChatView code shown — acceptable (same code, different identifiers), not a "see Task N" dodge.
+
+**Type/name consistency:** `upsertMessage(contextId, message)` defined in Task 3, used in Task 4. `useRealtimeHealth(): boolean` defined in Task 2, used in Task 4. `MessageItem` stays a named export (Task 5 keeps the name via `export const MessageItem = memo(...)`), so MessageFeed's `import { MessageItem }` still resolves. `visible`/`visibleCount`/`hasOlder`/`INITIAL_CAP`/`CAP_STEP` consistent within Task 6. The GET routes return the raw Graph message which the client treats as `MSMessage` (same shape the list route returns).
+
+**Note:** `MSMessage.lastModifiedDateTime` is used for change-detection in Tasks 3 & 5 — it's a standard Graph chatMessage field; if a message lacks it, `undefined === undefined` makes upsert treat same-id as unchanged (safe — the reconcile poll still catches genuine edits).

--- a/docs/superpowers/specs/2026-06-11-reactivity-b2-b3-design.md
+++ b/docs/superpowers/specs/2026-06-11-reactivity-b2-b3-design.md
@@ -1,0 +1,131 @@
+# Reactivity B2/B3 — push-append + adaptive poll + cheap rendering — Design
+
+**Date:** 2026-06-11
+**Status:** Approved (design)
+**Issue:** #104 (subsumes #21). Native-feel audit **track B**; B1 (per-context loading + sidebar prefetch) already shipped (PR #75).
+
+## Problem
+
+Once the shell is fast, the remaining "feels like a refreshing web page" tells are in the message feed:
+
+1. **Every update is a full refetch + list replace.** On mount, on a 30s safety poll, and on every realtime SSE push, `ChatView`/`ChannelView` call `load()` → `GET /api/.../messages` → `setMessages(replace)`. A push (new message from someone else) triggers a whole-list re-fetch and replace — a skeleton/flash, not an in-place append.
+2. **No memoization.** `MessageItem` is a plain function and the list-replace creates all-new message objects, so **every** row re-renders on any update. Long histories get janky.
+3. **No render bound.** `MessageFeed` maps every message; very long histories render every row.
+4. **Always-on 30s poll** even when SSE is healthy — redundant network + the source of the periodic full-replace re-render.
+
+## Goal & success criteria
+
+The message view **mutates in place** instead of refetch-and-flashing:
+
+- A realtime push updates the open conversation by **upserting the single changed message** (no list replace, no skeleton).
+- The safety poll is **adaptive**: slow reconciliation when SSE is healthy, fast (today's 30s) when it isn't.
+- Rendering is cheap: `MessageItem` is memoized and unchanged rows don't re-render; long histories render a **bounded slice** (last N) with a "load older" control.
+- New-message auto-scroll is **smooth** (when already near the bottom); existing near-bottom anchoring + jump-to-message are preserved.
+- **Correctness is never weakened**: the poll remains the backstop, so a missed/failed push is always reconciled. Behavior is identical on web and desktop.
+- `npm run build` passes.
+
+## Non-goals (YAGNI)
+
+- No full windowing/virtualization library (render-cap instead).
+- No read receipts, no new realtime event types, no change to the send path or the disappearing (4s) / scheduled (5s) sweeps.
+- No offline message store changes beyond identity-preserving merge.
+
+## Established facts (from exploration)
+
+- SSE client already exists: `src/hooks/useRealtimeEvents.ts` (shared `EventSource` in `RealtimeEventsMount`, per-handler registration) — but it has **no health/reconnect signal**.
+- `ChatView.tsx` / `ChannelView.tsx`: `load()` does a full `GET messages` → `setMessages(replace)`; called on mount, `setInterval(load, 30_000)`, and from the `useRealtimeEvents` handler (`loadRef.current()`) on a matching `chat_message`/`channel_message` event.
+- Store (`src/store/workspace.ts`): has `appendMessage` + a merging `setMessages` (handles expired-filter + optimistic preservation) — but the merge takes the **fresh incoming objects** (no identity reuse).
+- `MessageItem` is **not** memoized. `MessageFeed` already tracks `isNearBottom` and only auto-scrolls when near bottom (currently `"instant"`); supports anchor/jump-to-message; **no virtualization**.
+- Single-message route **exists for chats** (`/api/chats/[chatId]/messages/[messageId]`) but **not for channels** — the plan adds the channel twin.
+
+## Decisions
+
+### A. Push → upsert one message (B2)
+The SSE event carries the `messageId`. On a matching event, fetch just that message and **upsert** it into the store — add if new, replace-in-place if edited. No list replace ⇒ no flash, and every other message keeps its object reference. Falls back to the existing full `load()` if the single-message fetch fails (lossless).
+
+### B. Identity-preserving merge (B2/B3 synergy)
+Rewrite `setMessages` so an incoming message that is unchanged (same `id` + `lastModifiedDateTime`) reuses the **existing** object reference. This keeps `React.memo` effective on both the push-upsert path and the (rare) poll reconcile. The existing expired-filter and optimistic/pending preservation are retained.
+
+### C. Adaptive poll
+The `load` interval is health-aware: **120s** when SSE is healthy (recent open connection + event flow), **30s** when unhealthy/disconnected. Disappearing (4s) and scheduled (5s) sweeps are unchanged.
+
+### D. Render-cap + memo + smooth scroll (B3)
+- `React.memo(MessageItem)`; memoize the per-message link + markdown detection (`useMemo` keyed on the message body) so it isn't recomputed each render.
+- `MessageFeed` renders only the most recent **N = 100** messages; a "Load older messages" control at the top raises the cap (e.g. +100) and preserves scroll position. Date dividers + grouping operate on the capped slice; `isNearBottom` anchoring and anchor/jump-to-message are preserved.
+- Live near-bottom auto-scroll uses `"smooth"`.
+
+## Architecture & data flow
+
+```
+RealtimeEventsMount (shared EventSource)
+  ├─ onopen → health = healthy; onerror → health = unhealthy; record lastEventAt
+  └─ dispatch event → registered handlers
+
+ChatView / ChannelView
+  ├─ useRealtimeEvents(handler):
+  │     matching {chat,channel}_message → GET single message by id
+  │          → upsertMessage(contextId, msg)        // in place, no flash
+  │          (on fetch failure → loadRef.current())  // lossless fallback
+  ├─ adaptive poll: setInterval(load, healthy ? 120_000 : 30_000)  // reconcile
+  └─ load(): GET messages → setMessages (identity-preserving merge)
+
+MessageFeed
+  └─ render last N (100); "Load older" raises cap; memo'd rows;
+     near-bottom → smooth auto-scroll; anchor/jump preserved
+```
+
+## Components & interfaces
+
+### `src/hooks/useRealtimeEvents.ts` (modify)
+- In `RealtimeEventsMount`, set `es.onopen`/`es.onerror` to update a module-level health state + `lastEventAt` (updated in `onmessage`).
+- Export `useRealtimeHealth(): { healthy: boolean }` — `healthy` = connection open AND (an event seen recently OR connection fresh). Backed by a `useSyncExternalStore` (or a tiny zustand store) so components re-render on health change.
+
+### `src/store/workspace.ts` (modify)
+- Add `upsertMessage(contextId, message)`: replace-by-id-in-place if present (keeps array slot, re-sort only if `createdDateTime` changed), else insert in sorted position; persist; preserve optimistic messages.
+- Rewrite the `setMessages` merge to reuse the existing object when `incoming.id` matches and `lastModifiedDateTime` is unchanged. Keep expired-filter + pending preservation.
+
+### `src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts` (new)
+- GET a single channel message by id via Graph, mirroring the existing chat single-message route (`/api/chats/[chatId]/messages/[messageId]`). Auth-gated like its siblings.
+
+### `src/components/messages/ChatView.tsx` / `ChannelView.tsx` (modify)
+- Realtime handler: on matching event, fetch the single message by id → `upsertMessage`; on failure, call `loadRef.current()`.
+- Poll interval: derive from `useRealtimeHealth()` (120s healthy / 30s unhealthy). Recreate the interval when health flips.
+
+### `src/components/messages/MessageItem.tsx` (modify)
+- Wrap export in `React.memo`. Ensure callback props from parents are stable (memoized); `useMemo` the link/markdown detection keyed on the message body + id.
+
+### `src/components/messages/MessageFeed.tsx` (modify)
+- Maintain a `visibleCount` (default 100); render `messages.slice(-visibleCount)`. A top "Load older messages" button increments `visibleCount` and preserves scroll position (anchor to the previous top message). Reset `visibleCount` on `contextId` change. Live auto-scroll uses `"smooth"`.
+
+## Error handling & edge cases
+
+| Condition | Behavior |
+|---|---|
+| Single-message fetch fails on push | fall back to full `loadRef.current()` (lossless) |
+| SSE drops | `onerror` → health unhealthy → poll tightens to 30s; EventSource auto-reconnects |
+| Edited message pushed | upsert replaces in place (same slot) |
+| Deleted message | caught by the reconcile poll (push doesn't carry deletes reliably) |
+| Pending/optimistic message | never hidden by the cap (it's recent); preserved by the merge |
+| Jump-to-message to an older (capped-out) message | "load older" / anchor logic raises the cap to include it (handled where the anchor effect runs) |
+| Desktop (local-first) | identical — all client-side; SSE/poll unchanged by environment |
+
+## Testing / verification
+
+`npm run build` green (real gate; no test runner). Manual:
+- Two accounts: B sends to a chat A has open → appears in-place in A, **no skeleton flash**.
+- Edit from B → updates in place.
+- Long history: scrolling stays smooth; "Load older" reveals history and holds scroll position.
+- Force SSE off (block `/api/realtime/sse`): the 30s poll still updates the feed.
+- The `useRealtimeHealth` + merge identity logic are pure-ish and unit-checkable if a runner is ever added.
+
+## File-change summary
+
+New:
+- `src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts`
+
+Modified:
+- `src/hooks/useRealtimeEvents.ts` (health signal + `useRealtimeHealth`)
+- `src/store/workspace.ts` (`upsertMessage` + identity-preserving `setMessages`)
+- `src/components/messages/ChatView.tsx`, `ChannelView.tsx` (push→upsert, adaptive poll)
+- `src/components/messages/MessageItem.tsx` (`React.memo` + memoized detection)
+- `src/components/messages/MessageFeed.tsx` (render-cap + load-older + smooth scroll)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -300,6 +300,12 @@ function createWindow(): void {
   // Reveal once the first frame is painted — the no-flash launch.
   mainWindow.once('ready-to-show', () => mainWindow?.show());
 
+  // Desktop apps don't pinch-zoom the whole UI like a web page — clamp the
+  // visual (trackpad/ctrl-scroll) zoom to 1 so the chrome stays put.
+  mainWindow.webContents.on('did-finish-load', () => {
+    void mainWindow?.webContents.setVisualZoomLevelLimits(1, 1);
+  });
+
   // If the app URL can't be reached (offline / host down), show a branded retry
   // page instead of a raw Chromium error, and make sure the window is visible
   // (ready-to-show may never fire when the very first load fails).

--- a/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
+++ b/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
@@ -45,6 +45,28 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
   }
 }
 
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const session = await auth();
+  if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { chatId, messageId } = await params;
+  try {
+    const res = await fetch(
+      `https://graph.microsoft.com/v1.0/chats/${chatId}/messages/${messageId}`,
+      { headers: { Authorization: `Bearer ${session.accessToken}` } }
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error("Graph get chat message failed", res.status, text);
+      return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+    }
+    return NextResponse.json(await res.json());
+  } catch (err) {
+    console.error("Graph get chat message error", err);
+    return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+  }
+}
+
 export async function DELETE(_req: Request, { params }: { params: Params }) {
   const session = await auth();
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts
+++ b/src/app/api/teams/[teamId]/channels/[channelId]/messages/[messageId]/route.ts
@@ -1,0 +1,26 @@
+import { auth } from "@/lib/auth/config";
+import { NextResponse } from "next/server";
+
+type Params = Promise<{ teamId: string; channelId: string; messageId: string }>;
+
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const session = await auth();
+  if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { teamId, channelId, messageId } = await params;
+  try {
+    const res = await fetch(
+      `https://graph.microsoft.com/v1.0/teams/${teamId}/channels/${channelId}/messages/${messageId}`,
+      { headers: { Authorization: `Bearer ${session.accessToken}` } }
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error("Graph get channel message failed", res.status, text);
+      return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+    }
+    return NextResponse.json(await res.json());
+  } catch (err) {
+    console.error("Graph get channel message error", err);
+    return NextResponse.json({ error: "Graph get failed" }, { status: 502 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,14 @@ button:disabled,
   cursor: not-allowed;
 }
 
+/* ─── Native-app feel ───────────────────────────────────────────────────
+   No rubber-band overscroll / pull-to-refresh, and the document itself never
+   scrolls (panes scroll internally) — chat panes feel like an app, not a page. */
+html,
+body {
+  overscroll-behavior: none;
+}
+
 /* ─── Base design tokens (dark — app ships dark-first) ──────────────────── */
 :root {
   /* Backgrounds */

--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -177,7 +177,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
           event.teamId === teamId &&
           event.channelId === channelId
         ) {
-          fetch(`/api/teams/${teamId}/channels/${channelId}/messages/${event.messageId}`)
+          fetch(`/api/teams/${teamId}/channels/${channelId}/messages/${encodeURIComponent(event.messageId)}`)
             .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
             .then((msg: MSMessage) => upsertMessage(contextId, msg))
             .catch(() => void loadRef.current());

--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -17,7 +17,7 @@ import { useMemberPanelStore } from "@/store/memberPanel";
 import { openTeamsChannelMeeting } from "@/lib/utils/teams-deeplink";
 import { markdownToHtml } from "@/lib/utils/markdown-to-html";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
-import { useRealtimeEvents } from "@/hooks/useRealtimeEvents";
+import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 
 export function ChannelView({ teamId, channelId }: { teamId: string; channelId: string }) {
@@ -41,6 +41,8 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
   const loadingThisChannel = useWorkspaceStore(
     (s) => s.loadingContexts[`${teamId}:${channelId}`] ?? false,
   );
+  const upsertMessage = useWorkspaceStore((s) => s.upsertMessage);
+  const sseHealthy = useRealtimeHealth();
   const [threadMessage, setThreadMessage] = useState<MSMessage | null>(null);
   const [forwardMessage, setForwardMessage] = useState<MSMessage | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("messages");
@@ -132,8 +134,9 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     loadRef.current = load;
     load();
 
-    // Webhook push is primary; poll kept at 30s as safety net for missed events.
-    const interval = setInterval(load, 30_000);
+    // Webhook push is primary; when SSE is healthy, poll less frequently (2 min)
+    // and fall back to 30 s when SSE is degraded.
+    const interval = setInterval(load, sseHealthy ? 120_000 : 30_000);
 
     // Disappearing-message sweep on a fast cadence (network-free unless one of
     // our own messages has actually expired) — matches the DM view's behavior.
@@ -164,7 +167,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamId, channelId, contextId, isHydrated, setContextLoading, setMessages, showToast, sweepExpired]);
+  }, [teamId, channelId, contextId, isHydrated, sseHealthy, setContextLoading, setMessages, showToast, sweepExpired]);
 
   useRealtimeEvents(
     useCallback(
@@ -174,10 +177,13 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
           event.teamId === teamId &&
           event.channelId === channelId
         ) {
-          void loadRef.current();
+          fetch(`/api/teams/${teamId}/channels/${channelId}/messages/${event.messageId}`)
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+            .then((msg: MSMessage) => upsertMessage(contextId, msg))
+            .catch(() => void loadRef.current());
         }
       },
-      [teamId, channelId]
+      [teamId, channelId, contextId, upsertMessage]
     )
   );
 

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -301,7 +301,7 @@ export function ChatView({ chatId }: { chatId: string }) {
     useCallback(
       (event) => {
         if (event.type === "chat_message" && event.chatId === chatId) {
-          fetch(`/api/chats/${chatId}/messages/${event.messageId}`)
+          fetch(`/api/chats/${chatId}/messages/${encodeURIComponent(event.messageId)}`)
             .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
             .then((msg: MSMessage) => upsertMessage(chatId, msg))
             .catch(() => void loadRef.current());

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -18,7 +18,7 @@ import { openTeamsCall } from "@/lib/utils/teams-deeplink";
 import { getChatLabel } from "@/lib/utils/chat-label";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
-import { useRealtimeEvents } from "@/hooks/useRealtimeEvents";
+import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
 import { useScheduledStore } from "@/store/scheduled";
 
 export function ChatView({ chatId }: { chatId: string }) {
@@ -45,6 +45,8 @@ export function ChatView({ chatId }: { chatId: string }) {
   const isHydrated = useWorkspaceStore((s) => s.isHydrated);
   // First-load flag for THIS chat only — a cached chat never shows the skeleton.
   const loadingThisChat = useWorkspaceStore((s) => s.loadingContexts[chatId] ?? false);
+  const upsertMessage = useWorkspaceStore((s) => s.upsertMessage);
+  const sseHealthy = useRealtimeHealth();
   const scheduledMessages = useScheduledStore((s) => s.scheduled);
   const addScheduled = useScheduledStore((s) => s.addScheduled);
   const removeScheduled = useScheduledStore((s) => s.removeScheduled);
@@ -252,8 +254,9 @@ export function ChatView({ chatId }: { chatId: string }) {
     loadRef.current = load;
     load();
 
-    // Webhook push is primary; poll kept at 30s as safety net for missed events.
-    const interval = setInterval(load, 30_000);
+    // Webhook push is primary; when SSE is healthy, poll less frequently (2 min)
+    // and fall back to 30 s when SSE is degraded.
+    const interval = setInterval(load, sseHealthy ? 120_000 : 30_000);
 
     // Disappearing-message sweep stays on a fast cadence, decoupled from the
     // message fetch. It's network-free unless one of our own messages has
@@ -292,16 +295,19 @@ export function ChatView({ chatId }: { chatId: string }) {
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatId, isHydrated, setContextLoading, setMessages, showToast, sweepExpired, sweepScheduled]);
+  }, [chatId, isHydrated, sseHealthy, setContextLoading, setMessages, showToast, sweepExpired, sweepScheduled]);
 
   useRealtimeEvents(
     useCallback(
       (event) => {
         if (event.type === "chat_message" && event.chatId === chatId) {
-          void loadRef.current();
+          fetch(`/api/chats/${chatId}/messages/${event.messageId}`)
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+            .then((msg: MSMessage) => upsertMessage(chatId, msg))
+            .catch(() => void loadRef.current());
         }
       },
-      [chatId]
+      [chatId, upsertMessage]
     )
   );
 

--- a/src/components/messages/MessageFeed.tsx
+++ b/src/components/messages/MessageFeed.tsx
@@ -76,6 +76,10 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [newMessagesCount, setNewMessagesCount] = useState(0);
 
+  const INITIAL_CAP = 100;
+  const CAP_STEP = 100;
+  const [visibleCount, setVisibleCount] = useState(INITIAL_CAP);
+
   useSmartNotifications({ messages, contextName, contextId, contextKind, currentUserId });
 
   // Detect whether the user is near the bottom of the scroll container.
@@ -110,6 +114,7 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
     prevMessageCountRef.current = 0;
     setIsNearBottom(true);
     setNewMessagesCount(0);
+    setVisibleCount(INITIAL_CAP);
   }, [contextId]);
 
   // On initial load or context change: once messages are present and not
@@ -134,7 +139,7 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
     if (curr > prev) {
       const incoming = curr - prev;
       if (isNearBottom) {
-        scrollToBottom("instant");
+        scrollToBottom("smooth");
       } else {
         setNewMessagesCount((n) => n + incoming);
       }
@@ -172,6 +177,13 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
     // array changing under it.
     const scroll = scrollRef.current;
     if (!scroll) return;
+
+    const fullIdx = messages.findIndex((m) => m.id === anchorMessageId);
+    if (fullIdx >= 0 && messages.length - fullIdx > visibleCount) {
+      setVisibleCount(messages.length - fullIdx + 10);
+      return; // re-runs after the slice grows (messages.length / visibleCount dep) and the row mounts
+    }
+
     const node = scroll.querySelector<HTMLElement>(
       `[data-message-id="${cssEscape(anchorMessageId)}"]`
     );
@@ -198,9 +210,14 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
     return () => window.clearTimeout(giveUp);
     // Re-run when the array length changes so we re-try once the target row
     // is added by a polling refetch.
-  }, [anchorMessageId, loading, messages.length, onAnchorConsumed]);
+  }, [anchorMessageId, loading, messages, messages.length, onAnchorConsumed, visibleCount]);
 
-  const meta = useMemo(() => computeMeta(messages), [messages]);
+  const visible = useMemo(
+    () => (messages.length > visibleCount ? messages.slice(-visibleCount) : messages),
+    [messages, visibleCount]
+  );
+  const meta = useMemo(() => computeMeta(visible), [visible]);
+  const hasOlder = messages.length > visible.length;
 
   // Show skeleton only on first load (no messages yet). During background
   // polling refreshes (loading=true but messages already present) keep the
@@ -221,7 +238,24 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
             No messages yet. Say hello!
           </div>
         )}
-        {messages.map((msg, idx) => (
+        {hasOlder && (
+          <button
+            type="button"
+            onClick={() => {
+              const el = scrollRef.current;
+              const before = el?.scrollHeight ?? 0;
+              setVisibleCount((c) => c + CAP_STEP);
+              requestAnimationFrame(() => {
+                const el2 = scrollRef.current;
+                if (el2) el2.scrollTop += el2.scrollHeight - before;
+              });
+            }}
+            className="mx-auto my-2 rounded-full border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-1 text-[12px] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+          >
+            Load older messages
+          </button>
+        )}
+        {visible.map((msg, idx) => (
           <Fragment key={msg.id}>
             {meta[idx].showDivider && <DateDivider date={msg.createdDateTime} />}
             <MessageItem

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { format } from "date-fns";
-import { useState, useEffect, useRef, type KeyboardEvent } from "react";
+import { memo, useState, useEffect, useRef, useMemo, type KeyboardEvent } from "react";
 import { Clock, CheckCheck } from "lucide-react";
 import TextareaAutosize from "react-textarea-autosize";
 import { Avatar } from "@/components/ui/Avatar";
@@ -75,7 +75,7 @@ function DisappearBadge({ disappearAt }: { disappearAt: number }) {
   );
 }
 
-export function MessageItem({
+function MessageItemImpl({
   message,
   isGroupHead = true,
   contextId,
@@ -227,6 +227,17 @@ export function MessageItem({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expired, message.id]);
 
+  // Hoist content + detection above early returns so hooks are always called
+  // unconditionally (React rules of hooks).
+  const content = messagePlainText(message.body.content, message.body.contentType);
+  const detection = useMemo(
+    () => ({
+      github: detectGitHubLinks(content),
+      richLinks: detectRichLinks(content),
+    }),
+    [content, message.id]
+  );
+
   if (message.deletedDateTime) return null;
   if (expired) return null;
 
@@ -238,7 +249,6 @@ export function MessageItem({
   // Pending/failed messages suppress the full toolbar — retry/discard shown instead.
   const deleteHandler = isOwn && !message.__pending && !message.__failed ? onDelete : undefined;
   const editHandler = isOwn && !message.__pending && !message.__failed ? onEdit : undefined;
-  const content = messagePlainText(message.body.content, message.body.contentType);
 
   const pollVotingDisabled = Boolean(message.__pending || message.__failed) || !onToggleReaction;
   // Single-choice voting: toggling an option you've already picked clears it;
@@ -442,8 +452,8 @@ export function MessageItem({
                     <DisappearBadge disappearAt={decoded.disappearAt} />
                   )}
                 </div>
-                <GitHubCards text={content} />
-                <RichLinkCards text={content} />
+                <GitHubCards links={detection.github} />
+                <RichLinkCards links={detection.richLinks} />
               </>
             )
           )}
@@ -534,7 +544,7 @@ export function MessageItem({
               {disappearing && decoded && decoded.disappearAt > Date.now() && (
                 <DisappearBadge disappearAt={decoded.disappearAt} />
               )}
-              <GitHubCards text={content} />
+              <GitHubCards links={detection.github} />
             </>
           )
         )}
@@ -552,8 +562,7 @@ export function MessageItem({
   );
 }
 
-function GitHubCards({ text }: { text: string }) {
-  const links = detectGitHubLinks(text);
+function GitHubCards({ links }: { links: ReturnType<typeof detectGitHubLinks> }) {
   if (links.length === 0) return null;
   return (
     <div className="mt-1 flex flex-col gap-2">
@@ -562,8 +571,7 @@ function GitHubCards({ text }: { text: string }) {
   );
 }
 
-function RichLinkCards({ text }: { text: string }) {
-  const links = detectRichLinks(text);
+function RichLinkCards({ links }: { links: ReturnType<typeof detectRichLinks> }) {
   if (links.length === 0) return null;
   return (
     <div className="mt-1 flex flex-col gap-2">
@@ -638,3 +646,19 @@ function ReactionsRow({
     </div>
   );
 }
+
+function propsEqual(a: Props, b: Props): boolean {
+  // Callback props are intentionally ignored: their behavior is row-independent,
+  // so a new closure identity from the parent must not force a re-render.
+  return (
+    a.message.id === b.message.id &&
+    a.message.lastModifiedDateTime === b.message.lastModifiedDateTime &&
+    a.message.__pending === b.message.__pending &&
+    a.message.__failed === b.message.__failed &&
+    a.isGroupHead === b.isGroupHead &&
+    a.contextId === b.contextId &&
+    a.contextLabel === b.contextLabel
+  );
+}
+
+export const MessageItem = memo(MessageItemImpl, propsEqual);

--- a/src/hooks/useRealtimeEvents.ts
+++ b/src/hooks/useRealtimeEvents.ts
@@ -1,14 +1,37 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import type { RealtimeEvent } from "@/lib/realtime/pubsub";
 
 type Handler = (event: RealtimeEvent) => void;
 
-// Module-level set so all hook instances share one EventSource connection
-// created by RealtimeEventsMount. Handlers are registered/deregistered per
-// component lifecycle without tearing down the underlying SSE stream.
 const handlers = new Set<Handler>();
+
+// ---- Health (so views can slow their reconcile poll when push is live) ------
+let connected = false;
+const healthListeners = new Set<() => void>();
+
+function emitHealth() {
+  for (const l of healthListeners) l();
+}
+function setConnected(v: boolean) {
+  if (connected !== v) { connected = v; emitHealth(); }
+}
+
+// "Healthy" = SSE connection is open. Push delivery is best-effort; the
+// reconcile poll is the backstop, so open-connection is a sufficient signal
+// to slow the poll.
+function isHealthy(): boolean {
+  return connected;
+}
+
+export function useRealtimeHealth(): boolean {
+  return useSyncExternalStore(
+    (cb) => { healthListeners.add(cb); return () => healthListeners.delete(cb); },
+    isHealthy,
+    () => false, // SSR: assume unhealthy → views use the fast poll until hydrated
+  );
+}
 
 export function useRealtimeEvents(handler: Handler) {
   useEffect(() => {
@@ -20,6 +43,8 @@ export function useRealtimeEvents(handler: Handler) {
 export function RealtimeEventsMount() {
   useEffect(() => {
     const es = new EventSource("/api/realtime/sse");
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false); // EventSource auto-reconnects; onopen flips back
     es.onmessage = (e) => {
       let event: RealtimeEvent;
       try {
@@ -29,7 +54,7 @@ export function RealtimeEventsMount() {
       }
       for (const h of handlers) h(event);
     };
-    return () => { es.close(); };
+    return () => { es.close(); setConnected(false); };
   }, []);
   return null;
 }

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -349,6 +349,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             );
             return {
               ...message,
+              // Bump so the memoized MessageItem (compares lastModifiedDateTime)
+              // re-renders this optimistic change; reconciled by the next poll.
+              lastModifiedDateTime: new Date().toISOString(),
               reactions: reaction
                 ? reactions.filter((r) => r !== reaction)
                 : [
@@ -411,7 +414,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             index,
           };
           const next = [...existing];
-          next[index] = { ...msg, body: { contentType: "html", content: newContent } };
+          next[index] = {
+            ...msg,
+            lastModifiedDateTime: new Date().toISOString(),
+            body: { contentType: "html", content: newContent },
+          };
           persistContext(contextId, next);
           return {
             messagesByContext: { ...s.messagesByContext, [contextId]: next },
@@ -428,6 +435,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const next = [...existing];
           next[index] = {
             ...next[index],
+            lastModifiedDateTime: new Date().toISOString(),
             body: { contentType: previousContentType, content: previousContent },
           };
           persistContext(contextId, next);

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -92,6 +92,10 @@ interface WorkspaceState {
    */
   setMessages: (contextId: string, messages: MSMessage[]) => void;
   appendMessage: (contextId: string, message: MSMessage) => void;
+  /** Add a single message if new, or replace it in place if it already exists
+   * (by id). Preserves the array slot + every other message's object identity
+   * so memoized rows don't re-render. Used by the realtime push path. */
+  upsertMessage: (contextId: string, message: MSMessage) => void;
   appendPendingMessage: (contextId: string, message: MSMessage) => void;
   replaceMessage: (contextId: string, tempId: string, serverMessage: MSMessage) => void;
   markMessageFailed: (contextId: string, tempId: string) => void;
@@ -203,7 +207,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const pending = existing.filter((m) => m.__pending || m.__failed);
           const serverIds = new Set(filtered.map((m) => m.id));
           const uniquePending = pending.filter((m) => !serverIds.has(m.id));
-          const merged = trimToMax(sortByCreatedDateTime([...filtered, ...uniquePending]));
+          // Reuse the existing object for any message whose id + lastModified
+          // are unchanged, so React.memo'd rows don't re-render on reconcile.
+          const byId = new Map(existing.map((m) => [m.id, m]));
+          const reused = filtered.map((m) => {
+            const prev = byId.get(m.id);
+            return prev && prev.lastModifiedDateTime === m.lastModifiedDateTime ? prev : m;
+          });
+          const merged = trimToMax(sortByCreatedDateTime([...reused, ...uniquePending]));
           persistContext(contextId, merged);
           return {
             messagesByContext: { ...s.messagesByContext, [contextId]: merged },
@@ -231,6 +242,24 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           return {
             messagesByContext: { ...s.messagesByContext, [contextId]: next },
           };
+        }),
+
+      upsertMessage: (contextId, message) =>
+        set((s) => {
+          if (s.expiredMessageIds.has(message.id)) return s;
+          const existing = s.messagesByContext[contextId] ?? [];
+          const idx = existing.findIndex((m) => m.id === message.id);
+          let next: MSMessage[];
+          if (idx >= 0) {
+            if (existing[idx].lastModifiedDateTime === message.lastModifiedDateTime) return s;
+            next = [...existing];
+            next[idx] = message;
+            next = sortByCreatedDateTime(next);
+          } else {
+            next = trimToMax(sortByCreatedDateTime([...existing, message]));
+          }
+          persistContext(contextId, next);
+          return { messagesByContext: { ...s.messagesByContext, [contextId]: next } };
         }),
 
       appendPendingMessage: (contextId, message) =>


### PR DESCRIPTION
Two native-feel improvements (build + electron:compile green; web/Electron only — hosted path unaffected).

## Reactivity B2/B3 (Closes #104, Closes #21)
The message feed now updates **in place** instead of refetch-and-flash:
- Realtime push **upserts the single changed message** (new single-message GET routes for chats + channels) — no skeleton flash.
- Reconcile poll is **SSE-health-aware** (120s when push is live, 30s when not) via a new `useRealtimeHealth` signal.
- Store: `upsertMessage` + identity-preserving `setMessages` merge (reuses unchanged objects so memoized rows don't re-render).
- `MessageItem` is **memoized** (+ memoized link/markdown detection); optimistic reactions/poll-votes/edits stamp `lastModifiedDateTime` so they still re-render under the memo.
- `MessageFeed` **render-caps** to the last 100 with "load older" (scroll-preserving), smooth live scroll, and raises the cap for an off-screen jump-to-message target (#21).

## De-web-ify
- `overscroll-behavior: none` — no rubber-band / pull-to-refresh.
- Electron `setVisualZoomLevelLimits(1, 1)` — desktop UI doesn't pinch-zoom like a web page.

## Test plan
- [ ] Two accounts: B sends/edits in a chat A has open → updates in place, no skeleton flash (chat + channel).
- [ ] Long history scrolls smoothly; "Load older" reveals history and holds position.
- [ ] Block /api/realtime/sse → 30s poll still updates.
- [ ] Jump-to-message to an old result scrolls to it.
- [ ] (Desktop) no rubber-band overscroll; pinch-zoom doesn't scale the UI.