### PR TITLE
fix: launch-readiness (realtime auth, MCP docs, dead menu item)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ claude mcp add teamsly -- npx -y @teamsly/mcp
 | `list_channels` | List channels in a team |
 | `get_channel_messages` | Read messages from a channel |
 | `send_channel_message` | Post to a channel |
+| `find_people` | Search your organization's directory for a person |
+| `send_dm` | Send a direct message to someone by name or user ID |
 
-For self-hosted deployments, replace `TEAMSLY_BASE_URL` with your own URL and set `TEAMSLY_MCP_SECRET` to the value of your `TEAMSLY_MCP_SECRET` environment variable.
+To point the server at your own Azure app instead of the public Teamsly one, set `TEAMSLY_CLIENT_ID` and `TEAMSLY_TENANT_ID` (they default to Teamsly's app on the `common` tenant). Tokens are cached in `~/.config/teamsly-mcp/`; override the location with `TEAMSLY_TOKEN_DIR`.
 
 ## Architecture
 

--- a/src/app/api/realtime/sse/route.ts
+++ b/src/app/api/realtime/sse/route.ts
@@ -7,11 +7,11 @@ export const maxDuration = 300;
 
 export async function GET(req: Request) {
   const session = await auth();
-  if (!session?.user?.id) {
+  if (!session?.userId) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const userId = session.user.id;
+  const userId = session.userId;
 
   const stream = new ReadableStream({
     async start(controller) {

--- a/src/app/api/realtime/subscribe/route.ts
+++ b/src/app/api/realtime/subscribe/route.ts
@@ -11,7 +11,7 @@ const REUSE_IF_REMAINING_MS = 15 * 60 * 1000;
 
 export async function POST(req: Request) {
   const session = await auth();
-  if (!session?.accessToken || !session.user?.id) {
+  if (!session?.accessToken || !session.userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
     chatId?: string;
   };
   const { teamId, channelId, chatId } = body;
-  const userId = session.user.id;
+  const userId = session.userId;
   const now = Date.now();
 
   // Per-subscription secret. Graph echoes it in every notification; the webhook

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useWorkspaceStore } from "@/store/workspace";
 import { useRouter, useParams } from "next/navigation";
-import { Hash, Lock, MessageSquare, ChevronDown, ChevronRight, Plus, Search, Settings, UserPlus, Moon, LogOut, Inbox, GitBranch, Star, Check, Circle, CircleDot, BellOff, Clock, CircleOff, Smile, MessageCircleQuestion, MoreHorizontal, MailOpen, Mail, CheckCheck } from "lucide-react";
+import { Hash, Lock, MessageSquare, ChevronDown, ChevronRight, Plus, Search, Settings, Moon, LogOut, Inbox, GitBranch, Star, Check, Circle, CircleDot, BellOff, Clock, CircleOff, Smile, MessageCircleQuestion, MoreHorizontal, MailOpen, Mail, CheckCheck } from "lucide-react";
 import { useState, useEffect, useRef, useCallback } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { signOut } from "next-auth/react";
@@ -524,16 +524,6 @@ export function Sidebar() {
             >
               <Settings className="h-4 w-4 flex-shrink-0" />
               Preferences
-            </DropdownMenu.Item>
-
-            <DropdownMenu.Item
-              onSelect={() => {
-                // TODO: open invite people flow
-              }}
-              className="flex cursor-pointer items-center gap-2.5 px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-75 data-[highlighted]:bg-[var(--accent)] data-[highlighted]:text-white"
-            >
-              <UserPlus className="h-4 w-4 flex-shrink-0" />
-              Invite people
             </DropdownMenu.Item>
 
             <DropdownMenu.Sub>


### PR DESCRIPTION
Fixes from a production-grade pre-launch audit (#88).

## P0 — realtime push was broken in production
The realtime SSE + subscribe routes gated on `session.user.id`, but the auth callback only sets `session.userId` (the Entra sub). So every authenticated request returned 401 and realtime push **silently fell back to polling for all users** — the headline "real-time" feature was effectively off in prod. Both routes now use `session.userId`, matching the AI routes.

## P0 (docs) — MCP self-hosting env vars were wrong
The README told self-hosters to set `TEAMSLY_BASE_URL` / `TEAMSLY_MCP_SECRET`, which **don't exist** in the published `@teamsly/mcp` server — it uses `TEAMSLY_CLIENT_ID` / `TEAMSLY_TENANT_ID` / `TEAMSLY_TOKEN_DIR`. Corrected. Also added the two shipped tools the table omitted (`find_people`, `send_dm`) — 9 tools total.

## P2 — dead menu item
Removed the no-op "Invite people" dropdown item (and its now-unused icon import).

## Verified
- `npm run build` (Next 16 / Turbopack) — green, 42/42 pages
- `npm run electron:compile` — green

Config-only items from the audit (not code) are tracked for the owner: confirm Upstash Redis (AI quota fails open without it), `GITHUB_TOKEN`, and `TENOR_API_KEY` are set in Vercel prod.