### PR TITLE
fix(messages): restore three-dots menu, fix composer popover layering

### DIFF
--- a/src/components/messages/MessageHoverToolbar.tsx
+++ b/src/components/messages/MessageHoverToolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { forwardRef, type ComponentPropsWithoutRef } from "react";
 import { Bookmark, Smile, MessageSquare, Forward, Pin, MoreHorizontal, Trash2, Pencil, type LucideIcon } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { EmojiPicker } from "./EmojiPicker";
@@ -92,28 +93,36 @@ export function MessageHoverToolbar({
   );
 }
 
-interface ToolbarButtonProps {
+interface ToolbarButtonProps extends ComponentPropsWithoutRef<"button"> {
   icon: LucideIcon;
   label: string;
-  onClick?: () => void;
   /** Visual press-state; used by Save-for-later to indicate the message is bookmarked. */
   active?: boolean;
 }
 
-function ToolbarButton({ icon: Icon, label, onClick, active }: ToolbarButtonProps) {
+// forwardRef + prop spread so this works as a Radix `asChild` trigger: the
+// dropdown/popover injects onPointerDown/onKeyDown/ref onto its child, and a
+// plain component that only re-wired onClick silently dropped them (which left
+// the "More actions" DropdownMenu unopenable — it opens on pointerdown, not click).
+const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(function ToolbarButton(
+  { icon: Icon, label, active, className, ...rest },
+  ref
+) {
   return (
     <button
+      ref={ref}
       type="button"
-      onClick={onClick}
       aria-label={label}
       aria-pressed={active ?? undefined}
       title={label}
       className={cn(
         "flex h-7 w-7 items-center justify-center rounded transition-colors duration-100 hover:bg-[var(--surface-hover)] hover:text-white focus-ring",
-        active ? "text-[var(--accent)]" : "text-[var(--text-secondary)]"
+        active ? "text-[var(--accent)]" : "text-[var(--text-secondary)]",
+        className
       )}
+      {...rest}
     >
       <Icon size={16} strokeWidth={2} fill={active ? "currentColor" : "none"} />
     </button>
   );
-}
+});

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -1321,7 +1321,7 @@ export function MessageInput({
                   ⏱{disappearMs ? <span className="ml-[2px] text-[10px]">on</span> : null}
                 </button>
                 {showDisappearMenu && (
-                  <div className="absolute bottom-full z-50 mb-2 min-w-[160px] rounded-md border border-[var(--border)] bg-[var(--modal-bg)] py-1 shadow-lg">
+                  <div className="absolute bottom-full right-0 z-[120] mb-2 min-w-[160px] rounded-md border border-[var(--border)] bg-[var(--modal-bg)] py-1 shadow-lg">
                     <button
                       type="button"
                       onClick={() => { setDisappearMs(null); setShowDisappearMenu(false); }}
@@ -1384,7 +1384,7 @@ export function MessageInput({
                   📅{scheduleTime ? <span className="ml-[2px] text-[10px]">{formatScheduleLabel(scheduleTime)}</span> : null}
                 </button>
                 {showScheduleMenu && (
-                  <div className="absolute bottom-full right-0 z-50 mb-2 min-w-[200px] rounded-md border border-[var(--border)] bg-[var(--modal-bg)] py-1 shadow-lg">
+                  <div className="absolute bottom-full right-0 z-[120] mb-2 min-w-[200px] rounded-md border border-[var(--border)] bg-[var(--modal-bg)] py-1 shadow-lg">
                     {whenFreeTarget && (
                       <>
                         <button


### PR DESCRIPTION
## Bugs

Two issues reported in the message composer / hover toolbar:

1. **Three-dots (…) "More actions" menu did nothing** when clicked.
2. **Disappearing-message timer dropdown** rendered *behind* the message hover toolbar and clipped off the right edge.

## Root causes

**#1 — dead dropdown trigger.** `ToolbarButton` was a plain function component that only re-applied `onClick`. Radix `DropdownMenu.Trigger asChild` injects `onPointerDown` / `onKeyDown` / `ref` onto its child — and the dropdown opens on **pointerdown, not click** — so those were silently dropped and the menu never opened. The emoji `Popover` in the same toolbar kept working *only because Popover opens on `onClick`*, which was forwarded. Fix: make `ToolbarButton` a `forwardRef` component that spreads all props onto the `<button>`.

**#2 — z-index / anchor.** The timer menu was `z-50`, below the hover toolbar's `z-[100]`, and had no horizontal anchor so it clipped off-screen. Raised to `z-[120]` (the layer the emoji/GIF pickers already use) + `right-0`. Same fix applied to the twin schedule (📅) menu.

## Verification

- `npm run build` passes (type-check + lint) ✅
- Interaction check (three-dots opens, timer sits above the toolbar) needs a signed-in session — please confirm on the preview.

## Scope note

A review of the same two bug classes found the rest of the codebase clean for the dropdown-trigger issue; remaining composer popovers (mention, slash) with the same low z-index are tracked separately in #127.