### PR TITLE
fix(voice): map LiveKit room-not-found to empty participants

### DIFF
--- a/src/app/api/voice/active/[roomName]/route.ts
+++ b/src/app/api/voice/active/[roomName]/route.ts
@@ -35,8 +35,18 @@ export async function GET(
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // Room doesn't exist yet — return empty list rather than erroring
-    if (msg.includes("not found") || msg.includes("404") || msg.includes("room_not_found")) {
+    // Room doesn't exist yet (nobody has joined the call) — the normal case
+    // for this poll, not an error. LiveKit's TwirpError reports it as
+    // status 404 / code "not_found" with message "requested room does not
+    // exist", so check the structured fields, not just the message text.
+    const status = (err as { status?: number }).status;
+    const code = (err as { code?: string }).code;
+    if (
+      status === 404 ||
+      code === "not_found" ||
+      msg.includes("not found") ||
+      msg.includes("does not exist")
+    ) {
       return NextResponse.json({ participants: [] });
     }
     console.error("[voice] listParticipants failed:", msg);


### PR DESCRIPTION
## Problem

Prod logs show `GET /api/voice/active/<room>` returning **500 on every poll** — which is the steady state, since voice rooms only exist while someone is in a call.

## Root cause

LiveKit's `TwirpError` for a missing room is `status: 404`, `code: "not_found"`, message `"requested room does not exist"`. The route only string-matched the message against `"not found"` / `"404"` / `"room_not_found"` — none match, so the normal empty-room case fell through to the 500 path. (Reproduced against LiveKit Cloud with the same SDK version, 2.16.0, to capture the exact error shape. Credentials are fine — this is purely the error-mapping.)

The batch route (`/api/voice/active-batch`) is unaffected — its fallback already resolves to 0 either way.

## Fix

Check the structured `status`/`code` fields (plus the message text as a fallback) and return `{ participants: [] }` for the room-missing case.

## Verification

- `npm run build` clean.
- Post-merge: prod logs should show these polls as 200s; 500 remains only for genuine failures (e.g. bad credentials).