### PR TITLE
feat(gifs): migrate GIF search from Tenor to Klipy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ AI_DAILY_REQUEST_LIMIT=50
 # Optional — higher GitHub API rate limit for PR/issue cards (60/hr without, 5000/hr with)
 GITHUB_TOKEN=
 
+# Optional — GIF picker (the /giphy command + composer GIF button). Without it,
+# the picker returns no results. Free, no usage caps — get a key at
+# https://klipy.com/developers (the public Tenor API was shut down by Google).
+KLIPY_API_KEY=
+
 # Real-time channel messages via Graph webhooks need these Microsoft Graph permissions:
 # - ChannelMessage.Read.All (delegated)
 # Subscriptions require the app to be publicly reachable.

--- a/src/app/api/gifs/search/route.ts
+++ b/src/app/api/gifs/search/route.ts
@@ -1,41 +1,99 @@
 import { auth } from "@/lib/auth/config";
 import { NextRequest, NextResponse } from "next/server";
 
-// Tenor's officially documented demo key — published in their own API docs for
-// development and low-traffic use. Override with TENOR_API_KEY in .env.local
-// to use a dedicated key (free at console.cloud.google.com → Tenor API).
-const TENOR_KEY = process.env.TENOR_API_KEY ?? "LIVDSRZULELA096";
+// GIF search via the Klipy API. Google shut down the public Tenor API
+// (hard cutoff 2026-06-30, no new keys), so we moved off it. Klipy is a
+// near-Tenor, lifetime-free GIF API — get a key at https://klipy.com/developers
+// and set KLIPY_API_KEY. The key is passed as a URL path segment.
+const KLIPY_KEY = process.env.KLIPY_API_KEY ?? "";
+const KLIPY_BASE = "https://api.klipy.com/api/v1";
+
+// One format variant inside a Klipy item, e.g. file.hd.gif = { url, width, height }.
+type GifFormat = { url?: string; width?: number; height?: number };
+// tier ("hd"|"md"|"sm"|"xs") -> format ("gif"|"mp4"|"jpg"|...) -> variant
+type KlipyFile = Record<string, Record<string, GifFormat> | undefined>;
+interface KlipyItem {
+  id?: string | number;
+  title?: string;
+  file?: KlipyFile;
+  files?: KlipyFile;
+}
+
+// Shape the GIF picker (GifPicker.tsx) expects — kept stable across providers.
+interface MediaFormat {
+  url: string;
+  dims: [number, number];
+}
+
+// Pick the first available .gif variant across the given size tiers, with a
+// fallback for payloads that nest the format directly under `file` (no tier).
+function pickGif(file: KlipyFile | undefined, tiers: string[]): GifFormat | undefined {
+  if (!file) return undefined;
+  for (const t of tiers) {
+    const g = file[t]?.gif;
+    if (g?.url) return g;
+  }
+  const flat = (file as unknown as Record<string, GifFormat>).gif;
+  return flat?.url ? flat : undefined;
+}
+
+function toMediaFormat(g: GifFormat | undefined): MediaFormat | undefined {
+  if (!g?.url) return undefined;
+  return { url: g.url, dims: [g.width ?? 0, g.height ?? 0] };
+}
 
 export async function GET(req: NextRequest) {
-  // Gate behind a session so anonymous traffic can't burn the Tenor key.
+  // Gate behind a session so anonymous traffic can't burn the Klipy key.
   const session = await auth();
   if (!session?.accessToken) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  // Not configured: return a graceful empty result so the picker shows its
+  // empty state instead of erroring.
+  if (!KLIPY_KEY) {
+    return NextResponse.json({ results: [] });
+  }
+
   const q = req.nextUrl.searchParams.get("q") ?? "";
-  const limit = Math.min(Number(req.nextUrl.searchParams.get("limit") ?? "20"), 50);
-  const pos = req.nextUrl.searchParams.get("pos") ?? "";
+  const perPage = Math.min(Math.max(Number(req.nextUrl.searchParams.get("limit") ?? "24"), 8), 50);
+  const page = req.nextUrl.searchParams.get("page") ?? "1";
 
-  const endpoint = q
-    ? "https://api.tenor.com/v1/search"
-    : "https://api.tenor.com/v1/trending";
-
-  const url = new URL(endpoint);
-  url.searchParams.set("key", TENOR_KEY);
-  url.searchParams.set("limit", String(limit));
-  url.searchParams.set("contentfilter", "medium");
-  url.searchParams.set("media_filter", "minimal");
+  const url = new URL(`${KLIPY_BASE}/${KLIPY_KEY}/gifs/${q ? "search" : "trending"}`);
+  url.searchParams.set("per_page", String(perPage));
+  url.searchParams.set("page", page);
   if (q) url.searchParams.set("q", q);
-  if (pos) url.searchParams.set("pos", pos);
 
   try {
     const res = await fetch(url.toString(), { next: { revalidate: 30 } });
     if (!res.ok) {
-      return NextResponse.json({ error: "Tenor error", status: res.status }, { status: 502 });
+      return NextResponse.json({ error: "Klipy error", status: res.status }, { status: 502 });
     }
-    const data = await res.json();
-    return NextResponse.json(data);
+    const json = await res.json();
+    // Klipy wraps results as { result, data: { data: [...] } }; some payloads
+    // return the array directly under `data`. Handle both.
+    const raw = (json as { data?: unknown })?.data;
+    const items: KlipyItem[] = Array.isArray(raw)
+      ? (raw as KlipyItem[])
+      : ((raw as { data?: KlipyItem[] })?.data ?? []);
+
+    const results = items
+      .map((it) => {
+        const file = it.file ?? it.files;
+        const full = toMediaFormat(pickGif(file, ["hd", "md", "sm", "xs"]));
+        const preview = toMediaFormat(pickGif(file, ["sm", "xs", "md", "hd"]));
+        const gif = full ?? preview;
+        const tinygif = preview ?? full;
+        if (!gif || !tinygif) return null;
+        return {
+          id: String(it.id ?? gif.url),
+          title: it.title ?? "",
+          media: [{ gif, tinygif }],
+        };
+      })
+      .filter(Boolean);
+
+    return NextResponse.json({ results });
   } catch {
     return NextResponse.json({ error: "Failed to fetch GIFs" }, { status: 502 });
   }

--- a/src/components/messages/GifPicker.tsx
+++ b/src/components/messages/GifPicker.tsx
@@ -5,7 +5,7 @@ import * as Popover from "@radix-ui/react-popover";
 import { Search, Loader2 } from "lucide-react";
 import { useDebounce } from "@/lib/hooks/useDebounce";
 
-interface TenorGif {
+interface GifResult {
   id: string;
   title: string;
   media: Array<{
@@ -23,7 +23,7 @@ interface Props {
 export function GifPicker({ children, onSelect }: Props) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [gifs, setGifs] = useState<TenorGif[]>([]);
+  const [gifs, setGifs] = useState<GifResult[]>([]);
   const [loading, setLoading] = useState(false);
   const debouncedQuery = useDebounce(query, 400);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -117,7 +117,7 @@ export function GifPicker({ children, onSelect }: Props) {
           </div>
 
           <div className="border-t border-[var(--border)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
-            Powered by Tenor
+            Powered by Klipy
           </div>
         </Popover.Content>
       </Popover.Portal>


### PR DESCRIPTION
## Why
Google is shutting down the **public Tenor API** — deprecated Jan 2026, **hard cutoff June 30, 2026**, and **new key registration is already closed**. The GIF picker ran on Tenor's shared demo key (`api.tenor.com/v1`), so it was going to break entirely and *couldn't* be fixed with a new Tenor key.

## What
Migrate to **Klipy** — a lifetime-free GIF API (no usage caps, ad-supported) with a near-Tenor surface, built by ex-Tenor folks and already used by WhatsApp/Canva/Figma.

- `gifs/search/route.ts` now calls `https://api.klipy.com/api/v1/{KLIPY_API_KEY}/gifs/{search,trending}` and **normalizes Klipy's `{ data: { data: [...] } }` response into the shape `GifPicker` already consumes** (`results[].media[].gif/tinygif → {url, dims}`). So the frontend only changes its attribution footer.
- Defensive mapping: walks `file.{hd,md,sm,xs}.gif`, tolerates a flat `file.gif`, and accepts `file`/`files`.
- Returns an empty result (graceful empty state) when `KLIPY_API_KEY` is unset.
- `.env.example` documents `KLIPY_API_KEY`.

## ⚠️ Needs a key to verify
Klipy's official docs are bot-blocked, so the response mapping is derived from a real third-party Klipy client + docs hints, **not yet verified against the live API**. Before relying on it: get a free key at https://klipy.com/developers, set `KLIPY_API_KEY` (local + Vercel), and test the picker. If GIFs don't render, the `file` tier/format field names differ — send a sample response and it's a 2-minute mapping fix.

## Verified
- `npm run build` (Next 16 / Turbopack) — green.