### PR TITLE
fix(mcp): derive serverInfo version from package.json

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -33,6 +33,7 @@ import { z } from "zod";
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+import { version } from "./package.json";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -241,7 +242,7 @@ async function graph(path: string, options: RequestInit = {}) {
 // MCP server + tools
 // ---------------------------------------------------------------------------
 
-const server = new McpServer({ name: "teamsly", version: "2.0.0" });
+const server = new McpServer({ name: "teamsly", version });
 
 server.tool(
   "list_chats",


### PR DESCRIPTION
The MCP server hardcoded `version: "2.0.0"` in serverInfo while the published `@teamsly/mcp` is 0.1.0. Now imported from `package.json` so they can't drift.

Verified over stdio: `initialize` response reports `{"name":"teamsly","version":"0.1.0"}` after `npm run build`. (The pre-existing `data?.value` tsc complaints in this package are untouched — tsup doesn't type-check and they predate this change.)

Needs an npm republish to propagate to `npx @teamsly/mcp` users (owner).

Closes #171