### PR TITLE
feat(activity): keyword alerts across conversations (#147)

### DIFF
--- a/docs/superpowers/specs/2026-07-02-keyword-alerts-design.md
+++ b/docs/superpowers/specs/2026-07-02-keyword-alerts-design.md
@@ -1,0 +1,108 @@
+# Keyword alerts across conversations (#147)
+
+**Status:** design approved 2026-07-02 · **Branch:** `feat/keyword-alerts`
+
+## Problem
+
+Users want to be notified when a chosen word/phrase (a project name, "prod down",
+their product) appears in **any** conversation — Slack's "highlight words". Microsoft
+Teams has no out-of-box equivalent; only Power Automate / Graph-subscription
+workarounds exist.
+
+## What already exists (do NOT rebuild)
+
+- **`notificationKeywords`** preference (comma-separated string) + **`mutedKeywords`**
+  (string[]), with settings UI in `PreferencesModal` and `SettingsModal`.
+- **`useSmartNotifications`** — matches `notificationKeywords` against incoming
+  messages and fires a desktop notification, honoring `mutedKeywords`, quiet hours,
+  focus mode, snooze, and click-to-jump. **But it is fed `messages` from the
+  currently-open `ChatView`/`ChannelView` only**, so it covers just the open
+  conversation.
+- **`/api/activity/scan`** — walks the user's recent messages across DMs + the
+  **active team's** channels and classifies each into `mentions` / `threads` /
+  `reactions` (`ActivityItem[]`), cached ~60s per user. Consumed by
+  `src/app/workspace/activity/page.tsx`, which also feeds `scanData` to
+  `useActivityNotifications` for desktop notifications.
+
+**The gap:** cross-conversation keyword coverage + a place to browse hits.
+
+## Approach (chosen: A)
+
+Match keywords **server-side inside the existing activity scan** (it already walks
+the messages), return a new `keywords` bucket, notify for new hits, and add a
+"Keywords" tab to the Activity page. Rejected: B (return raw messages, match
+client-side — bigger payload, marginal privacy gain on your own server) and C
+(dedicated all-teams keyword endpoint — more Graph load, duplicated walk, YAGNI).
+
+## Design
+
+### 1. Scan route — `src/app/api/activity/scan/route.ts`
+
+- Add `"keyword"` to the `ActivityItem["type"]` union.
+- Add `keywords: ActivityItem[]` to the `ScanResult` interface.
+- Read the keyword list from a query param `kw` (comma-joined, URL-encoded);
+  parse to a lowercased, trimmed, non-empty list. Absent/empty → skip matching,
+  return `keywords: []` (zero added cost).
+- During the existing per-message walk (where the plain-text `summary` is already
+  derived), test the message text against the keywords with a **case-insensitive
+  substring match** (same semantics as `useSmartNotifications.shouldNotify`). On a
+  match, push an `ActivityItem` (`type: "keyword"`, existing fields, `href` with the
+  `?anchor=` deep-link the other buckets use). A message can appear in both its
+  natural bucket and `keywords`.
+- No new Graph calls; matching is pure string work inside the existing try/catch,
+  so the existing `partial: true` degradation is unchanged.
+- Cap the `keywords` bucket to the same politeness cap the other buckets use.
+
+### 2. Activity page — `src/app/workspace/activity/page.tsx`
+
+- Append the user's `notificationKeywords` to the existing scan-fetch query string
+  (`kw=<encoded>`). Re-fetch when the keyword pref changes (add to the effect's deps).
+- Add `"keywords"` to `ActivityTab`, to `TABS` (label "Keywords"), and to
+  `SCAN_TABS`. Include `scanData.keywords` in the "All" aggregation and add a
+  `visibleItems` branch for the keywords tab. Add an `EmptyState` entry.
+- Existing "Unread only" filter, row rendering, and `?anchor=` navigation work
+  unchanged (keyword items carry the same `href` shape).
+
+### 3. Notifications — `src/hooks/useActivityNotifications.ts`
+
+- Fold `scanData.keywords` into the scanned `allItems`, reusing the existing
+  seen-id dedup, first-scan baseline seed, and quiet-hours/desktop gates.
+- **Dedup with `useSmartNotifications`:** skip keyword items whose `href` points to
+  the **currently-open** conversation (compare against `window.location.pathname`),
+  because that hook already notifies there — prevents a double notification.
+- **Apply `mutedKeywords`** to keyword *notifications* (mute wins), matching
+  `useSmartNotifications`. The Keywords *tab* still lists all positive hits (mute
+  only silences the ding, it doesn't hide the item).
+
+### 4. Settings copy — `PreferencesModal` + `SettingsModal`
+
+- Update the `notificationKeywords` field's help text to note it now watches your
+  DMs + active team's channels (background), not just the open conversation. No new
+  setting, no behavior change to the input itself.
+
+## Non-goals (YAGNI)
+
+- Coverage beyond what the scan already walks (i.e. NOT all teams' channels).
+- Regex / whole-word / per-keyword matching — reuse the existing substring match.
+- Per-keyword notification settings or a separate keyword store.
+
+## Error handling
+
+Reuses the scan's existing per-conversation 5xx catch → `partial: true`. Keyword
+parsing tolerates empty/whitespace entries. No throw paths added.
+
+## Verification
+
+- `npm run build` must pass (Vercel enforces `react-hooks/rules-of-hooks` +
+  page-export rules). No automated test suite in the repo.
+- Signed-in preview check (fold into QA issue #141): set a keyword, have it appear
+  in a non-open conversation, confirm a notification fires and the hit shows in the
+  Keywords tab; confirm no double-ding when the keyword lands in the open chat;
+  confirm a `mutedKeywords` term silences the ding but still lists in the tab.
+
+## Files touched
+
+- `src/app/api/activity/scan/route.ts` (type + bucket + query param + match)
+- `src/app/workspace/activity/page.tsx` (qs param + tab + aggregation)
+- `src/hooks/useActivityNotifications.ts` (fold in keywords + dedup + mute)
+- `src/components/modals/PreferencesModal.tsx`, `SettingsModal.tsx` (help copy)

--- a/src/app/api/activity/scan/route.ts
+++ b/src/app/api/activity/scan/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth/config";
 import { getGraphClient } from "@/lib/graph/client";
+import { firstKeywordMatch, parseKeywords } from "@/lib/utils/keyword-match";
 import { NextRequest, NextResponse } from "next/server";
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,8 @@ export interface ActivityItem {
   summary: string;
   timestamp: string;
   href: string;
+  /** Keyword-bucket items only: the watched keyword that matched (lowercased). */
+  matchedKeyword?: string;
 }
 
 interface ScanResult {
@@ -81,22 +84,6 @@ function truncate(s: string, n: number): string {
 function bodyText(message: MSMessage): string {
   const raw = message.body?.content ?? "";
   return message.body?.contentType === "html" ? stripHtml(raw) : raw;
-}
-
-/** Parse the `kw` query param into a lowercased, de-blanked keyword list. */
-function parseKeywords(raw: string | null): string[] {
-  if (!raw) return [];
-  return raw
-    .split(",")
-    .map((k) => k.trim().toLowerCase())
-    .filter(Boolean);
-}
-
-/** Case-insensitive substring match — same semantics as useSmartNotifications. */
-function matchesKeyword(text: string, keywords: string[]): boolean {
-  if (keywords.length === 0) return false;
-  const t = text.toLowerCase();
-  return keywords.some((k) => t.includes(k));
 }
 
 function isMentionOfUser(
@@ -283,16 +270,20 @@ export async function GET(request: NextRequest) {
       }
 
       // keyword — someone else's message contains a watched keyword
-      if (sender && sender.id !== meId && matchesKeyword(bodyText(msg), keywordList)) {
-        keywords.push({
-          id: `keyword-chat-${chat.id}-${msg.id}`,
-          type: "keyword",
-          senderId: sender.id,
-          senderName: sender.displayName,
-          summary,
-          timestamp: msg.createdDateTime,
-          href: chatHref,
-        });
+      if (sender && sender.id !== meId) {
+        const matched = firstKeywordMatch(bodyText(msg), keywordList);
+        if (matched) {
+          keywords.push({
+            id: `keyword-chat-${chat.id}-${msg.id}`,
+            type: "keyword",
+            senderId: sender.id,
+            senderName: sender.displayName,
+            summary,
+            timestamp: msg.createdDateTime,
+            href: chatHref,
+            matchedKeyword: matched,
+          });
+        }
       }
     }
   }
@@ -388,16 +379,20 @@ export async function GET(request: NextRequest) {
         }
 
         // keyword — someone else's message contains a watched keyword
-        if (sender && sender.id !== meId && matchesKeyword(bodyText(msg), keywordList)) {
-          keywords.push({
-            id: `keyword-ch-${channel.id}-${msg.id}`,
-            type: "keyword",
-            senderId: sender.id,
-            senderName: sender.displayName,
-            summary: `#${channel.displayName}: ${summary}`,
-            timestamp: msg.createdDateTime,
-            href: channelHref,
-          });
+        if (sender && sender.id !== meId) {
+          const matched = firstKeywordMatch(bodyText(msg), keywordList);
+          if (matched) {
+            keywords.push({
+              id: `keyword-ch-${channel.id}-${msg.id}`,
+              type: "keyword",
+              senderId: sender.id,
+              senderName: sender.displayName,
+              summary: `#${channel.displayName}: ${summary}`,
+              timestamp: msg.createdDateTime,
+              href: channelHref,
+              matchedKeyword: matched,
+            });
+          }
         }
 
         // Track my own recent channel messages for the thread-reply pass.

--- a/src/app/api/activity/scan/route.ts
+++ b/src/app/api/activity/scan/route.ts
@@ -24,7 +24,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 export interface ActivityItem {
   id: string;
-  type: "mention" | "thread" | "reaction";
+  type: "mention" | "thread" | "reaction" | "keyword";
   senderId: string;
   senderName: string;
   summary: string;
@@ -36,6 +36,7 @@ interface ScanResult {
   mentions: ActivityItem[];
   threads: ActivityItem[];
   reactions: ActivityItem[];
+  keywords: ActivityItem[];
   partial: boolean;
 }
 
@@ -80,6 +81,22 @@ function truncate(s: string, n: number): string {
 function bodyText(message: MSMessage): string {
   const raw = message.body?.content ?? "";
   return message.body?.contentType === "html" ? stripHtml(raw) : raw;
+}
+
+/** Parse the `kw` query param into a lowercased, de-blanked keyword list. */
+function parseKeywords(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((k) => k.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/** Case-insensitive substring match — same semantics as useSmartNotifications. */
+function matchesKeyword(text: string, keywords: string[]): boolean {
+  if (keywords.length === 0) return false;
+  const t = text.toLowerCase();
+  return keywords.some((k) => t.includes(k));
 }
 
 function isMentionOfUser(
@@ -144,6 +161,7 @@ export async function GET(request: NextRequest) {
 
   const accessToken = session.accessToken;
   const teamId = request.nextUrl.searchParams.get("teamId");
+  const keywordList = parseKeywords(request.nextUrl.searchParams.get("kw"));
 
   const client = getGraphClient(accessToken);
 
@@ -169,7 +187,9 @@ export async function GET(request: NextRequest) {
   // Serve from cache if fresh. The cache key is the userId — teamId scoping
   // is implicit because most users only have one active team and the
   // sub-60-second staleness is acceptable for an activity hub.
-  const cacheKey = `${meId}::${teamId ?? "no-team"}`;
+  // keywordList is part of the key so changing watched keywords doesn't serve a
+  // stale bucket from the 60s cache.
+  const cacheKey = `${meId}::${teamId ?? "no-team"}::${keywordList.join(",")}`;
   const now = Date.now();
   const cached = cache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
@@ -179,6 +199,7 @@ export async function GET(request: NextRequest) {
   const mentions: ActivityItem[] = [];
   const threads: ActivityItem[] = [];
   const reactions: ActivityItem[] = [];
+  const keywords: ActivityItem[] = [];
   let partial = false;
 
   // -----------------------------------------------------------------------
@@ -259,6 +280,19 @@ export async function GET(request: NextRequest) {
             href: chatHref,
           });
         }
+      }
+
+      // keyword — someone else's message contains a watched keyword
+      if (sender && sender.id !== meId && matchesKeyword(bodyText(msg), keywordList)) {
+        keywords.push({
+          id: `keyword-chat-${chat.id}-${msg.id}`,
+          type: "keyword",
+          senderId: sender.id,
+          senderName: sender.displayName,
+          summary,
+          timestamp: msg.createdDateTime,
+          href: chatHref,
+        });
       }
     }
   }
@@ -351,6 +385,19 @@ export async function GET(request: NextRequest) {
               href: channelHref,
             });
           }
+        }
+
+        // keyword — someone else's message contains a watched keyword
+        if (sender && sender.id !== meId && matchesKeyword(bodyText(msg), keywordList)) {
+          keywords.push({
+            id: `keyword-ch-${channel.id}-${msg.id}`,
+            type: "keyword",
+            senderId: sender.id,
+            senderName: sender.displayName,
+            summary: `#${channel.displayName}: ${summary}`,
+            timestamp: msg.createdDateTime,
+            href: channelHref,
+          });
         }
 
         // Track my own recent channel messages for the thread-reply pass.
@@ -450,6 +497,7 @@ export async function GET(request: NextRequest) {
     mentions: dedupe(mentions).sort(sortDesc),
     threads: dedupe(threads).sort(sortDesc),
     reactions: dedupe(reactions).sort(sortDesc),
+    keywords: dedupe(keywords).sort(sortDesc),
     partial,
   };
 

--- a/src/app/workspace/activity/page.tsx
+++ b/src/app/workspace/activity/page.tsx
@@ -17,6 +17,7 @@ import {
   GitBranch,
   Smile,
   Bell,
+  Hash,
   ChevronDown,
 } from "lucide-react";
 
@@ -24,11 +25,11 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-type ActivityTab = "all" | "mentions" | "threads" | "reactions" | "dms";
+type ActivityTab = "all" | "mentions" | "threads" | "reactions" | "keywords" | "dms";
 
 interface ActivityItem {
   id: string;
-  type: "dm" | "channel_unread" | "mention" | "thread" | "reaction";
+  type: "dm" | "channel_unread" | "mention" | "thread" | "reaction" | "keyword";
   senderId: string;
   senderName: string;
   summary: string;
@@ -40,6 +41,7 @@ interface ScanResponse {
   mentions: ActivityItem[];
   threads: ActivityItem[];
   reactions: ActivityItem[];
+  keywords?: ActivityItem[];
   partial?: boolean;
 }
 
@@ -54,10 +56,11 @@ const TABS: TabDef[] = [
   { id: "mentions", label: "Mentions" },
   { id: "threads", label: "Threads" },
   { id: "reactions", label: "Reactions" },
+  { id: "keywords", label: "Keywords" },
   { id: "dms", label: "DMs" },
 ];
 
-const SCAN_TABS: ActivityTab[] = ["all", "mentions", "threads", "reactions"];
+const SCAN_TABS: ActivityTab[] = ["all", "mentions", "threads", "reactions", "keywords"];
 const SCAN_POLL_MS = 60 * 1000;
 
 // ---------------------------------------------------------------------------
@@ -77,6 +80,8 @@ function ActivityTypeIcon({ type }: { type: ActivityItem["type"] }) {
       return <GitBranch className={cn(cls, "text-[#57bb8a]")} />;
     case "reaction":
       return <Smile className={cn(cls, "text-[#cd5b45]")} />;
+    case "keyword":
+      return <Hash className={cn(cls, "text-[#818CF8]")} />;
   }
 }
 
@@ -206,6 +211,10 @@ function EmptyState({ tab, unreadOnly }: { tab: ActivityTab; unreadOnly: boolean
       heading: "No reactions",
       sub: "Nobody reacted to your recent messages.",
     },
+    keywords: {
+      heading: "No keyword hits",
+      sub: "None of your watched keywords appeared in recent messages. Set keywords in Settings.",
+    },
   };
 
   const msg = messages[tab];
@@ -302,6 +311,10 @@ export default function ActivityPage() {
 
   useActivityNotifications(scanData ?? undefined);
 
+  // Watched keywords — passed to the scan so it matches across DMs + the active
+  // team's channels; a change re-fires the scan (fetchScan depends on it).
+  const notificationKeywords = usePreferencesStore((s) => s.notificationKeywords);
+
   // Reset cached state when the active team changes so the next visit
   // refetches against the new scope.
   useEffect(() => {
@@ -314,9 +327,11 @@ export default function ActivityPage() {
       const isFirstLoad = !scanLoadedRef.current;
       if (isFirstLoad) setScanLoading(true);
       try {
-        const qs = activeTeamId
-          ? `?teamId=${encodeURIComponent(activeTeamId)}`
-          : "";
+        const params = new URLSearchParams();
+        if (activeTeamId) params.set("teamId", activeTeamId);
+        if (notificationKeywords.trim()) params.set("kw", notificationKeywords);
+        const qsStr = params.toString();
+        const qs = qsStr ? `?${qsStr}` : "";
         const res = await fetch(`/api/activity/scan${qs}`, { signal });
         if (res.status === 401) {
           // The reconnect banner in AppShell already handles refresh-token
@@ -343,7 +358,7 @@ export default function ActivityPage() {
         if (isFirstLoad) setScanLoading(false);
       }
     },
-    [activeTeamId, showToast]
+    [activeTeamId, notificationKeywords, showToast]
   );
 
   const isScanTab = SCAN_TABS.includes(activeTab);
@@ -446,6 +461,7 @@ export default function ActivityPage() {
       ...(scanData?.mentions ?? []),
       ...(scanData?.threads ?? []),
       ...(scanData?.reactions ?? []),
+      ...(scanData?.keywords ?? []),
     ];
     const merged = [...allItems, ...scanItems];
     const seen = new Set<string>();
@@ -465,6 +481,8 @@ export default function ActivityPage() {
     visibleItems = scanData?.threads ?? [];
   } else if (activeTab === "reactions") {
     visibleItems = scanData?.reactions ?? [];
+  } else if (activeTab === "keywords") {
+    visibleItems = scanData?.keywords ?? [];
   }
 
   // Unread-only filter — applies to every tab.

--- a/src/app/workspace/activity/page.tsx
+++ b/src/app/workspace/activity/page.tsx
@@ -30,6 +30,7 @@ type ActivityTab = "all" | "mentions" | "threads" | "reactions" | "keywords" | "
 interface ActivityItem {
   id: string;
   type: "dm" | "channel_unread" | "mention" | "thread" | "reaction" | "keyword";
+  matchedKeyword?: string;
   senderId: string;
   senderName: string;
   summary: string;
@@ -313,7 +314,17 @@ export default function ActivityPage() {
 
   // Watched keywords — passed to the scan so it matches across DMs + the active
   // team's channels; a change re-fires the scan (fetchScan depends on it).
+  // Debounced: the settings modals write the pref on every keystroke, and each
+  // distinct keyword string is a server-cache miss (kw is in the cache key), so
+  // an undebounced dep would fire a full Graph walk per character typed.
   const notificationKeywords = usePreferencesStore((s) => s.notificationKeywords);
+  const [scanKeywords, setScanKeywords] = useState(notificationKeywords);
+  useEffect(() => {
+    if (notificationKeywords === scanKeywords) return;
+    const timer = setTimeout(() => setScanKeywords(notificationKeywords), 800);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notificationKeywords]);
 
   // Reset cached state when the active team changes so the next visit
   // refetches against the new scope.
@@ -329,7 +340,7 @@ export default function ActivityPage() {
       try {
         const params = new URLSearchParams();
         if (activeTeamId) params.set("teamId", activeTeamId);
-        if (notificationKeywords.trim()) params.set("kw", notificationKeywords);
+        if (scanKeywords.trim()) params.set("kw", scanKeywords);
         const qsStr = params.toString();
         const qs = qsStr ? `?${qsStr}` : "";
         const res = await fetch(`/api/activity/scan${qs}`, { signal });
@@ -358,7 +369,7 @@ export default function ActivityPage() {
         if (isFirstLoad) setScanLoading(false);
       }
     },
-    [activeTeamId, notificationKeywords, showToast]
+    [activeTeamId, scanKeywords, showToast]
   );
 
   const isScanTab = SCAN_TABS.includes(activeTab);

--- a/src/components/modals/PreferencesModal.tsx
+++ b/src/components/modals/PreferencesModal.tsx
@@ -515,7 +515,7 @@ function NotificationsPanel() {
 
       <FieldGroup
         label="Keyword alerts"
-        hint="Comma-separated words that trigger notifications (case-insensitive)."
+        hint="Comma-separated words that trigger notifications across your DMs + active team's channels (case-insensitive)."
       >
         <input
           value={keywords}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -187,7 +187,7 @@ function NotificationsPanel() {
         value={mentionsOnly}
         onChange={setMentionsOnly}
       />
-      <FieldGroup label="Keyword alerts" hint="Comma-separated words that can trigger smart notifications.">
+      <FieldGroup label="Keyword alerts" hint="Comma-separated words. Notifies you when they appear across your DMs or the active team's channels — not just the open chat.">
         <input
           value={keywords}
           onChange={(event) => setKeywords(event.target.value)}

--- a/src/hooks/useActivityNotifications.ts
+++ b/src/hooks/useActivityNotifications.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { usePreferencesStore } from "@/store/preferences";
 import { inQuietHours } from "@/hooks/useSmartNotifications";
 import { fireDesktopNotification } from "@/lib/utils/desktop-notification";
+import { sameDecodedPath } from "@/lib/realtime/ids";
 
 interface ActivityItem {
   id: string;
@@ -11,6 +12,7 @@ interface ActivityItem {
   senderName: string;
   summary: string;
   href: string;
+  matchedKeyword?: string;
 }
 
 interface ActivityScanResult {
@@ -38,19 +40,29 @@ function notificationTitle(item: ActivityItem): string {
   }
 }
 
-/** True if `href` is the conversation the user is currently viewing. */
+/**
+ * True if `href` is the conversation the user is currently viewing. Compared
+ * with percent-encoding normalized away: scan hrefs embed raw Graph ids while
+ * location.pathname carries the encoded route param.
+ */
 function isViewingHref(href: string): boolean {
   if (typeof window === "undefined") return false;
-  return window.location.pathname === href;
+  return sameDecodedPath(window.location.pathname, href);
 }
 
-/** Case-insensitive substring match against the muted-keyword list. */
-function isMutedSummary(summary: string, mutedKeywords: string[]): boolean {
+/**
+ * Mute wins when the matched keyword itself is muted (exact, case-insensitive)
+ * or a muted term appears in the summary. The keyword check runs against the
+ * server-side match on the full message body — the summary alone is truncated
+ * and `#channel:`-prefixed, so it can both miss and over-match.
+ */
+function isMutedKeywordItem(item: { matchedKeyword?: string; summary: string }, mutedKeywords: string[]): boolean {
   if (!mutedKeywords || mutedKeywords.length === 0) return false;
-  const s = summary.toLowerCase();
+  const matched = item.matchedKeyword?.toLowerCase();
+  const s = item.summary.toLowerCase();
   return mutedKeywords.some((raw) => {
     const k = raw.trim().toLowerCase();
-    return k ? s.includes(k) : false;
+    return k ? k === matched || s.includes(k) : false;
   });
 }
 
@@ -96,7 +108,7 @@ export function useActivityNotifications(scanData: ActivityScanResult | undefine
       // conversation (skip to avoid a double ding), and muted keywords win.
       if (
         item.type === "keyword" &&
-        (isViewingHref(item.href) || isMutedSummary(item.summary, mutedKeywords))
+        (isViewingHref(item.href) || isMutedKeywordItem(item, mutedKeywords))
       ) {
         continue;
       }

--- a/src/hooks/useActivityNotifications.ts
+++ b/src/hooks/useActivityNotifications.ts
@@ -7,7 +7,7 @@ import { fireDesktopNotification } from "@/lib/utils/desktop-notification";
 
 interface ActivityItem {
   id: string;
-  type: "dm" | "channel_unread" | "mention" | "thread" | "reaction";
+  type: "dm" | "channel_unread" | "mention" | "thread" | "reaction" | "keyword";
   senderName: string;
   summary: string;
   href: string;
@@ -17,6 +17,7 @@ interface ActivityScanResult {
   mentions: ActivityItem[];
   threads: ActivityItem[];
   reactions: ActivityItem[];
+  keywords?: ActivityItem[];
   partial?: boolean;
 }
 
@@ -28,6 +29,8 @@ function notificationTitle(item: ActivityItem): string {
       return `Reply from ${item.senderName}`;
     case "reaction":
       return `${item.senderName} reacted to your message`;
+    case "keyword":
+      return `Keyword match from ${item.senderName}`;
     case "dm":
       return `New DM from ${item.senderName}`;
     default:
@@ -35,11 +38,28 @@ function notificationTitle(item: ActivityItem): string {
   }
 }
 
+/** True if `href` is the conversation the user is currently viewing. */
+function isViewingHref(href: string): boolean {
+  if (typeof window === "undefined") return false;
+  return window.location.pathname === href;
+}
+
+/** Case-insensitive substring match against the muted-keyword list. */
+function isMutedSummary(summary: string, mutedKeywords: string[]): boolean {
+  if (!mutedKeywords || mutedKeywords.length === 0) return false;
+  const s = summary.toLowerCase();
+  return mutedKeywords.some((raw) => {
+    const k = raw.trim().toLowerCase();
+    return k ? s.includes(k) : false;
+  });
+}
+
 export function useActivityNotifications(scanData: ActivityScanResult | undefined): void {
   const desktopNotifications = usePreferencesStore((s) => s.desktopNotifications);
   const quietHoursEnabled = usePreferencesStore((s) => s.quietHoursEnabled);
   const quietHoursStart = usePreferencesStore((s) => s.quietHoursStart);
   const quietHoursEnd = usePreferencesStore((s) => s.quietHoursEnd);
+  const mutedKeywords = usePreferencesStore((s) => s.mutedKeywords);
 
   const seenIds = useRef<Set<string>>(new Set());
   const isFirstScan = useRef(true);
@@ -51,6 +71,7 @@ export function useActivityNotifications(scanData: ActivityScanResult | undefine
       ...(scanData.mentions ?? []),
       ...(scanData.threads ?? []),
       ...(scanData.reactions ?? []),
+      ...(scanData.keywords ?? []),
     ];
 
     // Always establish the baseline on the first scan — even when notifications
@@ -71,6 +92,15 @@ export function useActivityNotifications(scanData: ActivityScanResult | undefine
       seenIds.current.add(item.id);
       if (suppressed) continue; // record as seen but don't notify while gated
 
+      // Keyword hits: useSmartNotifications already notifies for the open
+      // conversation (skip to avoid a double ding), and muted keywords win.
+      if (
+        item.type === "keyword" &&
+        (isViewingHref(item.href) || isMutedSummary(item.summary, mutedKeywords))
+      ) {
+        continue;
+      }
+
       const href = item.href;
       fireDesktopNotification(notificationTitle(item), item.summary, {
         tag: item.id,
@@ -80,5 +110,5 @@ export function useActivityNotifications(scanData: ActivityScanResult | undefine
         },
       });
     }
-  }, [scanData, desktopNotifications, quietHoursEnabled, quietHoursStart, quietHoursEnd]);
+  }, [scanData, desktopNotifications, quietHoursEnabled, quietHoursStart, quietHoursEnd, mutedKeywords]);
 }

--- a/src/lib/realtime/ids.test.ts
+++ b/src/lib/realtime/ids.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decodeGraphId } from "./ids";
+import { decodeGraphId, sameDecodedPath } from "./ids";
 
 // Guards the root cause of the realtime outage: Next.js leaves route params
 // percent-encoded, so every id must normalize to the raw Graph form whether
@@ -34,5 +34,21 @@ describe("decodeGraphId", () => {
     const decoded = decodeGraphId("..%2F..%2Fme%2Fmessages");
     expect(decoded).toBe("../../me/messages");
     expect(CHAT_ID_SAFE.test(decoded!)).toBe(false);
+  });
+});
+
+describe("sameDecodedPath", () => {
+  it("matches raw and percent-encoded spellings of the same conversation path", () => {
+    expect(
+      sameDecodedPath("/workspace/dm/19:xyz@unq.gbl.spaces", "/workspace/dm/19%3Axyz%40unq.gbl.spaces")
+    ).toBe(true);
+    expect(
+      sameDecodedPath("/workspace/t/team-guid/19%3Aabc%40thread.tacv2", "/workspace/t/team-guid/19:abc@thread.tacv2")
+    ).toBe(true);
+  });
+
+  it("rejects different conversations and survives malformed escapes", () => {
+    expect(sameDecodedPath("/workspace/dm/a", "/workspace/dm/b")).toBe(false);
+    expect(sameDecodedPath("/workspace/dm/19%ZZ", "/workspace/dm/19%ZZ")).toBe(true);
   });
 });

--- a/src/lib/realtime/ids.ts
+++ b/src/lib/realtime/ids.ts
@@ -10,3 +10,12 @@ export function decodeGraphId(id: string): string | null {
     return null;
   }
 }
+
+// URL paths embedding conversation ids also come in both spellings —
+// location.pathname may carry raw : and @ while app-built hrefs carry the
+// percent-encoded route param (or vice versa). Comparing mixed forms is the
+// bug class behind the open-conversation suppression failures; always compare
+// through this. Malformed escapes fall back to comparing as-is.
+export function sameDecodedPath(a: string, b: string): boolean {
+  return (decodeGraphId(a) ?? a) === (decodeGraphId(b) ?? b);
+}

--- a/src/lib/utils/keyword-match.test.ts
+++ b/src/lib/utils/keyword-match.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { firstKeywordMatch, parseKeywords } from "./keyword-match";
+
+describe("parseKeywords", () => {
+  it("splits, trims, lowercases, and drops blanks", () => {
+    expect(parseKeywords("Prod Down, deploy ,  ,API")).toEqual(["prod down", "deploy", "api"]);
+    expect(parseKeywords(null)).toEqual([]);
+    expect(parseKeywords("")).toEqual([]);
+  });
+});
+
+describe("firstKeywordMatch", () => {
+  it("returns the first matching keyword, case-insensitively", () => {
+    expect(firstKeywordMatch("The DEPLOY failed on prod", ["prod down", "deploy"])).toBe("deploy");
+    expect(firstKeywordMatch("prod down since 3am", ["prod down", "deploy"])).toBe("prod down");
+  });
+
+  it("returns null when nothing matches or the list is empty", () => {
+    expect(firstKeywordMatch("all quiet", ["deploy"])).toBeNull();
+    expect(firstKeywordMatch("anything", [])).toBeNull();
+  });
+});

--- a/src/lib/utils/keyword-match.ts
+++ b/src/lib/utils/keyword-match.ts
@@ -1,0 +1,21 @@
+/**
+ * Keyword-alert matching (#147), shared by the activity scan route and any
+ * client-side consumers. Case-insensitive substring semantics — the same
+ * contract useSmartNotifications applies to the open conversation.
+ */
+
+/** Parse a comma-separated keyword pref into a lowercased, de-blanked list. */
+export function parseKeywords(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((k) => k.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/** The first keyword occurring in `text`, or null. Keywords must be pre-lowercased. */
+export function firstKeywordMatch(text: string, keywords: string[]): string | null {
+  if (keywords.length === 0) return null;
+  const t = text.toLowerCase();
+  return keywords.find((k) => t.includes(k)) ?? null;
+}


### PR DESCRIPTION
Implements **#147** — get notified when a watched word appears in **any** conversation (Slack "highlight words"). `npm run build` passes. Spec: `docs/superpowers/specs/2026-07-02-keyword-alerts-design.md`.

## Context
Keyword notifications already existed but only covered the **currently-open** conversation (`useSmartNotifications` is fed the open view's messages). This extends coverage to your DMs + the active team's channels by piggybacking on the existing activity scan.

## Changes
- **`api/activity/scan/route.ts`** — new `kw` query param; matches each walked message (case-insensitive substring, same semantics as `useSmartNotifications`, skipping your own messages) into a new `keywords: ActivityItem[]` bucket. No new Graph calls. Cache key now includes the keyword list so a keyword change can't serve a stale cached bucket.
- **`workspace/activity/page.tsx`** — passes `notificationKeywords` as `kw` (re-fetches when it changes); adds a **"Keywords" tab** (with a `Hash` icon + empty state) and folds hits into "All".
- **`useActivityNotifications.ts`** — fires desktop notifications for new keyword hits, reusing the seen-id dedup + quiet-hours/desktop gates. **Dedup:** skips hits in the open conversation (`useSmartNotifications` handles those) to avoid a double ding; honors `mutedKeywords` (mute silences the ding but the hit still lists in the tab).
- **Settings copy** (Preferences + Settings modals) — notes keywords now watch across DMs + the active team's channels.

## Design decisions (open to change)
- **Coverage = what the scan already walks** (DMs + active team's channels), not all teams — consistent with mentions/threads/reactions. (YAGNI; noted in spec.)
- **href has no `?anchor=`** — matches the existing mention/reaction items (they link to the conversation, not the exact message). Deviates from the spec's aside; chose consistency.
- Substring match reused as-is (no regex/whole-word).

## Verification
`npm run build` → exit 0 (type-check + lint clean). Interaction check needs a signed-in session (fold into QA #141): set a keyword, have it appear in a **non-open** conversation → notification + Keywords-tab hit; confirm no double-ding when it lands in the open chat; confirm a muted term silences the ding but still lists.

Not merged — for your review.

Closes #147