### PR TITLE
fix(ids): align raw and percent-encoded conversation-id keyspaces

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -76,11 +76,22 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const unreadCounts = useWorkspaceStore((s) => s.unreadCounts);
   // Pull the active context's messages so SearchModal can find matches in the
   // currently open chat/channel. Empty array when nothing is open.
+  // The views key messagesByContext by their route params, which arrive
+  // percent-encoded — while active*Id holds the raw Graph id. Check the
+  // encoded form first, then raw, so the lookup works whichever form the
+  // router delivered.
   const activeContextId = activeChannelId && activeTeamId
     ? `${activeTeamId}:${activeChannelId}`
     : activeChatId ?? null;
+  const activeContextIdEncoded = activeChannelId && activeTeamId
+    ? `${activeTeamId}:${encodeURIComponent(activeChannelId)}`
+    : activeChatId ? encodeURIComponent(activeChatId) : null;
   const activeMessages = useWorkspaceStore((s) =>
-    activeContextId ? (s.messagesByContext[activeContextId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES
+    activeContextId
+      ? (activeContextIdEncoded ? s.messagesByContext[activeContextIdEncoded] : undefined) ??
+        s.messagesByContext[activeContextId] ??
+        EMPTY_MESSAGES
+      : EMPTY_MESSAGES
   );
   const openCatchUp = useCatchUpStore((s) => s.setOpen);
   const showToast = useToastStore((state) => state.showToast);

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -220,7 +220,10 @@ export function ChatView({ chatId }: { chatId: string }) {
   useEffect(() => {
     if (chat) return;
     let cancelled = false;
-    fetch(`/api/chats/${encodeURIComponent(chatId)}`)
+    // chatId is the route param and already percent-encoded — wrapping it in
+    // encodeURIComponent again double-encodes and 404s (same as the messages
+    // fetch below, which uses it directly).
+    fetch(`/api/chats/${chatId}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data: MSChat | null) => { if (!cancelled && data) patchChat(data); })
       .catch(() => {});
@@ -238,7 +241,7 @@ export function ChatView({ chatId }: { chatId: string }) {
   useEffect(() => {
     if (storeMembers.length > 0) return;
     let cancelled = false;
-    fetch(`/api/chats/${encodeURIComponent(chatId)}/members`)
+    fetch(`/api/chats/${chatId}/members`)
       .then((r) => r.ok ? r.json() : Promise.reject())
       .then((data: MSChatMember[]) => {
         if (!cancelled) {

--- a/src/hooks/useSmartNotifications.ts
+++ b/src/hooks/useSmartNotifications.ts
@@ -67,13 +67,22 @@ export function useSmartNotifications({
     // 3. Quiet hours window — skip both sound and OS notifications.
     if (quietHoursEnabled && inQuietHours(new Date(), quietHoursStart, quietHoursEnd)) return;
 
-    // 3a. Snooze: skip if this context has an active snooze. The contextId
-    // shape that arrives here is "teamId/channelId" for channels but our
-    // snooze store keys with "teamId:channelId" (same shape used elsewhere) —
-    // check both so either spelling matches.
+    // 3a. Snooze: skip if this context has an active snooze. The sidebar
+    // snoozes with raw Graph ids while this hook receives the views'
+    // (percent-encoded) route params, and channels arrive as
+    // "teamId/channelId" while the store keys "teamId:channelId" — check
+    // every spelling so a snooze set anywhere actually silences here.
     if (contextId) {
-      const colonForm = contextId.replace("/", ":");
-      const expiresAt = snoozedContexts[contextId] ?? snoozedContexts[colonForm];
+      const decoded = safeDecode(contextId);
+      const candidates = [
+        contextId,
+        contextId.replace("/", ":"),
+        decoded,
+        decoded.replace("/", ":"),
+      ];
+      const expiresAt = candidates
+        .map((key) => snoozedContexts[key])
+        .find((v) => v !== undefined);
       if (expiresAt && expiresAt > Date.now()) return;
     }
 
@@ -183,10 +192,23 @@ function isMuted(text: string, mutedKeywords: string[]): boolean {
 function isViewingContext(contextId?: string, contextKind?: "chat" | "channel"): boolean {
   if (!contextId || !contextKind) return false;
   if (typeof window === "undefined") return false;
-  const path = window.location.pathname;
-  if (contextKind === "chat") return path === `/workspace/dm/${contextId}`;
+  // Decode both sides: the browser may keep : and @ raw in location.pathname
+  // while contextId is the (percent-encoded) route param — comparing mixed
+  // forms made this always false, so notifications fired for the very
+  // conversation the user was reading.
+  const path = safeDecode(window.location.pathname);
+  if (contextKind === "chat") return path === `/workspace/dm/${safeDecode(contextId)}`;
   // channel contextId is "{teamId}/{channelId}"
-  return path === `/workspace/t/${contextId}`;
+  return path === `/workspace/t/${safeDecode(contextId)}`;
+}
+
+/** decodeURIComponent that returns the input untouched on malformed escapes. */
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 /**

--- a/src/lib/graph/client.ts
+++ b/src/lib/graph/client.ts
@@ -1,4 +1,5 @@
 import { Client } from "@microsoft/microsoft-graph-client";
+import { decodeGraphId } from "@/lib/realtime/ids";
 
 export function getGraphClient(accessToken: string) {
   return Client.init({
@@ -127,6 +128,14 @@ export async function getChats(
   };
 }
 
+// Callers pass chat ids in whichever form they hold — raw Graph ids or the
+// still-percent-encoded route param. Normalize before encoding for the Graph
+// path (the SDK transmits it verbatim); encoding an already-encoded id twice
+// makes Graph 404 the chat.
+function encodeChatId(chatId: string): string {
+  return encodeURIComponent(decodeGraphId(chatId) ?? chatId);
+}
+
 export async function getChat(accessToken: string, chatId: string): Promise<MSChat> {
   const client = getGraphClient(accessToken);
   // Chat IDs containing '@' (e.g. @unq.gbl.spaces) must be percent-encoded.
@@ -134,7 +143,7 @@ export async function getChat(accessToken: string, chatId: string): Promise<MSCh
   // a property on the base conversationMember type), so we skip the expand here
   // and let the sidebar fetch members separately via /members.
   return client
-    .api(`/me/chats/${encodeURIComponent(chatId)}`)
+    .api(`/me/chats/${encodeChatId(chatId)}`)
     .select("id,chatType,topic,lastUpdatedDateTime,lastMessagePreview")
     .get() as Promise<MSChat>;
 }
@@ -142,7 +151,7 @@ export async function getChat(accessToken: string, chatId: string): Promise<MSCh
 export async function getChatMessages(accessToken: string, chatId: string) {
   const client = getGraphClient(accessToken);
   const res = await client
-    .api(`/me/chats/${encodeURIComponent(chatId)}/messages`)
+    .api(`/me/chats/${encodeChatId(chatId)}/messages`)
     .top(50)
     .get();
   return res.value as MSMessage[];
@@ -153,7 +162,7 @@ export async function getChatMembers(accessToken: string, chatId: string) {
   // Don't use $select — userId/email are on the derived aadUserConversationMember
   // type, not the base conversationMember, so selecting them causes a 400.
   const res = await client
-    .api(`/me/chats/${encodeURIComponent(chatId)}/members`)
+    .api(`/me/chats/${encodeChatId(chatId)}/members`)
     .get();
   return res.value as MSChatMember[];
 }

--- a/src/lib/storage/prefetch.ts
+++ b/src/lib/storage/prefetch.ts
@@ -13,13 +13,20 @@ import { getTopVisited, type VisitTarget } from "./visit-counter";
 import { useWorkspaceStore } from "@/store/workspace";
 
 function urlFor(target: VisitTarget): string {
+  // Visit targets hold raw Graph ids; encode for the URL exactly like the
+  // router does so the API route receives the same param form the views send.
   return target.kind === "channel"
-    ? `/api/messages/${target.teamId}/${target.channelId}`
-    : `/api/chats/${target.chatId}/messages`;
+    ? `/api/messages/${target.teamId}/${encodeURIComponent(target.channelId)}`
+    : `/api/chats/${encodeURIComponent(target.chatId)}/messages`;
 }
 
 function contextIdFor(target: VisitTarget): string {
-  return target.kind === "channel" ? `${target.teamId}:${target.channelId}` : target.chatId;
+  // Match the views' keyspace: they key messagesByContext by their route
+  // params, which arrive percent-encoded. Writing the raw id here warmed a
+  // key nothing ever read.
+  return target.kind === "channel"
+    ? `${target.teamId}:${encodeURIComponent(target.channelId)}`
+    : encodeURIComponent(target.chatId);
 }
 
 /**


### PR DESCRIPTION
Remaining findings from the id-format contract audit (same class as #156/#160 but client-side keyspaces). The store effectively had two id dialects — raw Graph ids (chats/channels lists, `active*Id`, snooze keys, visit counter) and percent-encoded route params (`messagesByContext` keys, view props). Every place they met, the feature silently no-op'd:

1. **In-conversation search never worked** — `AppShell` built `activeContextId` raw, `messagesByContext` is keyed encoded → `SearchModal` always got an empty array for real Teams conversations. Fixed with an encoded-first/raw-fallback lookup (form-agnostic).
2. **Snooze never silenced notifications** — sidebar writes raw keys, `useSmartNotifications` read the encoded form. The sidebar's own indicator reads the key it wrote, so the feature *looked* on while notifications kept firing. The notifier now checks all four spellings (raw/encoded × slash/colon).
3. **Open-conversation notification suppression failed** — encoded path template vs `location.pathname` (browsers keep `:`/`@` raw) → you got dinged for the chat you were reading. Both sides now decoded before comparing.
4. **Deep-link chat header/members 404'd** — `getChat`/`getChatMessages`/`getChatMembers` double-encoded the already-encoded param (and ChatView triple-wrapped two call sites). Helpers now normalize via decode-then-encode — a no-op for raw ids, so all callers are safe regardless of input form.
5. **Cold-start prefetch was dead weight** — warmed raw-keyed entries nothing reads and its already-cached check never matched, so it re-fetched hydrated contexts. Now uses the views' keyspace and encodes URLs.

Audit verified consistent (no change needed): unreadCounts/chatReadAt (raw⇄raw), loadingContexts (encoded⇄encoded within views), realtime event comparison (#156), navigation hrefs, presence maps, anchor params, send/reply/reaction Graph helpers.

`npm run build` clean.