### PR TITLE
fix: P3 backlog — composer popovers, API hardening, realtime retry

### DIFF
--- a/src/app/api/chats/[chatId]/messages/[messageId]/reactions/route.ts
+++ b/src/app/api/chats/[chatId]/messages/[messageId]/reactions/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/lib/auth/config";
 import { setChatMessageReaction, unsetChatMessageReaction } from "@/lib/graph/client";
-import { reactionEmoji } from "@/lib/utils/reactions";
+import { reactionEmoji, isReactionType } from "@/lib/utils/reactions";
 import { NextResponse } from "next/server";
 
 type Params = Promise<{ chatId: string; messageId: string }>;
@@ -10,8 +10,14 @@ export async function POST(req: Request, { params }: { params: Params }) {
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { chatId, messageId } = await params;
-  const { reactionType, action } = (await req.json()) as { reactionType?: string; action?: "set" | "unset" };
-  if (!reactionType || (action !== "set" && action !== "unset")) {
+  let reactionType: string | undefined;
+  let action: "set" | "unset" | undefined;
+  try {
+    ({ reactionType, action } = (await req.json()) as { reactionType?: string; action?: "set" | "unset" });
+  } catch {
+    return NextResponse.json({ error: "Invalid reaction request" }, { status: 400 });
+  }
+  if (!reactionType || !isReactionType(reactionType) || (action !== "set" && action !== "unset")) {
     return NextResponse.json({ error: "Invalid reaction request" }, { status: 400 });
   }
 

--- a/src/app/api/chats/[chatId]/messages/[messageId]/reply/route.ts
+++ b/src/app/api/chats/[chatId]/messages/[messageId]/reply/route.ts
@@ -9,8 +9,15 @@ export async function POST(req: Request, { params }: { params: Params }) {
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { chatId, messageId } = await params;
-  const { content } = await req.json();
-  if (!content?.trim()) return NextResponse.json({ error: "Empty reply" }, { status: 400 });
+  let content: unknown;
+  try {
+    ({ content } = (await req.json()) as { content?: unknown });
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  if (typeof content !== "string" || !content.trim()) {
+    return NextResponse.json({ error: "Empty reply" }, { status: 400 });
+  }
 
   try {
     const reply = await replyToChatMessage(session.accessToken, chatId, messageId, content);

--- a/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
+++ b/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
@@ -23,7 +23,7 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
   const { chatId, messageId } = await params;
   try {
     const res = await fetch(
-      `https://graph.microsoft.com/v1.0/chats/${chatId}/messages/${messageId}`,
+      `https://graph.microsoft.com/v1.0/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}`,
       {
         method: "PATCH",
         headers: {
@@ -52,7 +52,7 @@ export async function GET(_req: Request, { params }: { params: Params }) {
   const { chatId, messageId } = await params;
   try {
     const res = await fetch(
-      `https://graph.microsoft.com/v1.0/chats/${chatId}/messages/${messageId}`,
+      `https://graph.microsoft.com/v1.0/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}`,
       { headers: { Authorization: `Bearer ${session.accessToken}` } }
     );
     if (!res.ok) {
@@ -80,7 +80,7 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
     // which is why expired disappearing messages were vanishing locally but
     // surviving in native Teams.
     const res = await fetch(
-      `https://graph.microsoft.com/v1.0/me/chats/${chatId}/messages/${messageId}/softDelete`,
+      `https://graph.microsoft.com/v1.0/me/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}/softDelete`,
       {
         method: "POST",
         headers: {

--- a/src/app/api/chats/route.ts
+++ b/src/app/api/chats/route.ts
@@ -9,6 +9,12 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const encodedNextLink = searchParams.get("next");
   const nextLink = encodedNextLink ? decodeURIComponent(encodedNextLink) : undefined;
+  // The nextLink is forwarded to the Graph SDK, which fetches whatever host it
+  // names — reject anything that isn't an actual Graph paging URL to prevent a
+  // caller from turning this into a server-side request to an arbitrary host.
+  if (nextLink && !nextLink.startsWith("https://graph.microsoft.com/")) {
+    return NextResponse.json({ error: "Invalid next link" }, { status: 400 });
+  }
 
   try {
     const page = await getChats(session.accessToken, { nextLink });
@@ -19,7 +25,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[graph] chats failed:", msg);
-    return NextResponse.json({ error: "Graph chats failed", detail: msg }, { status: 502 });
+    return NextResponse.json({ error: "Graph chats failed" }, { status: 502 });
   }
 }
 
@@ -45,6 +51,6 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[graph] create chat failed:", msg);
-    return NextResponse.json({ error: "Create chat failed", detail: msg }, { status: 502 });
+    return NextResponse.json({ error: "Create chat failed" }, { status: 502 });
   }
 }

--- a/src/app/api/messages/[teamId]/[channelId]/[messageId]/reactions/route.ts
+++ b/src/app/api/messages/[teamId]/[channelId]/[messageId]/reactions/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/lib/auth/config";
 import { setChannelMessageReaction, unsetChannelMessageReaction } from "@/lib/graph/client";
-import { reactionEmoji } from "@/lib/utils/reactions";
+import { reactionEmoji, isReactionType } from "@/lib/utils/reactions";
 import { NextResponse } from "next/server";
 
 type Params = Promise<{ teamId: string; channelId: string; messageId: string }>;
@@ -10,8 +10,14 @@ export async function POST(req: Request, { params }: { params: Params }) {
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { teamId, channelId, messageId } = await params;
-  const { reactionType, action } = (await req.json()) as { reactionType?: string; action?: "set" | "unset" };
-  if (!reactionType || (action !== "set" && action !== "unset")) {
+  let reactionType: string | undefined;
+  let action: "set" | "unset" | undefined;
+  try {
+    ({ reactionType, action } = (await req.json()) as { reactionType?: string; action?: "set" | "unset" });
+  } catch {
+    return NextResponse.json({ error: "Invalid reaction request" }, { status: 400 });
+  }
+  if (!reactionType || !isReactionType(reactionType) || (action !== "set" && action !== "unset")) {
     return NextResponse.json({ error: "Invalid reaction request" }, { status: 400 });
   }
 

--- a/src/app/api/messages/[teamId]/[channelId]/[messageId]/replies/route.ts
+++ b/src/app/api/messages/[teamId]/[channelId]/[messageId]/replies/route.ts
@@ -9,8 +9,15 @@ export async function POST(req: Request, { params }: { params: Params }) {
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { teamId, channelId, messageId } = await params;
-  const { content } = await req.json();
-  if (!content?.trim()) return NextResponse.json({ error: "Empty reply" }, { status: 400 });
+  let content: unknown;
+  try {
+    ({ content } = (await req.json()) as { content?: unknown });
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  if (typeof content !== "string" || !content.trim()) {
+    return NextResponse.json({ error: "Empty reply" }, { status: 400 });
+  }
 
   try {
     const reply = await sendChannelReply(session.accessToken, teamId, channelId, messageId, content);

--- a/src/app/api/people/route.ts
+++ b/src/app/api/people/route.ts
@@ -15,6 +15,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[graph] people search failed:", msg);
-    return NextResponse.json({ error: "People search failed", detail: msg }, { status: 502 });
+    // Log the upstream detail server-side only; don't leak Graph internals.
+    return NextResponse.json({ error: "People search failed" }, { status: 502 });
   }
 }

--- a/src/app/api/realtime/subscribe/route.ts
+++ b/src/app/api/realtime/subscribe/route.ts
@@ -9,6 +9,20 @@ const TTL_MS = 55 * 60 * 1000;
 const TTL_SEC = TTL_MS / 1000;
 const REUSE_IF_REMAINING_MS = 15 * 60 * 1000;
 
+// Subscription creation is a raw fetch (not the SDK, which already retries via
+// its default middleware), so honor Graph throttling here: retry 429/503 a
+// couple of times, respecting Retry-After, before surfacing the failure.
+async function graphPostWithRetry(url: string, init: RequestInit, attempts = 3): Promise<Response> {
+  let res = await fetch(url, init);
+  for (let i = 1; i < attempts && (res.status === 429 || res.status === 503); i++) {
+    const retryAfter = Number(res.headers.get("retry-after"));
+    const delayMs = (Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : 2 ** i) * 1000;
+    await new Promise((r) => setTimeout(r, delayMs));
+    res = await fetch(url, init);
+  }
+  return res;
+}
+
 export async function POST(req: Request) {
   const session = await auth();
   if (!session?.accessToken || !session.userId) {
@@ -94,7 +108,7 @@ export async function POST(req: Request) {
     clientState,
   };
 
-  const res = await fetch("https://graph.microsoft.com/v1.0/subscriptions", {
+  const res = await graphPostWithRetry("https://graph.microsoft.com/v1.0/subscriptions", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${session.accessToken}`,
@@ -106,7 +120,7 @@ export async function POST(req: Request) {
   if (!res.ok) {
     const text = await res.text();
     console.error("[realtime/subscribe] Graph subscription failed:", text);
-    return NextResponse.json({ error: text }, { status: 502 });
+    return NextResponse.json({ error: "Graph subscription failed" }, { status: 502 });
   }
 
   const sub = (await res.json()) as { id: string };

--- a/src/app/workspace/activity/page.tsx
+++ b/src/app/workspace/activity/page.tsx
@@ -256,15 +256,15 @@ function ScanSkeleton() {
  * Pull the underlying chat or channel id out of an activity item so we can
  * cross-reference `unreadCounts` for the Unread-only filter.
  *
- *   /app/dm/{chatId}             → { kind: "chat",    id: chatId }
- *   /app/t/{teamId}/{channelId}  → { kind: "channel", id: channelId }
+ *   /workspace/dm/{chatId}             → { kind: "chat",    id: chatId }
+ *   /workspace/t/{teamId}/{channelId}  → { kind: "channel", id: channelId }
  *
  * Returns null for malformed hrefs so the filter falls back to "include".
  */
 function unreadKeyFromHref(href: string): { kind: "chat" | "channel"; id: string } | null {
-  const dmMatch = /^\/app\/dm\/([^/]+)$/.exec(href);
+  const dmMatch = /^\/(?:workspace|app)\/dm\/([^/]+)$/.exec(href);
   if (dmMatch) return { kind: "chat", id: dmMatch[1] };
-  const chMatch = /^\/app\/t\/[^/]+\/([^/]+)$/.exec(href);
+  const chMatch = /^\/(?:workspace|app)\/t\/[^/]+\/([^/]+)$/.exec(href);
   if (chMatch) return { kind: "channel", id: chMatch[1] };
   return null;
 }

--- a/src/components/layout/LeftRail.tsx
+++ b/src/components/layout/LeftRail.tsx
@@ -76,10 +76,14 @@ export function LeftRail() {
   // On macOS the window uses titleBarStyle:'hiddenInset' which removes the
   // native title bar. We need a CSS drag region at the top and extra clearance
   // so the Search button doesn't sit behind the traffic light buttons.
-  const isMacDesktop =
-    typeof window !== "undefined" &&
-    window.electron?.isElectron?.() === true &&
-    window.electron?.platform === "darwin";
+  // Computed after mount (not during render) so SSR/first-paint HTML matches
+  // and there's no hydration mismatch in the packaged Electron app.
+  const [isMacDesktop, setIsMacDesktop] = useState(false);
+  useEffect(() => {
+    setIsMacDesktop(
+      window.electron?.isElectron?.() === true && window.electron?.platform === "darwin"
+    );
+  }, []);
 
   // Cmd+K global shortcut for search
   useEffect(() => {

--- a/src/components/messages/GifPicker.tsx
+++ b/src/components/messages/GifPicker.tsx
@@ -48,11 +48,11 @@ export function GifPicker({ children, onSelect }: Props) {
 
   useEffect(() => {
     if (open) {
-      setTimeout(() => inputRef.current?.focus(), 50);
-    } else {
-      setQuery("");
-      setGifs([]);
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
     }
+    setQuery("");
+    setGifs([]);
   }, [open]);
 
   return (

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -296,6 +296,8 @@ export function MessageInput({
   const [showScheduleMenu, setShowScheduleMenu] = useState(false);
   const emojiAnchorRef = useRef<HTMLButtonElement>(null);
   const emojiContainerRef = useRef<HTMLDivElement>(null);
+  const disappearMenuRef = useRef<HTMLDivElement>(null);
+  const scheduleMenuRef = useRef<HTMLDivElement>(null);
   // Mentions the user has accepted via the autocomplete (or `@everyone`).
   // Reset on send. Kept parallel to the plain `@Display Name` text in the
   // textarea so the parent can build a structured Graph `mentions[]`.
@@ -492,8 +494,9 @@ export function MessageInput({
         setSlashError(`No GIFs found for "${query}"`);
         return;
       }
+      const alt = (gif.title ?? "GIF").replace(/"/g, "&quot;");
       await onSend(
-        `<img src="${url}" alt="${gif.title.replace(/"/g, "&quot;")}" style="max-width:300px;border-radius:4px" />`
+        `<img src="${url}" alt="${alt}" style="max-width:300px;border-radius:4px" />`
       );
     } catch {
       setSlashError(`Couldn't fetch a GIF for "${query}"`);
@@ -572,6 +575,33 @@ export function MessageInput({
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [emojiOpen]);
+
+  // Close the disappearing-timer / send-later menus on outside click or Escape
+  // (the emoji picker above already does this; these two were the outliers).
+  useEffect(() => {
+    if (!showDisappearMenu && !showScheduleMenu) return;
+    function onDown(e: MouseEvent) {
+      const t = e.target as Node;
+      if (showDisappearMenu && disappearMenuRef.current && !disappearMenuRef.current.contains(t)) {
+        setShowDisappearMenu(false);
+      }
+      if (showScheduleMenu && scheduleMenuRef.current && !scheduleMenuRef.current.contains(t)) {
+        setShowScheduleMenu(false);
+      }
+    }
+    function onKey(e: globalThis.KeyboardEvent) {
+      if (e.key === "Escape") {
+        setShowDisappearMenu(false);
+        setShowScheduleMenu(false);
+      }
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [showDisappearMenu, showScheduleMenu]);
 
   function insertEmoji(emoji: { native: string }) {
     const ta = textareaRef.current;
@@ -1132,7 +1162,7 @@ export function MessageInput({
             ref={mentionPopoverRef}
             role="listbox"
             aria-label="Mention suggestions"
-            className="absolute bottom-full left-0 z-20 mb-1 w-72 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg"
+            className="absolute bottom-full left-0 z-[120] mb-1 w-72 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg"
           >
             {filteredCandidates.map((c, idx) => (
               <button
@@ -1309,7 +1339,7 @@ export function MessageInput({
 
               {/* Disappearing message duration picker */}
               {allowDisappearing && (
-              <div className="relative">
+              <div className="relative" ref={disappearMenuRef}>
                 <button
                   type="button"
                   aria-label="Disappearing message"
@@ -1372,7 +1402,7 @@ export function MessageInput({
 
               {/* Send-later (scheduled message) picker */}
               {allowSchedule && (
-              <div className="relative">
+              <div className="relative" ref={scheduleMenuRef}>
                 <button
                   type="button"
                   aria-label="Schedule message"

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -647,6 +647,10 @@ function ReactionsRow({
   );
 }
 
+function attachmentSig(m: Props["message"]): string {
+  return (m.attachments ?? []).map((x) => x.id).join(",");
+}
+
 function propsEqual(a: Props, b: Props): boolean {
   // Callback props are intentionally ignored: their behavior is row-independent,
   // so a new closure identity from the parent must not force a re-render.
@@ -655,6 +659,8 @@ function propsEqual(a: Props, b: Props): boolean {
     a.message.lastModifiedDateTime === b.message.lastModifiedDateTime &&
     a.message.__pending === b.message.__pending &&
     a.message.__failed === b.message.__failed &&
+    // A late-arriving attachment/card can change without bumping lastModified.
+    attachmentSig(a.message) === attachmentSig(b.message) &&
     a.isGroupHead === b.isGroupHead &&
     a.contextId === b.contextId &&
     a.contextLabel === b.contextLabel

--- a/src/components/messages/ReactionPill.tsx
+++ b/src/components/messages/ReactionPill.tsx
@@ -19,6 +19,7 @@ export function ReactionPill({ reactionType, count, active, onClick }: ReactionP
   const prevActiveRef = useRef(active);
   const burstTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const plusOneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     const countIncreased = count > prevCountRef.current;
@@ -27,7 +28,7 @@ export function ReactionPill({ reactionType, count, active, onClick }: ReactionP
     if (countIncreased || justActivated) {
       setBursting(false);
       // Force a re-render cycle so re-adding the class re-triggers the animation
-      requestAnimationFrame(() => {
+      rafRef.current = requestAnimationFrame(() => {
         setBursting(true);
         if (burstTimerRef.current) clearTimeout(burstTimerRef.current);
         burstTimerRef.current = setTimeout(() => setBursting(false), 360);
@@ -48,6 +49,7 @@ export function ReactionPill({ reactionType, count, active, onClick }: ReactionP
     return () => {
       if (burstTimerRef.current) clearTimeout(burstTimerRef.current);
       if (plusOneTimerRef.current) clearTimeout(plusOneTimerRef.current);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
   }, []);
 

--- a/src/components/messages/SlashCommandMenu.tsx
+++ b/src/components/messages/SlashCommandMenu.tsx
@@ -47,7 +47,7 @@ export function SlashCommandMenu({ filtered, selectedIdx, onHover, onPick, open 
       role="listbox"
       aria-label="Slash command suggestions"
       className={cn(
-        "absolute bottom-full left-0 z-30 mb-1 w-80 overflow-hidden rounded-md border border-[var(--border)] bg-[var(--surface)] shadow-lg",
+        "absolute bottom-full left-0 z-[120] mb-1 w-80 overflow-hidden rounded-md border border-[var(--border)] bg-[var(--surface)] shadow-lg",
         entering && "slash-menu-enter"
       )}
     >

--- a/src/hooks/useActivityNotifications.ts
+++ b/src/hooks/useActivityNotifications.ts
@@ -46,8 +46,6 @@ export function useActivityNotifications(scanData: ActivityScanResult | undefine
 
   useEffect(() => {
     if (!scanData) return;
-    if (!desktopNotifications) return;
-    if (quietHoursEnabled && inQuietHours(new Date(), quietHoursStart, quietHoursEnd)) return;
 
     const allItems: ActivityItem[] = [
       ...(scanData.mentions ?? []),
@@ -55,15 +53,23 @@ export function useActivityNotifications(scanData: ActivityScanResult | undefine
       ...(scanData.reactions ?? []),
     ];
 
+    // Always establish the baseline on the first scan — even when notifications
+    // are off or we're in quiet hours — so items already present at load aren't
+    // later mistaken for "new" once the gate lifts.
     if (isFirstScan.current) {
       for (const item of allItems) seenIds.current.add(item.id);
       isFirstScan.current = false;
       return;
     }
 
+    const suppressed =
+      !desktopNotifications ||
+      (quietHoursEnabled && inQuietHours(new Date(), quietHoursStart, quietHoursEnd));
+
     for (const item of allItems) {
       if (seenIds.current.has(item.id)) continue;
       seenIds.current.add(item.id);
+      if (suppressed) continue; // record as seen but don't notify while gated
 
       const href = item.href;
       fireDesktopNotification(notificationTitle(item), item.summary, {

--- a/src/lib/utils/reactions.ts
+++ b/src/lib/utils/reactions.ts
@@ -14,3 +14,8 @@ export const REACTION_TYPES = Object.keys(REACTION_EMOJI) as ReactionType[];
 export function reactionEmoji(type: string): string {
   return REACTION_EMOJI[type as ReactionType] ?? type;
 }
+
+/** True only for one of the six supported Teams reaction types. */
+export function isReactionType(type: string): type is ReactionType {
+  return Object.prototype.hasOwnProperty.call(REACTION_EMOJI, type);
+}

--- a/src/store/toasts.ts
+++ b/src/store/toasts.ts
@@ -15,15 +15,27 @@ interface ToastState {
   dismissToast: (id: string) => void;
 }
 
+// Auto-dismiss timers, keyed by toast id, so a manual dismiss can cancel the
+// pending timeout instead of leaving it to fire later as a dangling no-op.
+const dismissTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
 export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
   showToast: (toast) => {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     set((state) => ({ toasts: [...state.toasts, { ...toast, id }] }));
-    window.setTimeout(() => {
+    const timer = setTimeout(() => {
+      dismissTimers.delete(id);
       set((state) => ({ toasts: state.toasts.filter((item) => item.id !== id) }));
     }, 5000);
+    dismissTimers.set(id, timer);
   },
-  dismissToast: (id) =>
-    set((state) => ({ toasts: state.toasts.filter((toast) => toast.id !== id) })),
+  dismissToast: (id) => {
+    const timer = dismissTimers.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      dismissTimers.delete(id);
+    }
+    set((state) => ({ toasts: state.toasts.filter((toast) => toast.id !== id) }));
+  },
 }));


### PR DESCRIPTION
Clears the P3/follow-up backlog from the systematic review. `npm run build` passes (type-check + lint). Two commits: client-side and server-side.

## Closes #127 — composer popovers
- Mention (`z-20`) and slash-command (`z-30`) popovers raised above the `z-[100]` hover toolbar.
- Disappearing-timer (⏱) and send-later (📅) menus now dismiss on outside-click / Escape (they were the only composer menus that didn't).

## Closes #136 — API correctness & hardening
- Percent-encode `chatId`/`messageId` in chat message edit/get/delete (chat ids contain `@` → were breaking those calls).
- Guard `req.json()` / `content` on reply + reaction routes (400 not 500 on malformed bodies); reject reaction types outside the six supported.
- Reject non-`graph.microsoft.com` `next=` paging links (blind SSRF).
- Stop echoing raw Graph error text to clients (people/chats/subscribe) — log server-side only.

## Closes #133 — realtime
- Retry 429/503 on the raw subscription-creation fetch, honoring `Retry-After`. (The fail-closed persistence fix already landed in #138; SDK calls already retry via the default middleware.)

## Partially addresses #137 — client/UI
Done: MessageItem re-renders on attachment change; ReactionPill rAF + GifPicker/toast timer cleanup; activity "Unread only" filter regex (`/app/`→`/workspace/`); LeftRail hydration; GIF title guard.
**Deferred (regression risk, need manual QA):** ChatView over-subscription (its message read is a non-reactive getter — narrowing the subscription would break live updates without first converting it to a selector) and message-cache eviction (touches persistence). #137 stays open for these.

## Verification
Build green. The composer dismissal, activity filter, and attachment re-render want a quick look on the preview; the rest is mechanical.