### PR TITLE
fix(thread): track the live parent message while the panel is open

### DIFF
--- a/src/components/messages/ChannelView.tsx
+++ b/src/components/messages/ChannelView.tsx
@@ -7,6 +7,7 @@ import { useShallow } from "zustand/react/shallow";
 import { MessageFeed } from "./MessageFeed";
 import { MessageInput } from "./MessageInput";
 import { ThreadPanel } from "./ThreadPanel";
+import { selectThreadParent } from "@/lib/utils/threads";
 import { ChannelMessageHeader, type Tab } from "./MessageHeader";
 import { ChannelIntroCard } from "./IntroCard";
 import { ContextFilesTab } from "./ContextFilesTab";
@@ -519,7 +520,7 @@ export function ChannelView({ teamId, channelId }: { teamId: string; channelId: 
       )}
       <ThreadPanel
         open={Boolean(threadMessage)}
-        message={threadMessage}
+        message={selectThreadParent(messages, threadMessage)}
         onClose={() => setThreadMessage(null)}
         onSendReply={handleThreadReply}
         onForward={setForwardMessage}

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -8,6 +8,7 @@ import { usePreferencesStore } from "@/store/preferences";
 import { MessageFeed } from "./MessageFeed";
 import { MessageInput } from "./MessageInput";
 import { ThreadPanel } from "./ThreadPanel";
+import { selectThreadParent } from "@/lib/utils/threads";
 import { DmMessageHeader, type Tab } from "./MessageHeader";
 import { DmIntroCard } from "./IntroCard";
 import { ContextFilesTab } from "./ContextFilesTab";
@@ -853,7 +854,7 @@ export function ChatView({ chatId }: { chatId: string }) {
       )}
       <ThreadPanel
         open={Boolean(threadMessage)}
-        message={threadMessage}
+        message={selectThreadParent(messages, threadMessage)}
         onClose={() => setThreadMessage(null)}
         onSendReply={handleThreadReply}
         onForward={setForwardMessage}

--- a/src/components/messages/DemoChannelView.tsx
+++ b/src/components/messages/DemoChannelView.tsx
@@ -6,6 +6,7 @@ import { mockMessages } from "@/lib/mock/data";
 import { MessageFeed } from "./MessageFeed";
 import { MessageInput } from "./MessageInput";
 import { ThreadPanel } from "./ThreadPanel";
+import { selectThreadParent } from "@/lib/utils/threads";
 import { ChannelMessageHeader, type Tab } from "./MessageHeader";
 import { ChannelIntroCard } from "./IntroCard";
 import { useMemberPanelStore } from "@/store/memberPanel";
@@ -140,7 +141,7 @@ export function DemoChannelView({ channelId }: { channelId: string }) {
       )}
       <ThreadPanel
         open={Boolean(threadMessage)}
-        message={threadMessage}
+        message={selectThreadParent(messages, threadMessage)}
         onClose={() => setThreadMessage(null)}
         onForward={setForwardMessage}
       />

--- a/src/components/messages/DemoChatView.tsx
+++ b/src/components/messages/DemoChatView.tsx
@@ -9,6 +9,7 @@ import { textToHtml } from "@/lib/utils/render-message";
 import { MessageFeed } from "./MessageFeed";
 import { MessageInput } from "./MessageInput";
 import { ThreadPanel } from "./ThreadPanel";
+import { selectThreadParent } from "@/lib/utils/threads";
 import { DmMessageHeader, type Tab } from "./MessageHeader";
 import { DmIntroCard } from "./IntroCard";
 import { ForwardMessageModal, type ForwardDestination } from "@/components/modals/ForwardMessageModal";
@@ -172,7 +173,7 @@ export function DemoChatView({ chatId }: { chatId: string }) {
       )}
       <ThreadPanel
         open={Boolean(threadMessage)}
-        message={threadMessage}
+        message={selectThreadParent(messages, threadMessage)}
         onClose={() => setThreadMessage(null)}
         onForward={setForwardMessage}
       />

--- a/src/components/messages/ThreadPanel.tsx
+++ b/src/components/messages/ThreadPanel.tsx
@@ -6,6 +6,7 @@ import { MessageInput } from "./MessageInput";
 import { MessageItem } from "./MessageItem";
 import { useWorkspaceStore } from "@/store/workspace";
 import { useToastStore } from "@/store/toasts";
+import { mergeThreadReplies } from "@/lib/utils/threads";
 
 interface ThreadPanelProps {
   message: MSMessage | null;
@@ -21,9 +22,13 @@ export function ThreadPanel({ message, open, onClose, onSendReply, onForward }: 
   const currentUserName = useWorkspaceStore((state) => state.currentUserName);
   const showToast = useToastStore((state) => state.showToast);
 
+  // Server replies render from the live parent; local state holds only
+  // optimistic sends, reset when the panel moves to another thread.
   useEffect(() => {
-    setLocalReplies(message?.replies ?? []);
+    setLocalReplies([]);
   }, [message?.id]);
+
+  const replies = mergeThreadReplies(message?.replies, localReplies);
 
   useEffect(() => {
     if (!open) return;
@@ -102,16 +107,16 @@ export function ThreadPanel({ message, open, onClose, onSendReply, onForward }: 
 
       <div className="flex-1 overflow-y-auto py-2">
         <MessageItem message={message} isGroupHead onForward={onForward} />
-        {localReplies.length > 0 && (
+        {replies.length > 0 && (
           <div className="my-2 flex items-center px-4">
             <div className="h-px flex-1 bg-[#3f4144]" />
             <span className="mx-3 text-[12px] font-bold text-[#6c6f75]">
-              {localReplies.length} {localReplies.length === 1 ? "reply" : "replies"}
+              {replies.length} {replies.length === 1 ? "reply" : "replies"}
             </span>
             <div className="h-px flex-1 bg-[#3f4144]" />
           </div>
         )}
-        {localReplies.map((reply) => (
+        {replies.map((reply) => (
           <MessageItem
             key={reply.id}
             message={reply}

--- a/src/lib/utils/threads.test.ts
+++ b/src/lib/utils/threads.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { mergeThreadReplies, selectThreadParent } from "./threads";
+
+// Guards the #164 fix: the thread panel must track the live parent message
+// from the store (edits/reactions surface while open) and must surface
+// server-fetched replies without dropping or duplicating optimistic ones.
+
+function msg(id: string, over: Partial<MSMessage> = {}): MSMessage {
+  return {
+    id,
+    createdDateTime: "2026-01-01T12:00:00Z",
+    lastModifiedDateTime: "2026-01-01T12:00:00Z",
+    body: { content: `msg ${id}`, contentType: "text" },
+    from: { user: { id: "other-user", displayName: "Other" } },
+    ...over,
+  } as MSMessage;
+}
+
+describe("selectThreadParent", () => {
+  it("returns the live message when the snapshot id is in the window", () => {
+    const snapshot = msg("1");
+    const live = msg("1", { body: { content: "edited", contentType: "text" } });
+    expect(selectThreadParent([msg("0"), live, msg("2")], snapshot)).toBe(live);
+  });
+
+  it("falls back to the snapshot when the id left the window", () => {
+    const snapshot = msg("gone");
+    expect(selectThreadParent([msg("1"), msg("2")], snapshot)).toBe(snapshot);
+  });
+
+  it("returns null for a null snapshot", () => {
+    expect(selectThreadParent([msg("1")], null)).toBeNull();
+  });
+});
+
+describe("mergeThreadReplies", () => {
+  it("appends optimistic local replies after server replies", () => {
+    const merged = mergeThreadReplies([msg("r1")], [msg("temp-1", { __pending: true })]);
+    expect(merged.map((m) => m.id)).toEqual(["r1", "temp-1"]);
+  });
+
+  it("dedupes a local reply once the server copy arrives, keeping the server copy", () => {
+    const server = msg("r1", { body: { content: "server copy", contentType: "text" } });
+    const local = msg("r1", { body: { content: "local copy", contentType: "text" } });
+    const merged = mergeThreadReplies([server], [local]);
+    expect(merged).toEqual([server]);
+  });
+
+  it("returns local replies alone when the parent has no server replies", () => {
+    const local = msg("temp-1", { __pending: true });
+    expect(mergeThreadReplies(undefined, [local])).toEqual([local]);
+  });
+
+  it("preserves server order ahead of local order", () => {
+    const merged = mergeThreadReplies(
+      [msg("r1"), msg("r2")],
+      [msg("r2"), msg("temp-1"), msg("temp-2")]
+    );
+    expect(merged.map((m) => m.id)).toEqual(["r1", "r2", "temp-1", "temp-2"]);
+  });
+});

--- a/src/lib/utils/threads.ts
+++ b/src/lib/utils/threads.ts
@@ -1,0 +1,24 @@
+/**
+ * Thread-panel selectors (#164). The panel opens from a snapshot captured in
+ * component state; these keep it tracking the live store while open.
+ */
+
+/** Live parent from the message window by id; snapshot fallback if it left the window. */
+export function selectThreadParent(
+  messages: MSMessage[],
+  snapshot: MSMessage | null
+): MSMessage | null {
+  if (!snapshot) return null;
+  return messages.find((m) => m.id === snapshot.id) ?? snapshot;
+}
+
+/** Server replies first, then optimistic local replies not yet echoed back by the server. */
+export function mergeThreadReplies(
+  serverReplies: MSMessage[] | undefined,
+  localReplies: MSMessage[]
+): MSMessage[] {
+  const server = serverReplies ?? [];
+  if (server.length === 0) return localReplies;
+  const serverIds = new Set(server.map((m) => m.id));
+  return [...server, ...localReplies.filter((m) => !serverIds.has(m.id))];
+}


### PR DESCRIPTION
## Summary
- `ThreadPanel` rendered the `threadMessage` snapshot captured in view state when the panel opened, so parent-message edits/reactions and replies fetched by later polls never surfaced while it was open (the deferred reconcile-audit finding).
- New pure helpers in `src/lib/utils/threads.ts`: `selectThreadParent` picks the live parent from the message window by id (snapshot fallback if it left the window); `mergeThreadReplies` renders server replies first and appends only optimistic local replies the server hasn't echoed back, deduped by id.
- All four views (`ChatView`, `ChannelView`, and both demo views) now pass the live parent; the panel's local reply state carries optimistic sends only.

## Testing
- 7 new vitest cases for the helpers (live-parent selection, window fallback, reply merge/dedup/order); full suite 31/31 green.
- `npm run build` passes.
- Manual QA (needs a signed-in session): open a thread, edit/react to the parent from the main feed or a second client — the panel should update in place.

Closes #164