### PR TITLE
fix(api): stop double-encoding Graph ids taken from route params

### DIFF
--- a/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
+++ b/src/app/api/chats/[chatId]/messages/[messageId]/route.ts
@@ -1,7 +1,14 @@
 import { auth } from "@/lib/auth/config";
+import { decodeGraphId } from "@/lib/realtime/ids";
 import { NextResponse } from "next/server";
 
 type Params = Promise<{ chatId: string; messageId: string }>;
+
+// Route params arrive still percent-encoded (Next.js doesn't decode them), so
+// decode before re-encoding for the Graph URL — encoding twice 404s the chat.
+function graphEncode(id: string): string {
+  return encodeURIComponent(decodeGraphId(id) ?? id);
+}
 
 // Client sends plain text; we convert to HTML because Graph requires contentType:"html".
 function textToHtml(text: string): string {
@@ -23,7 +30,7 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
   const { chatId, messageId } = await params;
   try {
     const res = await fetch(
-      `https://graph.microsoft.com/v1.0/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}`,
+      `https://graph.microsoft.com/v1.0/chats/${graphEncode(chatId)}/messages/${graphEncode(messageId)}`,
       {
         method: "PATCH",
         headers: {
@@ -52,7 +59,7 @@ export async function GET(_req: Request, { params }: { params: Params }) {
   const { chatId, messageId } = await params;
   try {
     const res = await fetch(
-      `https://graph.microsoft.com/v1.0/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}`,
+      `https://graph.microsoft.com/v1.0/chats/${graphEncode(chatId)}/messages/${graphEncode(messageId)}`,
       { headers: { Authorization: `Bearer ${session.accessToken}` } }
     );
     if (!res.ok) {
@@ -80,7 +87,7 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
     // which is why expired disappearing messages were vanishing locally but
     // surviving in native Teams.
     const res = await fetch(
-      `https://graph.microsoft.com/v1.0/me/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}/softDelete`,
+      `https://graph.microsoft.com/v1.0/me/chats/${graphEncode(chatId)}/messages/${graphEncode(messageId)}/softDelete`,
       {
         method: "POST",
         headers: {

--- a/src/app/api/files/preview/[itemId]/content/route.ts
+++ b/src/app/api/files/preview/[itemId]/content/route.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/lib/auth/config";
+import { decodeGraphId } from "@/lib/realtime/ids";
 import { NextResponse } from "next/server";
 
 type Params = Promise<{ itemId: string }>;
@@ -27,7 +28,9 @@ export async function GET(_req: Request, { params }: { params: Params }) {
     // client) because the SDK insists on parsing the body as JSON for /content
     // endpoints and binary/text passthrough is easier with raw fetch.
     const upstream = await fetch(
-      `https://graph.microsoft.com/v1.0/me/drive/items/${encodeURIComponent(itemId)}/content`,
+      // Route params arrive percent-encoded; decode before re-encoding so the
+      // Graph URL isn't double-encoded.
+      `https://graph.microsoft.com/v1.0/me/drive/items/${encodeURIComponent(decodeGraphId(itemId) ?? itemId)}/content`,
       {
         headers: { Authorization: `Bearer ${session.accessToken}` },
         // Graph 302-redirects to a pre-signed URL; fetch follows redirects by

--- a/src/app/api/voice/token/route.ts
+++ b/src/app/api/voice/token/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth/config";
 import { voiceRoomNameFor } from "@/lib/voice/types";
+import { decodeGraphId } from "@/lib/realtime/ids";
 import { AccessToken } from "livekit-server-sdk";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -29,14 +30,21 @@ export async function POST(request: NextRequest) {
   // Verify the caller is a member of the target chat/channel BEFORE issuing a
   // token, then derive the room name from the (verified) ids — the client never
   // picks the room directly, so it can't join a call it isn't a party to.
+  // Ids arrive percent-encoded (the client passes route params through as-is),
+  // so decode before re-encoding for the Graph path — encoding them twice made
+  // the membership check 404 and 403 every legitimate member. Room names keep
+  // deriving from the as-sent ids so they match the client's own derivation.
   let roomName: string;
   if (typeof chatId === "string" && chatId) {
-    if (!(await graphOk(`/me/chats/${encodeURIComponent(chatId)}`, session.accessToken))) {
+    const rawChatId = decodeGraphId(chatId) ?? chatId;
+    if (!(await graphOk(`/me/chats/${encodeURIComponent(rawChatId)}`, session.accessToken))) {
       return NextResponse.json({ error: "Not a member of this chat" }, { status: 403 });
     }
     roomName = voiceRoomNameFor({ chatId });
   } else if (typeof teamId === "string" && teamId && typeof channelId === "string" && channelId) {
-    if (!(await graphOk(`/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}`, session.accessToken))) {
+    const rawTeamId = decodeGraphId(teamId) ?? teamId;
+    const rawChannelId = decodeGraphId(channelId) ?? channelId;
+    if (!(await graphOk(`/teams/${encodeURIComponent(rawTeamId)}/channels/${encodeURIComponent(rawChannelId)}`, session.accessToken))) {
       return NextResponse.json({ error: "Not a member of this channel" }, { status: 403 });
     }
     roomName = voiceRoomNameFor({ teamId, channelId });


### PR DESCRIPTION
## Problem

Two more prod-breaking regressions of the same class as #156, found while sweeping every Graph URL built from route params (prompted by a live `DELETE /api/chats/... → 502` in prod logs):

1. **Chat message edit / single-fetch / delete return 502 for every call** — `encodeURIComponent(chatId)` on an already-percent-encoded route param double-encodes; Graph decodes once, sees `19%3A...`, 404s. Introduced by #139's hardening. Also silently broke the disappearing-message sweep (expired messages survived in native Teams) and the single-message fetch that realtime push (#156) uses.
2. **`/api/voice/token` 403s every legitimate member** — #138's membership check hits `/me/chats/<double-encoded>` → 404 → treated as non-member. Voice joins have been dead since it merged.
3. Files preview content — same pattern, currently latent (drive item ids have no encodable chars); fixed defensively.

## Fix

Decode-then-encode (`encodeURIComponent(decodeGraphId(id) ?? id)`) — a no-op for raw ids, correct for encoded ones. Voice **room names still derive from the as-sent ids**, deliberately: the client derives poll/room names from the same encoded ids, and canonicalizing only the server side would split callers across differently-named rooms.

## Audit of the full class

Swept every `graph.microsoft.com` URL and Graph-SDK `.api()` call built from params: the SDK-based routes (message lists, reactions, replies, members, files) interpolate the encoded param directly, which is correct — only the three files above re-encoded.

## Verification

`npm run build` clean. Post-deploy on prod: edit a message, delete a message, join a voice room — all should succeed; the log's recurring `DELETE → 502` should become 204.