### PR TITLE
fix(store): close reconcile races that drop or revert messages

### DIFF
--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -162,10 +162,6 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
     loadRef.current = load;
     load();
 
-    // Webhook push is primary; when SSE is healthy, poll less frequently (2 min)
-    // and fall back to 30 s when SSE is degraded.
-    const interval = setInterval(load, sseHealthy ? 120_000 : 30_000);
-
     // Disappearing-message sweep on a fast cadence (network-free unless one of
     // our own messages has actually expired) — matches the DM view's behavior.
     const sweep = setInterval(() => void sweepExpired(getMessages(contextId)), 4000);
@@ -189,13 +185,19 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
 
     return () => {
       cancelled = true;
-      clearInterval(interval);
       clearInterval(sweep);
       clearInterval(resubscribe);
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamId, channelId, contextId, isHydrated, sseHealthy, setContextLoading, setMessages, showToast, sweepExpired]);
+  }, [teamId, channelId, contextId, isHydrated, setContextLoading, setMessages, showToast, sweepExpired]);
+
+  // Reconcile poll in its own effect: SSE health flaps must only retime the
+  // interval, not re-run the load/subscribe effect above (see ChatView).
+  useEffect(() => {
+    const interval = setInterval(() => void loadRef.current(), sseHealthy ? 120_000 : 30_000);
+    return () => clearInterval(interval);
+  }, [contextId, sseHealthy]);
 
   useRealtimeEvents(
     useCallback(

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -287,10 +287,6 @@ export function ChatView({ chatId }: { chatId: string }) {
     loadRef.current = load;
     load();
 
-    // Webhook push is primary; when SSE is healthy, poll less frequently (2 min)
-    // and fall back to 30 s when SSE is degraded.
-    const interval = setInterval(load, sseHealthy ? 120_000 : 30_000);
-
     // Disappearing-message sweep stays on a fast cadence, decoupled from the
     // message fetch. It's network-free unless one of our own messages has
     // actually expired, so running it every 4s is cheap and preserves the
@@ -321,14 +317,23 @@ export function ChatView({ chatId }: { chatId: string }) {
 
     return () => {
       cancelled = true;
-      clearInterval(interval);
       clearInterval(sweep);
       clearInterval(scheduleSweep);
       clearInterval(resubscribe);
     };
     // getMessages is a stable selector — intentionally not in deps to avoid re-running on cache updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatId, isHydrated, sseHealthy, setContextLoading, setMessages, showToast, sweepExpired, sweepScheduled]);
+  }, [chatId, isHydrated, setContextLoading, setMessages, showToast, sweepExpired, sweepScheduled]);
+
+  // Reconcile poll in its own effect: SSE health flaps (EventSource reconnects
+  // flip healthy false→true) must only retime the interval — keeping sseHealthy
+  // out of the load/subscribe effect above avoids a redundant refetch +
+  // re-subscribe burst on every flap. Webhook push is primary; poll every 2 min
+  // while SSE is healthy, 30 s when degraded.
+  useEffect(() => {
+    const interval = setInterval(() => void loadRef.current(), sseHealthy ? 120_000 : 30_000);
+    return () => clearInterval(interval);
+  }, [chatId, sseHealthy]);
 
   useRealtimeEvents(
     useCallback(

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -14,7 +14,7 @@ import { messagePlainText, renderMessageBody } from "@/lib/utils/render-message"
 import { isDisappearing, unwrapMessage } from "@/lib/utils/disappear";
 import { isPoll, parsePoll } from "@/lib/polls";
 import { PollCard } from "./PollCard";
-import type { ReactionType } from "@/lib/utils/reactions";
+import { reactionsSignature, type ReactionType } from "@/lib/utils/reactions";
 import { useWorkspaceStore } from "@/store/workspace";
 import { useBookmarksStore } from "@/store/bookmarks";
 import { cn } from "@/lib/utils";
@@ -661,6 +661,8 @@ function propsEqual(a: Props, b: Props): boolean {
     a.message.__failed === b.message.__failed &&
     // A late-arriving attachment/card can change without bumping lastModified.
     attachmentSig(a.message) === attachmentSig(b.message) &&
+    // Reactions can also change without a lastModifiedDateTime bump.
+    reactionsSignature(a.message.reactions) === reactionsSignature(b.message.reactions) &&
     a.isGroupHead === b.isGroupHead &&
     a.contextId === b.contextId &&
     a.contextLabel === b.contextLabel

--- a/src/lib/utils/reactions.ts
+++ b/src/lib/utils/reactions.ts
@@ -19,3 +19,19 @@ export function reactionEmoji(type: string): string {
 export function isReactionType(type: string): type is ReactionType {
   return Object.prototype.hasOwnProperty.call(REACTION_EMOJI, type);
 }
+
+/**
+ * Order-insensitive fingerprint of a message's reactions. Reconcile merges and
+ * the memoized message row both key on lastModifiedDateTime, which Graph is
+ * not guaranteed to bump for reaction-only changes — compare this alongside it
+ * so reactions added by other people can't be silently discarded.
+ */
+export function reactionsSignature(
+  reactions?: Array<{ reactionType: string; user: { id: string } }>
+): string {
+  if (!reactions || reactions.length === 0) return "";
+  return reactions
+    .map((r) => `${r.reactionType}:${r.user?.id ?? ""}`)
+    .sort()
+    .join("|");
+}

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { loadAllContexts, saveContext } from "@/lib/storage/message-cache";
+import { reactionsSignature } from "@/lib/utils/reactions";
 
 // Cap each context's persisted+in-memory array. Graph pages are 50; 200
 // covers a couple of "Load more" jumps without unbounded growth.
@@ -204,20 +205,30 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             : incoming;
           // Preserve optimistic (pending/failed) messages that the server response
           // won't contain — they live only in local state until confirmed or failed.
-          const pending = existing.filter((m) => m.__pending || m.__failed);
+          // Also keep messages still inside their optimistic window even when the
+          // server array lacks them: a reconcile whose GET started before a send
+          // resolves without the just-confirmed message and would drop it.
+          const now = Date.now();
+          const pending = existing.filter(
+            (m) => m.__pending || m.__failed || (m.__optimisticUntil ?? 0) > now
+          );
           const serverIds = new Set(filtered.map((m) => m.id));
           const uniquePending = pending.filter((m) => !serverIds.has(m.id));
           // Reuse the existing object for any message whose id + lastModified
           // are unchanged, so React.memo'd rows don't re-render on reconcile.
           const byId = new Map(existing.map((m) => [m.id, m]));
-          const now = Date.now();
           const reused = filtered.map((m) => {
             const prev = byId.get(m.id);
             if (!prev) return m;
             // Hold a just-made optimistic reaction/edit until Graph reflects it,
             // otherwise a poll landing before read-after-write reverts the change.
             if (prev.__optimisticUntil && prev.__optimisticUntil > now) return prev;
-            return prev.lastModifiedDateTime === m.lastModifiedDateTime ? prev : m;
+            // Reactions can change without a lastModifiedDateTime bump, so
+            // compare them explicitly or other people's reactions never land.
+            return prev.lastModifiedDateTime === m.lastModifiedDateTime &&
+              reactionsSignature(prev.reactions) === reactionsSignature(m.reactions)
+              ? prev
+              : m;
           });
           const merged = trimToMax(sortByCreatedDateTime([...reused, ...uniquePending]));
           persistContext(contextId, merged);
@@ -256,7 +267,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const idx = existing.findIndex((m) => m.id === message.id);
           let next: MSMessage[];
           if (idx >= 0) {
-            if (existing[idx].lastModifiedDateTime === message.lastModifiedDateTime) return s;
+            const prev = existing[idx];
+            // The SSE echo of our own action can carry a stale pre-write version
+            // just like a reconcile poll — honor the optimistic window here too.
+            if (prev.__optimisticUntil && prev.__optimisticUntil > Date.now()) return s;
+            if (
+              prev.lastModifiedDateTime === message.lastModifiedDateTime &&
+              reactionsSignature(prev.reactions) === reactionsSignature(message.reactions)
+            )
+              return s;
             next = [...existing];
             next[idx] = message;
             next = sortByCreatedDateTime(next);
@@ -287,7 +306,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const existing = s.messagesByContext[contextId] ?? [];
           const next = existing.map((m) =>
             m.id === tempId
-              ? { ...serverMessage, __pending: undefined, __failed: undefined }
+              ? {
+                  ...serverMessage,
+                  __pending: undefined,
+                  __failed: undefined,
+                  // Survive a reconcile whose GET predates this send — without
+                  // a window, setMessages would drop the just-confirmed message
+                  // until a fresher poll includes it.
+                  __optimisticUntil: Date.now() + 10_000,
+                }
               : m
           );
           persistContext(contextId, next);
@@ -387,7 +414,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const next = [...existing];
           next.splice(index, 1);
           persistContext(contextId, next);
+          // Tombstone so a reconcile poll / SSE echo racing Graph's softDelete
+          // replication can't resurrect the message (mirrors expireMessage).
+          // restoreMessage (undo) lifts the tombstone.
+          const expiredMessageIds = new Set(s.expiredMessageIds);
+          expiredMessageIds.add(messageId);
           return {
+            expiredMessageIds,
             messagesByContext: { ...s.messagesByContext, [contextId]: next },
           };
         });
@@ -400,7 +433,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const next = [...existing];
           next.splice(index, 0, message);
           persistContext(contextId, next);
+          // Undo of a delete — lift the delete tombstone again.
+          const expiredMessageIds = new Set(s.expiredMessageIds);
+          expiredMessageIds.delete(message.id);
           return {
+            expiredMessageIds,
             messagesByContext: { ...s.messagesByContext, [contextId]: next },
           };
         }),


### PR DESCRIPTION
Five confirmed findings from the systematic race audit of the message reconcile paths (store merge rules × polling × SSE):

1. **Sent messages vanish for up to 2 minutes**: a reconcile GET that started before a send resolves without the new message; once `replaceMessage` cleared `__pending`, `setMessages` kept the confirmed message in neither the server array nor the pending filter → dropped. Now: `replaceMessage` stamps the existing 10s `__optimisticUntil` window and `setMessages` preserves in-window messages even when the (stale) server array lacks them.
2. **SSE echo reverts optimistic edits/reactions**: `upsertMessage` ignored `__optimisticUntil`, so the realtime echo of your own action could overwrite it with Graph's stale pre-write version. Now honors the window (matters much more now that #156 made SSE actually deliver).
3. **Deleted messages flicker back**: no delete tombstone, so a poll/SSE echo racing Graph's softDelete replication resurrected the message. Deletes now tombstone via `expiredMessageIds` (exactly how `expireMessage` already prevents this for disappearing messages); undo lifts it.
4. **Other people's reactions could never render**: store merges and the `MessageItem` memo comparator keyed only on `lastModifiedDateTime`, which Graph doesn't reliably bump for reaction-only changes. Added an order-insensitive `reactionsSignature` to both (own reactions were already safe via the optimistic stamp).
5. **SSE flap → refetch/re-subscribe storm**: `sseHealthy` in the polling effect's deps re-ran the whole load+subscribe effect on every EventSource reconnect. The reconcile interval now lives in its own effect (both views); flaps only retime it.

Audit also verified sound: pending-message preservation across polls, `__optimisticUntil` in `setMessages` for reactions/edits, context-switch cancellation, persist partialize (messages not persisted), cache hydration/eviction, realtime event context matching, webhook clientState validation.

`npm run build` clean.