### PR TITLE
perf/fix: ChatView subscription scope + message-cache eviction (#137)

### DIFF
--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useWorkspaceStore } from "@/store/workspace";
+import { useShallow } from "zustand/react/shallow";
 import { usePreferencesStore } from "@/store/preferences";
 import { MessageFeed } from "./MessageFeed";
 import { MessageInput } from "./MessageInput";
@@ -22,7 +23,14 @@ import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS }
 import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
 import { useScheduledStore } from "@/store/scheduled";
 
+// Stable empty reference so the reactive messages selector doesn't churn.
+const EMPTY_MESSAGES: MSMessage[] = [];
+
 export function ChatView({ chatId }: { chatId: string }) {
+  // Select only what this view uses (state we read + stable actions) via a
+  // shallow compare, so unrelated store churn (presence, other contexts'
+  // messages, unread counts) doesn't re-render the whole chat view. Messages
+  // are read through a dedicated reactive selector below.
   const {
     chats,
     getMessages,
@@ -42,7 +50,28 @@ export function ChatView({ chatId }: { chatId: string }) {
     revertMessageEdit,
     patchChat,
     patchChatMembers,
-  } = useWorkspaceStore();
+  } = useWorkspaceStore(
+    useShallow((s) => ({
+      chats: s.chats,
+      getMessages: s.getMessages,
+      currentUserId: s.currentUserId,
+      currentUserName: s.currentUserName,
+      setMessages: s.setMessages,
+      appendPendingMessage: s.appendPendingMessage,
+      replaceMessage: s.replaceMessage,
+      markMessageFailed: s.markMessageFailed,
+      removeMessage: s.removeMessage,
+      expireMessage: s.expireMessage,
+      setContextLoading: s.setContextLoading,
+      toggleReaction: s.toggleReaction,
+      deleteMessage: s.deleteMessage,
+      restoreMessage: s.restoreMessage,
+      editMessage: s.editMessage,
+      revertMessageEdit: s.revertMessageEdit,
+      patchChat: s.patchChat,
+      patchChatMembers: s.patchChatMembers,
+    }))
+  );
   const isHydrated = useWorkspaceStore((s) => s.isHydrated);
   // First-load flag for THIS chat only — a cached chat never shows the skeleton.
   const loadingThisChat = useWorkspaceStore((s) => s.loadingContexts[chatId] ?? false);
@@ -80,7 +109,9 @@ export function ChatView({ chatId }: { chatId: string }) {
     router.replace(pathname);
   }, [anchorMessageId, pathname, router]);
 
-  const messages = getMessages(chatId);
+  // Reactive read for rendering — re-renders when THIS chat's messages change.
+  // (getMessages remains for imperative reads in effects/handlers.)
+  const messages = useWorkspaceStore((s) => s.messagesByContext[chatId]) ?? EMPTY_MESSAGES;
   const chat = chats.find((c) => c.id === chatId);
 
   // Pending scheduled ("send later") messages for this chat, soonest-first.

--- a/src/lib/storage/message-cache.ts
+++ b/src/lib/storage/message-cache.ts
@@ -20,6 +20,11 @@ import { openTeamslyDb } from "./drafts";
 
 const STORE_NAME = "messages-by-context";
 
+// Cap the number of cached conversations so the cache (and the in-memory map
+// hydrated from it on boot) can't grow without bound over a long-lived install.
+// Excess contexts, least-recently-updated first, are evicted on cold-start load.
+const MAX_CONTEXTS = 50;
+
 interface ContextRecord {
   contextId: string;
   messages: MSMessage[];
@@ -48,13 +53,18 @@ export async function loadAllContexts(): Promise<Record<string, MSMessage[]>> {
       const store = tx.objectStore(STORE_NAME);
       const request = store.getAll();
       request.onsuccess = () => {
-        const records = (request.result ?? []) as ContextRecord[];
-        const out: Record<string, MSMessage[]> = {};
-        for (const r of records) {
-          if (r && r.contextId && Array.isArray(r.messages)) {
-            out[r.contextId] = r.messages;
-          }
+        let records = ((request.result ?? []) as ContextRecord[]).filter(
+          (r) => r && r.contextId && Array.isArray(r.messages)
+        );
+        // Bound growth: keep the most-recently-updated contexts, evict the rest.
+        if (records.length > MAX_CONTEXTS) {
+          records.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+          const evicted = records.slice(MAX_CONTEXTS).map((r) => r.contextId);
+          records = records.slice(0, MAX_CONTEXTS);
+          evictContexts(db, evicted);
         }
+        const out: Record<string, MSMessage[]> = {};
+        for (const r of records) out[r.contextId] = r.messages;
         resolve(out);
       };
       request.onerror = () => {
@@ -66,6 +76,18 @@ export async function loadAllContexts(): Promise<Record<string, MSMessage[]>> {
       resolve({});
     }
   });
+}
+
+/** Best-effort delete of evicted contexts; never throws. */
+function evictContexts(db: IDBDatabase, contextIds: string[]): void {
+  if (contextIds.length === 0) return;
+  try {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    const store = tx.objectStore(STORE_NAME);
+    for (const id of contextIds) store.delete(id);
+  } catch (err) {
+    console.warn("[message-cache] evict threw", err);
+  }
 }
 
 /**


### PR DESCRIPTION
Completes **#137** — the two items deferred from #139 because they carried regression risk. `npm run build` passes.

## ChatView over-subscription (perf)
`ChatView` called `useWorkspaceStore()` with no selector → subscribed to the whole store, re-rendering top-to-bottom on any mutation (presence, unread counts, other conversations' messages) every poll.

- Select only the read state + (stable) actions via `useShallow`.
- **Key detail:** the rendered message list was read via `getMessages(chatId)`, a *non-reactive* getter — it only updated because the broad subscription forced a re-render. Narrowing the subscription would have broken live updates, so the render read is now a dedicated reactive selector on `messagesByContext[chatId]` (with a stable empty fallback). `getMessages` stays for the imperative reads in effects/handlers.

## Message-cache eviction
`hydrateMessageCache` loaded every persisted context into memory on boot and nothing evicted old ones → unbounded growth on long-lived (desktop) installs. Now evicts all but the 50 most-recently-updated contexts on cold-start load (best-effort, using the existing `updatedAt`).

## Verification
Build green. **The ChatView change touches the message render path** — worth a real two-client check on the preview that live messages, optimistic sends, reactions, and thread opens all still update. If anything's off, this is the commit to look at.