### PR TITLE
fix(api): harden error handling from the route-resilience audit

### DIFF
--- a/src/app/api/ai/summary/route.ts
+++ b/src/app/api/ai/summary/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "OPENAI_API_KEY is not configured" }, { status: 503 });
   }
 
-  const body = (await req.json()) as { messages?: Array<{ author: string; content: string }> };
+  const body = (await req.json().catch(() => ({}))) as { messages?: Array<{ author: string; content: string }> };
   const messages = body.messages?.slice(-30) ?? [];
   if (messages.length === 0) {
     return NextResponse.json({ summary: "No unread messages to summarize." });

--- a/src/app/api/chats/[chatId]/messages/route.ts
+++ b/src/app/api/chats/[chatId]/messages/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request, { params }: { params: Params }) {
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { chatId } = await params;
 
-  const body = (await req.json()) as {
+  const body = (await req.json().catch(() => ({}))) as {
     content?: string;
     attachments?: unknown[];
     mentions?: ClientMention[];

--- a/src/app/api/chats/[chatId]/route.ts
+++ b/src/app/api/chats/[chatId]/route.ts
@@ -14,7 +14,14 @@ export async function GET(
   try {
     const chat = await getChat(session.accessToken, chatId);
     return NextResponse.json(chat);
-  } catch {
-    return NextResponse.json({ error: "Chat not found" }, { status: 404 });
+  } catch (err) {
+    // Only a genuine Graph 404 means the chat doesn't exist; anything else
+    // (throttling, transient outage) must not masquerade as permanent absence.
+    const statusCode = (err as { statusCode?: number })?.statusCode;
+    if (statusCode === 404) {
+      return NextResponse.json({ error: "Chat not found" }, { status: 404 });
+    }
+    console.error("[chats] getChat failed:", err);
+    return NextResponse.json({ error: "Graph get chat failed" }, { status: 502 });
   }
 }

--- a/src/app/api/chats/route.ts
+++ b/src/app/api/chats/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = (await request.json()) as { userId?: string; userIds?: string[]; topic?: string };
+  const body = (await request.json().catch(() => ({}))) as { userId?: string; userIds?: string[]; topic?: string };
   const ids = (body.userIds ?? (body.userId ? [body.userId] : [])).filter(
     (id): id is string => typeof id === "string" && id.length > 0
   );

--- a/src/app/api/files/upload/route.ts
+++ b/src/app/api/files/upload/route.ts
@@ -125,7 +125,7 @@ export async function POST(req: Request) {
     });
   } catch (err) {
     console.error("[graph] chunked drive upload failed:", err);
-    const status = err instanceof GraphUploadError ? 502 : 502;
+    const status = err instanceof GraphUploadError ? err.status : 502;
     return NextResponse.json({ error: "Upload to OneDrive failed" }, { status });
   }
 }

--- a/src/app/api/mcp/chats/[chatId]/messages/route.ts
+++ b/src/app/api/mcp/chats/[chatId]/messages/route.ts
@@ -10,8 +10,13 @@ export async function GET(
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { chatId } = await params;
-  const messages = await getChatMessages(token, chatId);
-  return NextResponse.json(messages);
+  try {
+    const messages = await getChatMessages(token, chatId);
+    return NextResponse.json(messages);
+  } catch (err) {
+    console.error("[mcp] getChatMessages failed:", err);
+    return NextResponse.json({ error: "Graph request failed" }, { status: 502 });
+  }
 }
 
 export async function POST(
@@ -22,9 +27,14 @@ export async function POST(
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { chatId } = await params;
-  const body = (await req.json()) as { message?: string };
+  const body = (await req.json().catch(() => ({}))) as { message?: string };
   if (!body.message) return NextResponse.json({ error: "message required" }, { status: 400 });
 
-  await sendChatMessage(token, chatId, body.message);
-  return NextResponse.json({ ok: true });
+  try {
+    await sendChatMessage(token, chatId, body.message);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[mcp] sendChatMessage failed:", err);
+    return NextResponse.json({ error: "Graph request failed" }, { status: 502 });
+  }
 }

--- a/src/app/api/mcp/chats/route.ts
+++ b/src/app/api/mcp/chats/route.ts
@@ -6,6 +6,11 @@ export async function GET(req: NextRequest) {
   const token = await mcpAuth(req);
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { chats } = await getChats(token, { pageSize: 50 });
-  return NextResponse.json(chats);
+  try {
+    const { chats } = await getChats(token, { pageSize: 50 });
+    return NextResponse.json(chats);
+  } catch (err) {
+    console.error("[mcp] getChats failed:", err);
+    return NextResponse.json({ error: "Graph request failed" }, { status: 502 });
+  }
 }

--- a/src/app/api/mcp/teams/[teamId]/channels/[channelId]/messages/route.ts
+++ b/src/app/api/mcp/teams/[teamId]/channels/[channelId]/messages/route.ts
@@ -10,8 +10,13 @@ export async function GET(
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { teamId, channelId } = await params;
-  const messages = await getMessages(token, teamId, channelId);
-  return NextResponse.json(messages);
+  try {
+    const messages = await getMessages(token, teamId, channelId);
+    return NextResponse.json(messages);
+  } catch (err) {
+    console.error("[mcp] getMessages failed:", err);
+    return NextResponse.json({ error: "Graph request failed" }, { status: 502 });
+  }
 }
 
 export async function POST(
@@ -22,9 +27,14 @@ export async function POST(
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { teamId, channelId } = await params;
-  const body = (await req.json()) as { message?: string };
+  const body = (await req.json().catch(() => ({}))) as { message?: string };
   if (!body.message) return NextResponse.json({ error: "message required" }, { status: 400 });
 
-  await sendMessage(token, teamId, channelId, body.message);
-  return NextResponse.json({ ok: true });
+  try {
+    await sendMessage(token, teamId, channelId, body.message);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[mcp] sendMessage failed:", err);
+    return NextResponse.json({ error: "Graph request failed" }, { status: 502 });
+  }
 }

--- a/src/app/api/mcp/teams/[teamId]/channels/route.ts
+++ b/src/app/api/mcp/teams/[teamId]/channels/route.ts
@@ -10,6 +10,11 @@ export async function GET(
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { teamId } = await params;
-  const channels = await getChannels(token, teamId);
-  return NextResponse.json(channels);
+  try {
+    const channels = await getChannels(token, teamId);
+    return NextResponse.json(channels);
+  } catch (err) {
+    console.error("[mcp] getChannels failed:", err);
+    return NextResponse.json({ error: "Graph request failed" }, { status: 502 });
+  }
 }

--- a/src/app/api/mcp/teams/route.ts
+++ b/src/app/api/mcp/teams/route.ts
@@ -6,6 +6,11 @@ export async function GET(req: NextRequest) {
   const token = await mcpAuth(req);
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const teams = await getTeams(token);
-  return NextResponse.json(teams);
+  try {
+    const teams = await getTeams(token);
+    return NextResponse.json(teams);
+  } catch (err) {
+    console.error("[mcp] getTeams failed:", err);
+    return NextResponse.json({ error: "Graph request failed" }, { status: 502 });
+  }
 }

--- a/src/app/api/messages/[teamId]/[channelId]/route.ts
+++ b/src/app/api/messages/[teamId]/[channelId]/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request, { params }: { params: Params }) {
   const session = await auth();
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { teamId, channelId } = await params;
-  const body = (await req.json()) as {
+  const body = (await req.json().catch(() => ({}))) as {
     content?: string;
     mentions?: ClientMention[];
     contentType?: "html" | "text";

--- a/src/app/api/presence/route.ts
+++ b/src/app/api/presence/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   const session = await auth();
   if (!session?.accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { userIds } = (await req.json()) as { userIds?: string[] };
+  const { userIds } = (await req.json().catch(() => ({}))) as { userIds?: string[] };
   const ids = [...new Set((userIds ?? []).filter(Boolean))].slice(0, 650);
   if (ids.length === 0) return NextResponse.json([]);
 

--- a/src/app/api/presence/setStatusMessage/route.ts
+++ b/src/app/api/presence/setStatusMessage/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = (await req.json()) as SetStatusMessageBody;
+  const body = (await req.json().catch(() => ({}))) as SetStatusMessageBody;
 
   const headers = {
     Authorization: `Bearer ${session.accessToken}`,

--- a/src/app/api/presence/setUserPreferredPresence/route.ts
+++ b/src/app/api/presence/setUserPreferredPresence/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = (await req.json()) as SetPresenceBody;
+  const body = (await req.json().catch(() => ({}))) as SetPresenceBody;
 
   const graphBase = "https://graph.microsoft.com/v1.0/me/presence";
   const headers = {

--- a/src/app/api/realtime/subscribe/route.ts
+++ b/src/app/api/realtime/subscribe/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = (await req.json()) as {
+  const body = (await req.json().catch(() => ({}))) as {
     teamId?: string;
     channelId?: string;
     chatId?: string;

--- a/src/app/api/voice/active-batch/route.ts
+++ b/src/app/api/voice/active-batch/route.ts
@@ -48,8 +48,20 @@ export async function POST(request: NextRequest) {
     if (result.status === "fulfilled") {
       counts[roomNames[i]] = result.value.count;
     } else {
+      // Room doesn't exist (nobody in the call) is the normal case — report 0
+      // silently. Anything else (auth failure, LiveKit outage) also degrades
+      // to 0 to keep the response shape, but gets logged so real failures
+      // aren't invisible. LiveKit's TwirpError signals not-found via the
+      // structured status/code fields, not the message text.
+      const status = (result.reason as { status?: number })?.status;
+      const code = (result.reason as { code?: string })?.code;
       const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
-      counts[roomNames[i]] = msg.includes("not found") || msg.includes("404") || msg.includes("room_not_found") ? 0 : 0;
+      const roomMissing =
+        status === 404 || code === "not_found" || msg.includes("not found") || msg.includes("does not exist");
+      if (!roomMissing) {
+        console.error("[voice] batch listParticipants failed for", roomNames[i], msg);
+      }
+      counts[roomNames[i]] = 0;
     }
   }
 


### PR DESCRIPTION
Systematic sweep of every API route's error mapping (follow-up to the LiveKit error-mapping fix in #157, hunting the same failure shapes elsewhere). Four real defects plus one consistency gap:

1. **`/api/voice/active-batch` — dead ternary `? 0 : 0`**: every LiveKit rejection (auth failure, outage, misconfig) was silently mapped to "0 participants" with no logging. Real outages were invisible, and the sidebar's 0→N transition detection could fire a false "call started" toast when a transient error cleared. Now mirrors #157's structured status/code check and logs non-not-found failures (response shape unchanged).
2. **All 5 MCP routes had zero try/catch around Graph calls** — a bad id, expired token, or Graph 429/5xx crashed to Next's generic unhandled-exception response instead of the JSON error contract MCP clients (Claude Desktop, Cursor) parse. Wrapped → structured 502 + logging; POST bodies' `req.json()` guarded.
3. **`/api/chats/[chatId]` collapsed every failure to 404 "Chat not found"** with no logging — masking throttling/transient outages as permanent absence (a trap for any future caller that navigates away on 404). Only a genuine Graph 404 maps to 404 now.
4. **`/api/files/upload` — dead ternary `? 502 : 502`** discarded `GraphUploadError.status`; upstream status passes through now.
5. **8 unguarded `await req.json()` sites** (including `/api/presence`, a 30s polling endpoint) crashed to 500 on malformed bodies while sibling routes guard the same pattern; all now degrade to the routes' own field validation.

Routes verified clean in the same sweep: activity/scan, ai/*, calendar, channels/*, chats/* (rest), files/*, gifs, image-proxy, github preview, me/teams/meetings/people, messages/*, presence setters (aside from the json guard), realtime sse/subscribe, users photo, voice/token, webhooks/graph, mcp/token.

`npm run build` clean.