### PR TITLE
fix: P1/P2 security & reliability fixes from the systematic review

### DIFF
--- a/src/app/api/ai/summary/route.ts
+++ b/src/app/api/ai/summary/route.ts
@@ -5,6 +5,9 @@ import { createHash } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
+// Cap per-message content so a single request can't send an unbounded transcript
+// to the model (message count is already capped at 30). ~2k chars ≈ a long message.
+const MAX_MSG_CHARS = 2000;
 
 interface CacheEntry {
   summary: string;
@@ -32,7 +35,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ summary: "No unread messages to summarize." });
   }
 
-  const transcript = messages.map((m) => `${m.author}: ${m.content}`).join("\n");
+  const transcript = messages
+    .map((m) => `${m.author}: ${(m.content ?? "").slice(0, MAX_MSG_CHARS)}`)
+    .join("\n");
   const cacheKey = createHash("sha256").update(transcript).digest("hex");
 
   const now = Date.now();

--- a/src/app/api/realtime/subscribe/route.ts
+++ b/src/app/api/realtime/subscribe/route.ts
@@ -110,7 +110,20 @@ export async function POST(req: Request) {
   }
 
   const sub = (await res.json()) as { id: string };
-  await transport.saveSub(sub.id, makeRecord(expiresAt), rkey, TTL_SEC);
+  try {
+    await transport.saveSub(sub.id, makeRecord(expiresAt), rkey, TTL_SEC);
+  } catch (err) {
+    // Persisting the record failed — without it the webhook handler can't match
+    // notifications, so realtime would be silently dead while the Graph
+    // subscription still burns quota. Fail closed: tear down the just-created
+    // subscription and tell the client to keep polling (don't report success).
+    console.error("[realtime/subscribe] saveSub failed; removing Graph subscription:", err);
+    await fetch(`https://graph.microsoft.com/v1.0/subscriptions/${sub.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${session.accessToken}` },
+    }).catch(() => {});
+    return NextResponse.json({ error: "Subscription store unavailable" }, { status: 503 });
+  }
 
   return NextResponse.json({ subscriptionId: sub.id, expiresAt });
 }

--- a/src/app/api/voice/token/route.ts
+++ b/src/app/api/voice/token/route.ts
@@ -1,18 +1,54 @@
 import { auth } from "@/lib/auth/config";
+import { voiceRoomNameFor } from "@/lib/voice/types";
 import { AccessToken } from "livekit-server-sdk";
 import { NextRequest, NextResponse } from "next/server";
 
-const ROOM_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+/** True only if the caller's delegated token can read the resource (i.e. is a member). */
+async function graphOk(path: string, token: string): Promise<boolean> {
+  try {
+    const res = await fetch(`https://graph.microsoft.com/v1.0${path}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
 
 export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = (await request.json()) as { roomName?: string };
-  const { roomName } = body;
+  const body = (await request.json().catch(() => ({}))) as {
+    chatId?: string;
+    teamId?: string;
+    channelId?: string;
+  };
+  const { chatId, teamId, channelId } = body;
 
-  if (!roomName || !ROOM_NAME_RE.test(roomName) || roomName.length > 100) {
-    return NextResponse.json({ error: "Invalid roomName" }, { status: 400 });
+  // Verify the caller is a member of the target chat/channel BEFORE issuing a
+  // token, then derive the room name from the (verified) ids — the client never
+  // picks the room directly, so it can't join a call it isn't a party to.
+  let roomName: string;
+  if (typeof chatId === "string" && chatId) {
+    if (!(await graphOk(`/me/chats/${encodeURIComponent(chatId)}`, session.accessToken))) {
+      return NextResponse.json({ error: "Not a member of this chat" }, { status: 403 });
+    }
+    roomName = voiceRoomNameFor({ chatId });
+  } else if (typeof teamId === "string" && teamId && typeof channelId === "string" && channelId) {
+    if (!(await graphOk(`/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}`, session.accessToken))) {
+      return NextResponse.json({ error: "Not a member of this channel" }, { status: 403 });
+    }
+    roomName = voiceRoomNameFor({ teamId, channelId });
+  } else {
+    return NextResponse.json(
+      { error: "Provide a chatId, or teamId and channelId" },
+      { status: 400 }
+    );
+  }
+
+  if (!roomName || roomName.length > 200) {
+    return NextResponse.json({ error: "Invalid room" }, { status: 400 });
   }
 
   const apiKey = process.env.LIVEKIT_API_KEY;
@@ -23,7 +59,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "LiveKit not configured" }, { status: 503 });
   }
 
-  const userId = (session.user as { id?: string; email?: string })?.id ?? session.user?.email ?? "unknown";
+  const userId = session.userId || session.user?.email || "unknown";
   const displayName = session.user?.name ?? userId;
 
   const at = new AccessToken(apiKey, apiSecret, {
@@ -33,5 +69,5 @@ export async function POST(request: NextRequest) {
   at.addGrant({ roomJoin: true, room: roomName, canPublish: true, canSubscribe: true });
   const jwt = await at.toJwt();
 
-  return NextResponse.json({ token: jwt, url });
+  return NextResponse.json({ token: jwt, url, roomName });
 }

--- a/src/components/ai/DigestView.tsx
+++ b/src/components/ai/DigestView.tsx
@@ -152,7 +152,9 @@ function renderDigestMarkdown(input: string): string {
 }
 
 function inlineMd(text: string): string {
-  return text
+  // Escape HTML FIRST so any markup in the (message-derived) digest text is inert
+  // before we introduce our own tags — this output is fed to dangerouslySetInnerHTML.
+  return escMd(text)
     .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
     .replace(/\*(.+?)\*/g, "<em>$1</em>")
     .replace(/`([^`]+)`/g, "<code>$1</code>");

--- a/src/components/messages/AiSummaryBanner.tsx
+++ b/src/components/messages/AiSummaryBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Sparkles } from "lucide-react";
 import { messagePlainText } from "@/lib/utils/render-message";
 
@@ -13,24 +13,26 @@ export function AiSummaryBanner({ messages }: AiSummaryBannerProps) {
   const [summary, setSummary] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const summaryInput = useMemo(
-    () =>
-      messages.slice(-30).map((message) => ({
-        author: message.from?.user?.displayName ?? "Unknown",
-        content: messagePlainText(message.body.content, message.body.contentType),
-      })),
-    [messages]
-  );
+  // Only re-summarize when the conversation actually changes (count, or the last
+  // message's id/edit time) — NOT on every poll, which rebuilds the `messages`
+  // array by reference and would otherwise re-fire this paid endpoint each cycle.
+  const lastMessage = messages[messages.length - 1];
+  const summaryKey = `${messages.length}|${lastMessage?.id ?? ""}|${lastMessage?.lastModifiedDateTime ?? ""}`;
 
   useEffect(() => {
     if (!enabled || messages.length < 10) return;
+
+    const input = messages.slice(-30).map((message) => ({
+      author: message.from?.user?.displayName ?? "Unknown",
+      content: messagePlainText(message.body.content, message.body.contentType),
+    }));
 
     let cancelled = false;
     setLoading(true);
     fetch("/api/ai/summary", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ messages: summaryInput }),
+      body: JSON.stringify({ messages: input }),
     })
       .then((response) => (response.ok ? response.json() : null))
       .then((data: { summary?: string } | null) => {
@@ -43,7 +45,10 @@ export function AiSummaryBanner({ messages }: AiSummaryBannerProps) {
     return () => {
       cancelled = true;
     };
-  }, [enabled, messages.length, summaryInput]);
+    // `messages` is intentionally omitted — summaryKey captures the content that
+    // matters, so we don't re-POST on every poll's fresh array reference.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, summaryKey]);
 
   if (!enabled || messages.length < 10) return null;
 

--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -17,6 +17,7 @@ import { useMemberPanelStore } from "@/store/memberPanel";
 import { openTeamsChannelMeeting } from "@/lib/utils/teams-deeplink";
 import { markdownToHtml } from "@/lib/utils/markdown-to-html";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
+import { voiceRoomNameFor } from "@/lib/voice/types";
 import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 
@@ -440,8 +441,10 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
         }
         voiceTrigger={
           <VoiceTrigger
-            roomName={`channel-${teamId}-${channelId}`}
+            roomName={voiceRoomNameFor({ teamId, channelId })}
             displayName={channel?.displayName ? `#${channel.displayName}` : "Channel voice"}
+            teamId={teamId}
+            channelId={channelId}
           />
         }
       />

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -17,6 +17,7 @@ import { useToastStore } from "@/store/toasts";
 import { openTeamsCall } from "@/lib/utils/teams-deeplink";
 import { getChatLabel } from "@/lib/utils/chat-label";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
+import { voiceRoomNameFor } from "@/lib/voice/types";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
 import { useScheduledStore } from "@/store/scheduled";
@@ -219,7 +220,7 @@ export function ChatView({ chatId }: { chatId: string }) {
   }, [chatId, storeMembers.length]);
 
   const label = getChatLabel(chat ? { ...chat, members } : undefined, currentUserId);
-  const voiceRoomName = `chat-${chatId.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  const voiceRoomName = voiceRoomNameFor({ chatId });
 
   // Reset tab when chat changes
   useEffect(() => {
@@ -709,6 +710,7 @@ export function ChatView({ chatId }: { chatId: string }) {
           <VoiceTrigger
             roomName={voiceRoomName}
             displayName={label}
+            chatId={chatId}
           />
         }
       />

--- a/src/components/voice/VoiceRoomProvider.tsx
+++ b/src/components/voice/VoiceRoomProvider.tsx
@@ -35,7 +35,12 @@ export function VoiceRoomProvider({ children }: { children: React.ReactNode }) {
       const res = await fetch("/api/voice/token", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ roomName: target.name }),
+        body: JSON.stringify({
+          roomName: target.name,
+          chatId: target.chatId,
+          teamId: target.teamId,
+          channelId: target.channelId,
+        }),
       });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };

--- a/src/components/voice/VoiceTrigger.tsx
+++ b/src/components/voice/VoiceTrigger.tsx
@@ -8,9 +8,13 @@ interface VoiceTriggerProps {
   roomName: string;
   displayName: string;
   className?: string;
+  /** Resource this room belongs to — forwarded so the server can verify membership. */
+  chatId?: string;
+  teamId?: string;
+  channelId?: string;
 }
 
-export function VoiceTrigger({ roomName, displayName, className }: VoiceTriggerProps) {
+export function VoiceTrigger({ roomName, displayName, className, chatId, teamId, channelId }: VoiceTriggerProps) {
   const { active, join } = useVoiceRoom();
   const [count, setCount] = useState(0);
 
@@ -42,7 +46,7 @@ export function VoiceTrigger({ roomName, displayName, className }: VoiceTriggerP
     <button
       type="button"
       disabled={isInThisRoom}
-      onClick={() => { void join({ name: roomName, displayName }); }}
+      onClick={() => { void join({ name: roomName, displayName, chatId, teamId, channelId }); }}
       title={isInThisRoom ? "Already in voice room" : count > 0 ? `Join voice (${count} in room)` : "Start voice room"}
       className={`flex items-center gap-1 rounded p-1.5 text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-raised)] hover:text-[var(--text-primary)] focus-ring disabled:cursor-default disabled:opacity-60 ${className ?? ""}`}
     >

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -61,6 +61,22 @@ async function refreshAccessToken(refreshToken: string) {
   };
 }
 
+// Concurrent requests can enter the jwt callback at the same time right after the
+// access token expires; each would call refreshAccessToken with the SAME
+// (single-use) refresh token, and Entra invalidates it on first use — so all but
+// one get invalid_grant and force a spurious re-login. Coalesce concurrent
+// refreshes for a given refresh token into one in-flight request per instance.
+const inflightRefreshes = new Map<string, ReturnType<typeof refreshAccessToken>>();
+function refreshAccessTokenDeduped(refreshToken: string) {
+  const existing = inflightRefreshes.get(refreshToken);
+  if (existing) return existing;
+  const p = refreshAccessToken(refreshToken).finally(() => {
+    inflightRefreshes.delete(refreshToken);
+  });
+  inflightRefreshes.set(refreshToken, p);
+  return p;
+}
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   // The bundled desktop server runs on a loopback host under NODE_ENV=production
   // with no VERCEL/AUTH_URL, so NextAuth would otherwise default trustHost to
@@ -133,7 +149,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       }
 
       try {
-        const refreshed = await refreshAccessToken(token.refreshToken);
+        const refreshed = await refreshAccessTokenDeduped(token.refreshToken);
         return {
           ...token,
           accessToken: refreshed.accessToken,

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { timingSafeEqual } from "node:crypto";
 import { auth } from "@/lib/auth/config";
 
 /**
@@ -6,22 +7,66 @@ import { auth } from "@/lib/auth/config";
  *
  * Two auth paths:
  * 1. Bearer token — MCP clients (Claude Desktop, Cursor, etc.) send a user-scoped
- *    Graph access token obtained from /api/mcp/token. Validated against Graph /me.
+ *    Graph access token obtained from /api/mcp/token. Validated against Graph /me,
+ *    and (when AZURE_AD_CLIENT_ID is set) the token's app id is verified to match
+ *    the Teamsly app so a token minted for some other app can't be replayed here.
  * 2. Session cookie — same-browser fallback (e.g. direct API calls from the web app).
  *
- * Both paths also require the x-mcp-secret header to match TEAMSLY_MCP_SECRET.
+ * Both paths also require the x-mcp-secret header to match TEAMSLY_MCP_SECRET
+ * (compared in constant time to avoid leaking the secret via response timing).
  */
+
+/** Constant-time string comparison; false on any length mismatch. */
+function secretsMatch(provided: string | null, expected: string): boolean {
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Reads the `appid`/`azp` claim from a Graph JWT WITHOUT verifying its signature.
+ * Only trustworthy after Graph has confirmed the token is genuine (the /me call
+ * below) — at that point the claims are authentic and we can bind to our app id.
+ */
+function tokenAppId(jwt: string): string | null {
+  try {
+    const payload = jwt.split(".")[1];
+    if (!payload) return null;
+    const json = Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    const claims = JSON.parse(json) as { appid?: string; azp?: string };
+    return claims.appid ?? claims.azp ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function mcpAuth(req: NextRequest): Promise<string | null> {
   const secret = process.env.TEAMSLY_MCP_SECRET;
-  if (!secret || req.headers.get("x-mcp-secret") !== secret) return null;
+  if (!secret || !secretsMatch(req.headers.get("x-mcp-secret"), secret)) return null;
 
   const authHeader = req.headers.get("authorization");
   if (authHeader?.startsWith("Bearer ")) {
     const token = authHeader.slice(7);
-    const check = await fetch("https://graph.microsoft.com/v1.0/me", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    return check.ok ? token : null;
+    let check: Response;
+    try {
+      check = await fetch("https://graph.microsoft.com/v1.0/me", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch {
+      // Transient network/DNS failure reaching Graph — treat as unauthenticated
+      // rather than throwing an opaque 500 out of the route.
+      return null;
+    }
+    if (!check.ok) return null;
+
+    // Token is genuine (Graph accepted it); bind it to the Teamsly app so a Graph
+    // token issued to a different app registration can't be replayed against MCP.
+    const expectedAppId = process.env.AZURE_AD_CLIENT_ID;
+    if (expectedAppId && tokenAppId(token) !== expectedAppId) return null;
+
+    return token;
   }
 
   const session = await auth();

--- a/src/lib/realtime/pubsub.ts
+++ b/src/lib/realtime/pubsub.ts
@@ -134,7 +134,10 @@ class RedisTransport implements RealtimeTransport {
         ),
       ]);
     } catch (err) {
+      // Do NOT swallow: a lost record means the webhook handler can't match
+      // notifications for this subscription. The caller must fail closed.
       console.error("[redis] saveSub failed:", err);
+      throw err;
     }
   }
 

--- a/src/lib/utils/markdown-to-html.ts
+++ b/src/lib/utils/markdown-to-html.ts
@@ -161,11 +161,13 @@ function applyInline(text: string): string {
   // Strikethrough ~~text~~
   processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");
 
-  // Links [label](url)
+  // Links [label](url) — only emit an <a> for safe schemes; otherwise render the
+  // label as plain text. `encodeURI` does NOT strip dangerous schemes, so without
+  // this a `javascript:`/`data:`/`vbscript:` URL would survive into the stored body.
   processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, url) => {
     const safeLabel = escapeHtml(label);
-    const safeUrl = encodeURI(url);
-    return `<a href="${safeUrl}">${safeLabel}</a>`;
+    const safe = safeHref(url);
+    return safe ? `<a href="${safe}">${safeLabel}</a>` : safeLabel;
   });
 
   // Restore inline code
@@ -182,4 +184,18 @@ function escapeHtml(s: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
+}
+
+/**
+ * Returns an encoded href for links with a safe scheme (http/https/mailto) or a
+ * relative target (starting with `/` or `#`); null for anything else so callers
+ * drop the link. Blocks `javascript:`/`data:`/`vbscript:` etc. at emit time.
+ */
+function safeHref(url: string): string | null {
+  const trimmed = url.trim();
+  if (/^(https?:|mailto:)/i.test(trimmed) || /^[/#]/.test(trimmed)) {
+    // encodeURI also neutralizes `"` (→ %22) so it can't break out of href="...".
+    return encodeURI(trimmed);
+  }
+  return null;
 }

--- a/src/lib/voice/types.ts
+++ b/src/lib/voice/types.ts
@@ -1,2 +1,32 @@
-export type VoiceRoomTarget = { name: string; displayName: string };
+export type VoiceRoomTarget = {
+  name: string;
+  displayName: string;
+  /**
+   * The chat/channel this room belongs to. The server re-derives the room name
+   * from this and verifies the caller is a member of that resource before issuing
+   * a token, so a client can't join an arbitrary room just by naming it. Exactly
+   * one form should be set (chatId, or teamId+channelId).
+   */
+  chatId?: string;
+  teamId?: string;
+  channelId?: string;
+};
 export type VoiceRoomState = { active: VoiceRoomTarget | null };
+
+/**
+ * Canonical voice-room name derived from the resource ids. Shared by the client
+ * (VoiceTrigger / active-participant polling) and the server (token route) so
+ * both agree on the exact string. Sanitized to the room-name charset.
+ */
+export function voiceRoomNameFor(ctx: {
+  chatId?: string;
+  teamId?: string;
+  channelId?: string;
+}): string {
+  const raw = ctx.chatId
+    ? `chat-${ctx.chatId}`
+    : ctx.teamId && ctx.channelId
+      ? `channel-${ctx.teamId}-${ctx.channelId}`
+      : "";
+  return raw.replace(/[^a-zA-Z0-9_-]/g, "-");
+}

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -210,9 +210,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           // Reuse the existing object for any message whose id + lastModified
           // are unchanged, so React.memo'd rows don't re-render on reconcile.
           const byId = new Map(existing.map((m) => [m.id, m]));
+          const now = Date.now();
           const reused = filtered.map((m) => {
             const prev = byId.get(m.id);
-            return prev && prev.lastModifiedDateTime === m.lastModifiedDateTime ? prev : m;
+            if (!prev) return m;
+            // Hold a just-made optimistic reaction/edit until Graph reflects it,
+            // otherwise a poll landing before read-after-write reverts the change.
+            if (prev.__optimisticUntil && prev.__optimisticUntil > now) return prev;
+            return prev.lastModifiedDateTime === m.lastModifiedDateTime ? prev : m;
           });
           const merged = trimToMax(sortByCreatedDateTime([...reused, ...uniquePending]));
           persistContext(contextId, merged);
@@ -352,6 +357,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               // Bump so the memoized MessageItem (compares lastModifiedDateTime)
               // re-renders this optimistic change; reconciled by the next poll.
               lastModifiedDateTime: new Date().toISOString(),
+              // Survive reconcile briefly so a poll landing before Graph's
+              // read-after-write doesn't revert the reaction (see setMessages).
+              __optimisticUntil: Date.now() + 10_000,
               reactions: reaction
                 ? reactions.filter((r) => r !== reaction)
                 : [
@@ -417,6 +425,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           next[index] = {
             ...msg,
             lastModifiedDateTime: new Date().toISOString(),
+            __optimisticUntil: Date.now() + 10_000,
             body: { contentType: "html", content: newContent },
           };
           persistContext(contextId, next);
@@ -436,6 +445,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           next[index] = {
             ...next[index],
             lastModifiedDateTime: new Date().toISOString(),
+            __optimisticUntil: Date.now() + 10_000,
             body: { contentType: previousContentType, content: previousContent },
           };
           persistContext(contextId, next);

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -65,6 +65,14 @@ interface MSMessage {
   __pending?: boolean;
   __failed?: boolean;
   __originalText?: string;
+  /**
+   * Epoch ms until which a just-made optimistic reaction/edit on an ALREADY-sent
+   * message should survive reconcile. A reconcile poll can return the server copy
+   * before Graph reflects the change; without this window the optimistic edit
+   * visibly reverts and then reappears. Local-only; harmless if persisted (a past
+   * value is simply ignored).
+   */
+  __optimisticUntil?: number;
 }
 
 interface MSChat {


### PR DESCRIPTION
Fixes the P1 and P2 findings from the whole-app review (issues #129–#135). Each is a focused commit. `npm run build` passes clean (type-check + `react-hooks` lint).

## P1
- **Voice-call access control** (#129) — `/api/voice/token` issued a join+publish+subscribe token for any named room with no membership check → any org user could join/eavesdrop on private calls. Now the client sends the chat/channel id, the server verifies membership via Graph, and the room name is derived server-side from the verified ids (centralized in `voiceRoomNameFor`). *Also incidentally makes channel room names valid (sanitized).*

## P2
- **Auth refresh race** (#132) — concurrent post-expiry requests each spent the single-use Entra refresh token → spurious re-login. In-flight refreshes are now coalesced per refresh token.
- **AI summary re-fetch every poll** (#134) — `AiSummaryBanner` depended on a per-poll array reference, re-POSTing the paid summary each cycle. Now keyed on stable content (count + last id/edit time); per-message input capped server-side.
- **Optimistic reaction/edit revert** (#135) — a reconcile poll landing before Graph's read-after-write took the server copy and reverted the change. A short `__optimisticUntil` window preserves the local object until the server catches up.
- **Realtime silent death** (#133, *partial*) — `saveSub` swallowed store errors while the route reported success, orphaning the Graph subscription. Now fails closed: on save failure it tears down the just-created Graph subscription and returns 503 so the client keeps polling. *Graph 429 backoff checkbox remains open on #133.*
- **Security hardening** (#130, #131) — MCP: constant-time secret compare + Bearer-token app-id binding + network-error guard. Markdown/digest: scheme allowlist on links (blocks `javascript:`/`data:`) and HTML-escape before `dangerouslySetInnerHTML` in the digest renderer.

## Verification
- `npm run build` → exit 0, no errors, no lint warnings.
- The voice and realtime flows need a signed-in two-client check on the preview — behavior can't be exercised headlessly. Please verify voice join (self = works; non-member = 403) and that reactions no longer flicker on poll.

## Not included
P3 bundles (#136 API hardening, #137 client/UI) remain open for a follow-up.