### PR TITLE
perf(channels): scope ChannelView's store subscription to what it uses (#151)

### DIFF
--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useWorkspaceStore } from "@/store/workspace";
+import { useShallow } from "zustand/react/shallow";
 import { MessageFeed } from "./MessageFeed";
 import { MessageInput } from "./MessageInput";
 import { ThreadPanel } from "./ThreadPanel";
@@ -21,7 +22,14 @@ import { voiceRoomNameFor } from "@/lib/voice/types";
 import { useRealtimeEvents, useRealtimeHealth } from "@/hooks/useRealtimeEvents";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 
+// Stable empty reference so the reactive messages selector doesn't churn.
+const EMPTY_MESSAGES: MSMessage[] = [];
+
 export function ChannelView({ teamId, channelId }: { teamId: string; channelId: string }) {
+  // Select only what this view uses (state we read + stable actions) via a
+  // shallow compare, so unrelated store churn (presence, other contexts'
+  // messages, unread counts) doesn't re-render the whole channel view.
+  // Messages are read through a dedicated reactive selector below.
   const {
     teams,
     channels,
@@ -36,7 +44,23 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     expireMessage,
     setContextLoading,
     toggleReaction,
-  } = useWorkspaceStore();
+  } = useWorkspaceStore(
+    useShallow((s) => ({
+      teams: s.teams,
+      channels: s.channels,
+      getMessages: s.getMessages,
+      currentUserId: s.currentUserId,
+      currentUserName: s.currentUserName,
+      setMessages: s.setMessages,
+      appendPendingMessage: s.appendPendingMessage,
+      replaceMessage: s.replaceMessage,
+      markMessageFailed: s.markMessageFailed,
+      removeMessage: s.removeMessage,
+      expireMessage: s.expireMessage,
+      setContextLoading: s.setContextLoading,
+      toggleReaction: s.toggleReaction,
+    }))
+  );
   const isHydrated = useWorkspaceStore((s) => s.isHydrated);
   // First-load flag for THIS channel only — a cached channel never shows the skeleton.
   const loadingThisChannel = useWorkspaceStore(
@@ -66,7 +90,9 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
 
   // Stable context key for this channel's message cache
   const contextId = `${teamId}:${channelId}`;
-  const messages = getMessages(contextId);
+  // Reactive read for rendering — re-renders when THIS channel's messages
+  // change. (getMessages remains for imperative reads in effects/handlers.)
+  const messages = useWorkspaceStore((s) => s.messagesByContext[contextId]) ?? EMPTY_MESSAGES;
 
   const team = teams.find((t) => t.id === teamId);
   const channel = channels[teamId]?.find((c) => c.id === channelId);


### PR DESCRIPTION
Mirror of the #140 ChatView fix, applied to ChannelView per #151:

- Narrow the whole-store destructure to a `useShallow` selection of the state the view reads plus its stable actions, so unrelated store churn (presence, unread counts, other conversations' messages) no longer re-renders the channel view.
- Replace the non-reactive `getMessages(contextId)` render read with a reactive selector on `messagesByContext[contextId]` with a stable empty fallback — the trap called out in #151: without this, narrowing the subscription would silently break live channel-message updates. `getMessages` remains for imperative reads in effects/handlers.

`npm run build` clean. Verification per #151: fold a signed-in two-client channel check into QA #141 (also depends on #156 for channel realtime to subscribe at all).

Closes #151