### PR TITLE
fix(realtime): accept percent-encoded conversation ids on subscribe

### DIFF
--- a/src/app/api/realtime/subscribe/route.ts
+++ b/src/app/api/realtime/subscribe/route.ts
@@ -1,9 +1,11 @@
 import { auth } from "@/lib/auth/config";
 import { NextResponse } from "next/server";
 import { transport, resourceKey, type SubscriptionRecord } from "@/lib/realtime/pubsub";
+import { decodeGraphId } from "@/lib/realtime/ids";
 
 const URL_SAFE = /^[A-Za-z0-9_-]+$/;
-// Teams chat IDs look like 19:xxx_yyy@unq.gbl.spaces — allow :, @, . in addition.
+// Teams chat ids (19:xxx_yyy@unq.gbl.spaces) and channel ids
+// (19:xxx@thread.tacv2) share this shape — allow :, @, . in addition.
 const CHAT_ID_SAFE = /^[A-Za-z0-9_@.:-]+$/;
 const TTL_MS = 55 * 60 * 1000;
 const TTL_SEC = TTL_MS / 1000;
@@ -48,27 +50,43 @@ export async function POST(req: Request) {
   let resource: string;
   let makeRecord: (expiresAt: number) => SubscriptionRecord;
 
+  // Clients send ids as they appear in route params, which Next.js leaves
+  // percent-encoded. Normalize to the raw Graph form: it's what the Graph
+  // subscription resource needs, and storing it in the record means realtime
+  // events carry the canonical id.
   if (chatId) {
-    if (!CHAT_ID_SAFE.test(chatId)) {
+    const rawChatId = decodeGraphId(chatId);
+    if (!rawChatId || !CHAT_ID_SAFE.test(rawChatId)) {
       return NextResponse.json({ error: "Invalid chatId" }, { status: 400 });
     }
-    rkey = resourceKey({ kind: "chat", chatId });
-    resource = `/chats/${chatId}/messages`;
+    rkey = resourceKey({ kind: "chat", chatId: rawChatId });
+    resource = `/chats/${rawChatId}/messages`;
     makeRecord = (expiresAt) => ({
       userId,
       resourceType: "chat_message",
-      chatId,
+      chatId: rawChatId,
       expiresAt,
       clientState,
     });
-  } else if (teamId && channelId && URL_SAFE.test(teamId) && URL_SAFE.test(channelId)) {
-    rkey = resourceKey({ kind: "channel", teamId, channelId });
-    resource = `/teams/${teamId}/channels/${channelId}/messages`;
+  } else if (teamId && channelId) {
+    const rawTeamId = decodeGraphId(teamId);
+    const rawChannelId = decodeGraphId(channelId);
+    // Team ids are GUIDs; channel ids share the chat-id shape.
+    if (
+      !rawTeamId ||
+      !rawChannelId ||
+      !URL_SAFE.test(rawTeamId) ||
+      !CHAT_ID_SAFE.test(rawChannelId)
+    ) {
+      return NextResponse.json({ error: "Invalid teamId or channelId" }, { status: 400 });
+    }
+    rkey = resourceKey({ kind: "channel", teamId: rawTeamId, channelId: rawChannelId });
+    resource = `/teams/${rawTeamId}/channels/${rawChannelId}/messages`;
     makeRecord = (expiresAt) => ({
       userId,
       resourceType: "channel_message",
-      teamId,
-      channelId,
+      teamId: rawTeamId,
+      channelId: rawChannelId,
       expiresAt,
       clientState,
     });

--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -19,6 +19,7 @@ import { markdownToHtml } from "@/lib/utils/markdown-to-html";
 import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
 import { voiceRoomNameFor } from "@/lib/voice/types";
 import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
+import { decodeGraphId } from "@/lib/realtime/ids";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 
 export function ChannelView({ teamId, channelId }: { teamId: string; channelId: string }) {
@@ -173,10 +174,12 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
   useRealtimeEvents(
     useCallback(
       (event) => {
+        // Events carry raw Graph ids; the props are (still percent-encoded)
+        // route params.
         if (
           event.type === "channel_message" &&
-          event.teamId === teamId &&
-          event.channelId === channelId
+          event.teamId === decodeGraphId(teamId) &&
+          event.channelId === decodeGraphId(channelId)
         ) {
           fetch(`/api/teams/${teamId}/channels/${channelId}/messages/${encodeURIComponent(event.messageId)}`)
             .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -21,6 +21,7 @@ import { VoiceTrigger } from "@/components/voice/VoiceTrigger";
 import { voiceRoomNameFor } from "@/lib/voice/types";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
+import { decodeGraphId } from "@/lib/realtime/ids";
 import { useScheduledStore } from "@/store/scheduled";
 
 // Stable empty reference so the reactive messages selector doesn't churn.
@@ -332,7 +333,9 @@ export function ChatView({ chatId }: { chatId: string }) {
   useRealtimeEvents(
     useCallback(
       (event) => {
-        if (event.type === "chat_message" && event.chatId === chatId) {
+        // Events carry the raw Graph id; the chatId prop is the (still
+        // percent-encoded) route param.
+        if (event.type === "chat_message" && event.chatId === decodeGraphId(chatId)) {
           fetch(`/api/chats/${chatId}/messages/${encodeURIComponent(event.messageId)}`)
             .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
             .then((msg: MSMessage) => upsertMessage(chatId, msg))

--- a/src/lib/realtime/ids.ts
+++ b/src/lib/realtime/ids.ts
@@ -1,0 +1,12 @@
+// Conversation ids reach realtime code in two forms: percent-encoded
+// (Next.js does not decode dynamic route params, and views pass them through
+// as-is) and raw (Graph payloads). Normalize to the raw Graph form before
+// validating, building Graph resource paths, or comparing against realtime
+// event payloads. Malformed encodings return null.
+export function decodeGraphId(id: string): string | null {
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

Realtime push has never worked in prod. Live prod logs show every `POST /api/realtime/subscribe` returning **400**, so no Graph change-notification subscription was ever created → Graph never calls the webhook → SSE never delivers → clients silently live on the 30s reconcile poll.

## Root cause

Next.js leaves dynamic route params **percent-encoded**, and the views pass them through as-is, so the subscribe route receives `19%3A...%40unq.gbl.spaces` — `CHAT_ID_SAFE` has no `%`, so every DM subscribe 400s. Channel subscribes were doubly broken: `URL_SAFE` rejects the `:`, `@`, `.` that every real channel id (`19:...@thread.tacv2`) contains, encoded or not. Both regexes date to the original realtime commits (8e6525e, 1748ab0) — the e2e two-client check in #141 was never run, so this went unnoticed.

## Fix

- Subscribe route: normalize ids to the raw Graph form (decode, then validate) before building the subscription `resource`; store the raw form in the subscription record so SSE events carry the canonical id. Channel ids are validated with the chat-id charset they actually use.
- ChatView/ChannelView: decode the (still-encoded) route params when matching incoming realtime events.
- New `src/lib/realtime/ids.ts` shared helper (kept separate from `pubsub.ts` so client components don't pull the Redis transport into the bundle).

Decode-then-validate keeps the traversal guard intact — `..%2F..%2Fme%2Fmessages` decodes to a string containing `/`, which the charset still rejects (covered in a logic check against real prod id forms).

## Verification

- Logic check against real prod ids (encoded/raw chat, group-thread, channel, GUID, traversal, malformed `%`): all pass.
- `npm run build` clean.
- Post-merge: watch prod logs for subscribe 200s + `/api/webhooks/graph` notification POSTs, then two-client <2s message check (#141).

Relates to #141.