### PR TITLE
feat(ui): motion pass — microinteractions + token foundation

### DIFF
--- a/docs/superpowers/plans/2026-07-14-motion-pass.md
+++ b/docs/superpowers/plans/2026-07-14-motion-pass.md
@@ -1,0 +1,359 @@
+# Motion Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the approved motion pass — token foundation plus playful-but-earned microinteractions (celebration confetti, send spring, picker stagger, sidebar/badge polish, landing reveals).
+
+**Architecture:** All motion is CSS-first on the existing token system in `src/app/globals.css` (Tailwind 4 `@theme`). New JS is limited to: one pure detector (`celebrate.ts`), one overlay component (`CelebrationBurst`), one preference flag, one IntersectionObserver hook, and a digit-roll badge span. Spec: `docs/superpowers/specs/2026-07-14-motion-pass-design.md` — read it first.
+
+**Tech Stack:** Next 16 / React / Tailwind 4 (`@theme` CSS tokens) / zustand / vitest.
+
+## Global Constraints
+
+- Zero new npm dependencies.
+- transform/opacity only; no new continuous animations.
+- Every new effect inside `@media (prefers-reduced-motion: no-preference)` OR driven by the tokens that zero under reduced motion.
+- Brand palette only — never introduce `#1164a3 #4a154b #3f0e40 #350d36 #611f69` or other Slack-palette hexes (BRAND.md).
+- No experimental Next.js flags.
+- No commit trailers mentioning AI/agents. Conventional Commits, imperative subject.
+- `npm test` and `npm run build` must pass at the end of every task.
+- Do not change component behavior — additive polish only.
+
+---
+
+### Task 1: Motion/radius/shadow tokens
+
+**Files:**
+- Modify: `src/app/globals.css` (the `@theme` block at top; the `:root` token block near line 100; the reduced-motion block near line 125)
+
+**Interfaces:**
+- Produces: CSS vars `--ease-bounce`, `--motion-slower`, `--radius-sm/md/lg/xl`, `--shadow-raised/overlay/popover` for later tasks.
+
+- [ ] **Step 1: Add easing + duration tokens**
+
+In the `:root` block that currently holds `--ease-snap/spring/out-soft` and `--motion-fast/base/slow`, add:
+
+```css
+  --ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);  /* earned-playful overshoot */
+  --motion-slower: 480ms;                              /* celebration-scale effects */
+```
+
+In the `@media (prefers-reduced-motion: reduce)` block where `--motion-fast/base/slow` zero out, add `--motion-slower: 0ms;`.
+
+- [ ] **Step 2: Add radius + shadow tokens to `@theme`**
+
+Inside the existing `@theme` block:
+
+```css
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --shadow-raised: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-overlay: -4px 0 16px rgba(0, 0, 0, 0.3);
+  --shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.4);
+```
+
+(Tailwind 4 maps `--radius-*`/`--shadow-*` theme vars onto `rounded-*`/`shadow-*` utilities; existing class usage keeps working. Before committing, grep two sample components using `rounded-md` and confirm rendering is unchanged by running the build.)
+
+- [ ] **Step 3: Retarget the existing bounce curves**
+
+`slash-fx-pop` uses `cubic-bezier(0.34, 1.56, 0.64, 1)` inline — replace with `var(--ease-bounce)`. Also swap the raw curves in `.react-burst` (`cubic-bezier(0.2, 0.8, 0.2, 1)`) and `.slash-menu-in` only if identical to an existing token; if not identical, leave and note in the PR body.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm test` → all pass; `npm run build` → clean.
+
+```bash
+git add src/app/globals.css
+git commit -m "feat(ui): add bounce/slower motion tokens and radius/shadow theme tokens"
+```
+
+### Task 2: Hardcoded motion sweep
+
+**Files:**
+- Modify: components under `src/components/**` and `src/app/**` that hardcode durations (`duration-150`, `duration-[80ms]`, `duration-[120ms]`, etc.) or inline easings.
+
+**Interfaces:**
+- Consumes: tokens from Task 1.
+
+- [ ] **Step 1: Inventory**
+
+Run: `grep -rn "duration-\[\|duration-75\|duration-100\|duration-150\|duration-200\|duration-300\|cubic-bezier" src/components src/app --include='*.tsx' | grep -v node_modules`
+
+- [ ] **Step 2: Apply the snap rule**
+
+For each hit: if the value is within 40ms of a token (fast=120, base=200, slow=320, slower=480), replace with the token via Tailwind arbitrary value, e.g. `duration-150` → `duration-[var(--motion-fast)]`, `duration-200` → `duration-[var(--motion-base)]`. `duration-[80ms]` → `duration-[var(--motion-fast)]`. Inline `cubic-bezier` in tsx `style`/classes → the matching `var(--ease-*)`. Anything not within 40ms of a token: leave it, list it in the commit body.
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `npm test` and `npm run build` → green. Visually spot-check one hover (sidebar item) and one modal open in demo mode if the dev server is available; otherwise rely on build.
+
+```bash
+git add -A
+git commit -m "refactor(ui): route hardcoded animation durations/easings through motion tokens"
+```
+
+### Task 3: Celebration confetti
+
+**Files:**
+- Create: `src/lib/utils/celebrate.ts`
+- Create: `src/lib/utils/celebrate.test.ts`
+- Create: `src/components/messages/CelebrationBurst.tsx`
+- Modify: `src/store/preferences.ts` (add `celebrationEffects: boolean`, default `true`, + setter, persisted like siblings)
+- Modify: `src/components/modals/PreferencesModal.tsx` (Notifications panel: toggle "Celebration effects" — hint: "Confetti when a message is pure celebration (🎉)")
+- Modify: `src/components/messages/MessageFeed.tsx` (render overlay + fire on qualifying messages)
+- Modify: `src/app/globals.css` (confetti keyframes)
+
+**Interfaces:**
+- Produces: `isCelebrationMessage(text: string): boolean`; `<CelebrationBurst playKey={string} />` — plays once per distinct non-empty `playKey`.
+
+- [ ] **Step 1: Write the failing detector test** (`src/lib/utils/celebrate.test.ts`)
+
+```ts
+import { describe, expect, it } from "vitest";
+import { isCelebrationMessage } from "./celebrate";
+
+describe("isCelebrationMessage", () => {
+  it("accepts pure celebration emoji", () => {
+    expect(isCelebrationMessage("🎉")).toBe(true);
+    expect(isCelebrationMessage("🎉🎉🎉")).toBe(true);
+    expect(isCelebrationMessage("🎊 🥳")).toBe(true);
+    expect(isCelebrationMessage("🥳🚀")).toBe(true); // other emoji allowed alongside a trigger
+  });
+  it("rejects text, mixed content, missing trigger, and empties", () => {
+    expect(isCelebrationMessage("party at 🎉 9")).toBe(false);
+    expect(isCelebrationMessage("congrats!")).toBe(false);
+    expect(isCelebrationMessage("🚀🚀")).toBe(false); // emoji but no celebration trigger
+    expect(isCelebrationMessage("")).toBe(false);
+    expect(isCelebrationMessage("<p>🎉</p>")).toBe(true); // html-wrapped still counts
+    expect(isCelebrationMessage("🎉".repeat(40))).toBe(false); // > 32 chars after strip
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect module-missing failure**
+
+Run: `npx vitest run src/lib/utils/celebrate.test.ts` → FAIL (cannot resolve `./celebrate`).
+
+- [ ] **Step 3: Implement the detector** (`src/lib/utils/celebrate.ts`)
+
+```ts
+/** Celebration detector (#72 motion pass): a message that is nothing but
+ * emoji, at least one of which is a celebration trigger, earns confetti. */
+const TRIGGERS = ["\u{1F389}", "\u{1F38A}", "\u{1F973}"]; // 🎉 🎊 🥳
+const EMOJI_ONLY = /^(?:\p{Extended_Pictographic}|\p{Emoji_Component}|‍|️|\s)+$/u;
+
+export function isCelebrationMessage(raw: string): boolean {
+  const text = raw.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim();
+  if (!text || text.length > 32) return false;
+  if (!TRIGGERS.some((t) => text.includes(t))) return false;
+  return EMOJI_ONLY.test(text);
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass; commit**
+
+```bash
+git add src/lib/utils/celebrate.ts src/lib/utils/celebrate.test.ts
+git commit -m "feat(chat): celebration-message detector"
+```
+
+- [ ] **Step 5: Keyframes + component**
+
+`globals.css`, inside `@media (prefers-reduced-motion: no-preference)`:
+
+```css
+  @keyframes confetti-fall {
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); opacity: 1; }
+    100% { transform: translate3d(var(--cf-x), var(--cf-y), 0) rotate(var(--cf-r)) scale(0.6); opacity: 0; }
+  }
+  .confetti-particle { animation: confetti-fall var(--motion-slower) var(--ease-out-soft) forwards; }
+```
+
+`CelebrationBurst.tsx` — client component; on `playKey` change (non-empty, unseen this mount) renders 24 absolutely-positioned spans in a `pointer-events-none absolute inset-0 overflow-hidden z-10` wrapper anchored to the feed; each span gets inline CSS vars derived from its index (deterministic, no `Math.random`): `--cf-x: ${(i % 8 - 3.5) * 28}px`, `--cf-y: ${120 + (i % 5) * 40}px`, `--cf-r: ${(i % 2 ? 1 : -1) * (180 + i * 20)}deg`, a 6×10px rounded rectangle, color cycling through `var(--accent)`, `#f0b429`, `#57bb8a`, `#cd5b45`, `#818CF8` (existing app hues); wrapper unmounts via `onAnimationEnd` counting to 24 or a `setTimeout(600)` fallback. Also bail out (render nothing) when `usePreferencesStore.celebrationEffects` is false.
+
+- [ ] **Step 6: Wire into MessageFeed**
+
+In `MessageFeed.tsx`: track `celebrateKey` state; in the effect that already watches `messages` for arrival detection, when the newest message `isCelebrationMessage(bodyText)` AND its id hasn't been seen in a module-level `Set` (seed the Set with all current ids on first run so history never fires), set `celebrateKey` to the message id. Render `<CelebrationBurst playKey={celebrateKey} />` inside the scroll container. This covers own sends (optimistic append) and incoming messages in the open conversation with one code path. Use `messagePlainText` from `@/lib/utils/render-message` to get body text.
+
+- [ ] **Step 7: Preference toggle**
+
+`preferences.ts`: add `celebrationEffects: true` + `setCelebrationEffects` following the exact pattern of an existing boolean pref (e.g. `desktopNotifications`), including persistence partialize if present. `PreferencesModal.tsx` Notifications panel: copy an existing Toggle row.
+
+- [ ] **Step 8: Verify + commit**
+
+Run: `npm test`, `npm run build` → green. Dev server: open `/demo`, send `🎉🎉` in a demo chat → confetti plays once; send plain text → nothing; toggle pref off → nothing.
+
+```bash
+git add -A
+git commit -m "feat(chat): confetti burst for pure-celebration messages"
+```
+
+### Task 4: Send feel + emoji picker play
+
+**Files:**
+- Modify: `src/app/globals.css` (`message-in` keyframe, picker stagger classes)
+- Modify: `src/components/messages/MessageItem.tsx` or `MessageFeed.tsx` (wherever `message-in` is applied — grep first; apply only to `__pending` messages)
+- Modify: `src/components/messages/MessageInput.tsx` (send button press)
+- Modify: `src/components/messages/EmojiPicker.tsx` (hover pop + stagger)
+
+**Interfaces:**
+- Consumes: `--ease-spring`, `--motion-fast/base` from Task 1.
+
+- [ ] **Step 1: Upgrade `message-in`**
+
+```css
+  @keyframes message-in {
+    from { opacity: 0; transform: translateY(8px) scale(0.98); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+  .message-in { animation: message-in var(--motion-base) var(--ease-spring) both; }
+```
+
+Grep `message-in` usage. Ensure the class lands ONLY on rows whose message has `__pending` (own optimistic sends); if it's currently applied more broadly, narrow it: `className={cn(..., message.__pending && "message-in")}`.
+
+- [ ] **Step 2: Send button micro-press**
+
+On the send button in `MessageInput.tsx` add `active:scale-90 transition-transform duration-[var(--motion-fast)] ease-[var(--ease-snap)]` (keep existing classes).
+
+- [ ] **Step 3: Picker hover pop + stagger**
+
+Emoji entry buttons: add `transition-transform duration-[var(--motion-fast)] hover:scale-125 focus-visible:scale-125` (transform-only). Picker open: on the grid wrapper's children add `style={{ animationDelay: `${Math.min(index, 20) * 12}ms` }}` with class `motion-fade-up` (existing keyframe) — only if entries are rendered from a mapped array with an index available; if the grid is one static block, apply `motion-fade-up` to category sections instead.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm test`, `npm run build`. Demo mode: send a message → it springs up once and does not re-animate on poll; open emoji picker → gentle stagger; hover an emoji → pop.
+
+```bash
+git add -A
+git commit -m "feat(chat): send spring, button press, emoji picker stagger"
+```
+
+### Task 5: Sidebar spring + unread badge roll + panel crossfade
+
+**Files:**
+- Modify: `src/components/sidebar/Sidebar.tsx` (item transitions; badge at ~line 946)
+- Create: `src/components/ui/RollingNumber.tsx`
+- Create: `src/components/ui/RollingNumber.test.tsx` — only if a pure digit-diff helper is extracted; otherwise skip the test file
+- Modify: `src/app/globals.css` (roll keyframes)
+- Modify: `src/components/messages/ChatView.tsx`, `ChannelView.tsx`, `src/app/workspace/activity/page.tsx`, catch-up home component (consistent `context-fade-in` on panel mount — grep `context-fade-in` for the existing pattern)
+
+**Interfaces:**
+- Produces: `<RollingNumber value={number} />` — renders the number; animates digit change.
+
+- [ ] **Step 1: Sidebar item spring**
+
+Nav item rows: ensure hover/active background + transform transitions use `transition-[background-color,transform] duration-[var(--motion-base)] ease-[var(--ease-spring)]`; add `active:scale-[0.98]` press. No structural refactor: skip the shared indicator pill unless the active item already has an absolutely-positioned sibling to animate.
+
+- [ ] **Step 2: RollingNumber**
+
+```tsx
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+/** Odometer-lite: when `value` changes, old number slides up+fades, new slides in. */
+export function RollingNumber({ value }: { value: number }) {
+  const prev = useRef(value);
+  const [anim, setAnim] = useState(false);
+  useEffect(() => {
+    if (prev.current !== value) {
+      prev.current = value;
+      setAnim(true);
+      const t = setTimeout(() => setAnim(false), 240);
+      return () => clearTimeout(t);
+    }
+  }, [value]);
+  return (
+    <span className="relative inline-block overflow-hidden tabular-nums">
+      <span key={value} className={anim ? "roll-in inline-block" : "inline-block"}>{value}</span>
+    </span>
+  );
+}
+```
+
+```css
+  @keyframes roll-in {
+    from { transform: translateY(0.7em); opacity: 0; }
+    to   { transform: translateY(0); opacity: 1; }
+  }
+  .roll-in { animation: roll-in var(--motion-base) var(--ease-spring) both; }
+```
+
+Swap the badge count text at `Sidebar.tsx:946` (the `rounded-full bg-[var(--badge-unread)]` span) to render `<RollingNumber value={count} />` where `count` is whatever expression currently renders (check for the `99+` cap case: if the rendered value is a string, keep the plain string for non-numeric and only roll numerics).
+
+- [ ] **Step 3: Panel crossfade**
+
+Grep `context-fade-in`. Apply the same class to the top-level content wrapper of ChatView, ChannelView, activity page, and the catch-up home component, keyed so it re-runs on conversation change (e.g. `key={contextId}` on the wrapper if not already present — check render cost first; if a view already remounts per conversation, the class alone suffices).
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm test`, `npm run build`. Demo mode: switch channels → content fades in; badge count changes → digits roll (trigger by sending demo messages).
+
+```bash
+git add -A
+git commit -m "feat(ui): sidebar spring, rolling unread badges, consistent panel crossfade"
+```
+
+### Task 6: Landing page first impressions
+
+**Files:**
+- Create: `src/hooks/useRevealOnScroll.ts`
+- Modify: `src/app/page.tsx` (hero stagger, feature-card reveal, screenshot tilt)
+- Modify: `src/app/globals.css` (reveal + tilt styles)
+
+**Interfaces:**
+- Produces: `useRevealOnScroll(): { ref, revealed }` — attach `ref` to a container; `revealed` flips true when ≥15% visible, once.
+
+- [ ] **Step 1: The hook**
+
+```ts
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+export function useRevealOnScroll<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T | null>(null);
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") { setRevealed(true); return; }
+    const io = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) { setRevealed(true); io.disconnect(); } },
+      { threshold: 0.15 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+  return { ref, revealed };
+}
+```
+
+- [ ] **Step 2: CSS**
+
+```css
+.reveal-on-scroll { opacity: 0; transform: translateY(12px); }
+.reveal-on-scroll.revealed {
+  opacity: 1; transform: translateY(0);
+  transition: opacity var(--motion-slow) var(--ease-out-soft), transform var(--motion-slow) var(--ease-spring);
+}
+@media (prefers-reduced-motion: reduce) {
+  .reveal-on-scroll { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: no-preference) {
+  .tilt-on-hover { transition: transform var(--motion-base) var(--ease-spring); transform: perspective(900px); }
+  .tilt-on-hover:hover { transform: perspective(900px) rotateX(2deg) rotateY(-3deg) scale(1.01); }
+}
+```
+
+- [ ] **Step 3: Apply on the landing page**
+
+`src/app/page.tsx` is a server component with client children — check first (grep `"use client"`). Hero: add `motion-fade-up` with `animationDelay` steps (0/60/120/180ms) to headline, subhead, CTA row, hero image. Feature-card sections: wrap in a small client component using `useRevealOnScroll` (`reveal-on-scroll` + conditional `revealed`). Screenshot/hero image: `tilt-on-hover`. If `page.tsx` must stay a server page, put the reveal logic in a `LandingReveal` client wrapper component created alongside (`src/components/landing/LandingReveal.tsx` — Create it in that case).
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm test`, `npm run build`. Dev server: load `/` logged out — hero staggers in, cards reveal on scroll, screenshot tilts on hover; with reduced-motion emulated, everything is visible statically.
+
+```bash
+git add -A
+git commit -m "feat(landing): hero stagger, scroll reveals, screenshot tilt"
+```

--- a/docs/superpowers/specs/2026-07-14-motion-pass-design.md
+++ b/docs/superpowers/specs/2026-07-14-motion-pass-design.md
@@ -1,0 +1,110 @@
+# Motion pass: microinteractions + token foundation (#72)
+
+**Status:** design approved 2026-07-14 · **Branch:** `feat/motion-pass`
+**Goal:** make the app feel alive and shareable for new users — "playful but earned":
+big effects only on explicit triggers, everything ambient stays subtle.
+
+## Context (what already exists — do NOT rebuild)
+
+- Tokens in `src/app/globals.css`: `--motion-fast/base/slow` (120/200/320ms),
+  `--ease-snap/spring/out-soft`, all zeroed under `prefers-reduced-motion`.
+- Keyframes already shipped: `react-burst`, `react-plus-one`, `slash-fx-pop`,
+  `typing-dot`, `presence-ping`, `message-in`, `send-ripple`, `badge-pulse`,
+  `toast-in/out`, `skeleton-shimmer`, `message-anchor-flash`, `context-fade-in`,
+  `motion-fade-up/pop-in/slide-in-right`.
+- The gap: components hardcode durations/easings instead of using tokens, and
+  there are no *memorable* moments (nothing a user would screenshot).
+
+## Hard constraints
+
+- **Zero new npm dependencies.** Hand-rolled CSS/DOM only.
+- **transform/opacity only** — nothing that triggers layout; no new continuous
+  animations (existing shimmer/typing dots are the only loops).
+- **Reduced-motion always wins**: every new effect either lives inside
+  `@media (prefers-reduced-motion: no-preference)` or uses the zeroed tokens.
+- **Brand palette only** (see BRAND.md; no Slack-palette hexes).
+- **No experimental Next.js flags** (no View Transitions API flag pre-launch).
+- Preserve all existing behavior; this is additive polish.
+
+## Phase 1 — token foundation
+
+1. Add tokens to `globals.css`: `--ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1)`
+   (promote the curve `slash-fx-pop` already uses), `--motion-slower: 480ms`
+   (zeroed under reduced motion like the others).
+2. Add radius tokens `--radius-sm: 4px / --radius-md: 6px / --radius-lg: 8px /
+   --radius-xl: 12px` and shadow tokens `--shadow-raised / --shadow-overlay /
+   --shadow-popover` (values lifted from the most common current usages), and
+   map them through the Tailwind theme so `rounded-*`/named shadows resolve to
+   the vars. Components keep their existing class names.
+3. Sweep `src/components/**` + `src/app/**`: replace hardcoded animation
+   durations/easings (`duration-150`, `duration-[80ms]`, inline cubic-beziers
+   in `globals.css` keyframe *rules*) with the tokens. Keyframe definitions
+   themselves keep raw curves only where a token doesn't exist after (1).
+   Judgment rule: if a hardcoded value is within 40ms of a token, snap to the
+   token; otherwise leave it and note it in the PR body.
+
+## Phase 2 — chat hero moments
+
+1. **Celebration confetti.**
+   - Pure detector `isCelebrationMessage(text: string): boolean` in
+     `src/lib/utils/celebrate.ts`: after stripping HTML tags and whitespace,
+     the text is non-empty, ≤ 32 chars, consists only of emoji, and contains at
+     least one of 🎉 🎊 🥳. Unit-tested (vitest) including negative cases
+     ("party at 🎉 9" → false, plain text → false, "🎉🎉🎉" → true).
+   - `<CelebrationBurst />` component: absolutely-positioned overlay rendered
+     inside MessageFeed's scroll container; ~24 particle `<span>`s with
+     randomized (CSS-var-driven, seeded from index) directions/colors from the
+     brand palette; single play (`--motion-slower`), nodes removed on
+     `animationend` of the last particle; `pointer-events: none`.
+   - Trigger: fires once per message id (module-level `Set`) when (a) the user
+     sends a message passing the detector (optimistic append path) or (b) an
+     incoming message passing the detector arrives in the *open* conversation
+     (upsert path). No queueing: concurrent triggers coalesce to one burst.
+   - New preference `celebrationEffects: boolean` (default `true`) in the
+     preferences store + a toggle in the Preferences modal (Notifications
+     panel), and the demo views honor it too.
+2. **Send feel.** Upgrade `message-in` to `translateY(8px) scale(0.98) → rest`
+   over `--motion-base` `--ease-spring`; apply ONLY to own optimistic appends
+   (`__pending` messages), never to polled/history renders. Send button:
+   `:active` scale press using `--motion-fast` (wire to existing `send-ripple`
+   if it is currently unused, else leave ripple as is).
+3. **Emoji picker play.** Hover pop (`scale(1.25)`, `--motion-fast`,
+   transform-only) on emoji buttons; staggered fade-in on picker open with
+   `animation-delay: min(index, 20) * 12ms` so long grids never feel slow.
+
+## Phase 3 — navigation polish + landing
+
+1. **Sidebar.** Springy hover/active transitions on nav items (`--ease-spring`,
+   `--motion-base`). A shared sliding indicator pill ONLY if the current list
+   structure allows an absolutely-positioned sibling without restructuring;
+   otherwise per-item spring only. Explicitly: no structural refactor.
+2. **Unread badge roll.** When a badge count changes, old digits translate up
+   and fade while new ones rise in (grid-stacked spans, transform/opacity).
+   Extract the digit-diff logic as a pure helper if it exceeds ~10 lines and
+   unit-test it.
+3. **Panel crossfade.** Apply the existing `context-fade-in` treatment
+   consistently to conversation/route panel content mounts (ChatView,
+   ChannelView, activity, catch-up home) — 120ms fade + 2px rise. No
+   experimental view-transition flags.
+4. **Landing page (`src/app/page.tsx`).** Staggered hero fade-up on load
+   (tokens + `motion-fade-up`, `animation-delay` steps), feature cards reveal
+   on scroll (single `IntersectionObserver` hook + CSS class, unobserve after
+   reveal), screenshot tilt on hover (`perspective` + `rotateX/Y` ≤ 4deg,
+   transform-only). SSR-safe: no observer references during render; cards are
+   visible (no-JS fallback) if the observer never fires.
+
+## Verification
+
+- `npm test` green (new: celebrate detector, badge-digit helper); `npm run build` green.
+- Drive demo mode (`/demo` routes — no sign-in needed) with the dev server and
+  screenshot: confetti on "🎉🎉", send spring, picker stagger, sidebar hover,
+  landing reveals. Reduced-motion spot-check via emulation.
+- Each phase is an independently green commit; ships as one PR (phases
+  reviewable per-commit) unless a phase turns risky, then it splits out.
+
+## Non-goals
+
+- Sounds, haptics, message-send "power mode" screen shake.
+- Always-on ambient wiggle/bounce (rejected: "full expressive" tier).
+- Next.js View Transitions flag, framer-motion, canvas-confetti.
+- Radius/shadow visual redesign — tokens map current values 1:1.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -526,6 +526,17 @@ body.focus-mode .focus-mode-hide {
     animation: slash-menu-in 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
     transform-origin: bottom left;
   }
+
+  /* Celebration confetti (#72 motion pass): each particle drifts to a
+     deterministic offset (set via inline --cf-* vars) while spinning and
+     fading. Only defined under no-preference so reduced-motion users never
+     see it animate; the CelebrationBurst component also refuses to render
+     when the celebrationEffects preference is off. */
+  @keyframes confetti-fall {
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); opacity: 1; }
+    100% { transform: translate3d(var(--cf-x), var(--cf-y), 0) rotate(var(--cf-r)) scale(0.6); opacity: 0; }
+  }
+  .confetti-particle { animation: confetti-fall var(--motion-slower) var(--ease-out-soft) forwards; }
 }
 
 @keyframes typing-dot {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -472,6 +472,50 @@ body {
   opacity: 0.85;
 }
 
+/* ─── Landing page first-impression motion (Task 6) ────────────────────
+   Scroll-reveal + hover-tilt for the public marketing page.
+
+   Crawler / no-JS safety: the hidden `.reveal-on-scroll` state (opacity:0)
+   is NEVER present in the server-rendered HTML — `LandingReveal` only adds
+   the class after mount. So a crawler or a JS-disabled visitor always gets
+   the copy at full opacity. Under reduced motion the hidden state is
+   restored to fully visible as a belt-and-braces fallback. */
+.reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(12px);
+}
+.reveal-on-scroll.revealed {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity var(--motion-slow) var(--ease-out-soft),
+    transform var(--motion-slow) var(--ease-spring);
+}
+@media (prefers-reduced-motion: reduce) {
+  .reveal-on-scroll {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Hero entrance stagger + screenshot tilt. The stagger delays live under
+   no-preference (not as inline styles) so reduced-motion users never get a
+   delayed opacity hold — `motion-fade-up` collapses to 0ms and every hero
+   element is visible at once. Tilt stays ≤4deg and is motion-gated, so it is
+   simply absent under reduced motion. */
+@media (prefers-reduced-motion: no-preference) {
+  .motion-stagger-1 { animation-delay: 60ms; }
+  .motion-stagger-2 { animation-delay: 120ms; }
+  .motion-stagger-3 { animation-delay: 180ms; }
+
+  .tilt-on-hover {
+    transition: transform var(--motion-base) var(--ease-spring);
+    transform: perspective(900px);
+  }
+  .tilt-on-hover:hover {
+    transform: perspective(900px) rotateX(2deg) rotateY(-3deg) scale(1.01);
+  }
+}
+
 @keyframes reaction-pop {
   0%   { transform: scale(1); }
   30%  { transform: scale(0.85); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -631,11 +631,17 @@ body.focus-mode .focus-mode-hide {
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  @keyframes message-in {
-    from { transform: translateY(8px); opacity: 0; }
-    to   { transform: translateY(0); opacity: 1; }
-  }
+/* Own optimistic sends only — gated on `message.__pending` in MessageItem,
+ * never on recency, so polled/history rows and other people's real-time
+ * messages never trigger it. Reconciling to the Graph id remounts the row
+ * (keyed by message.id) with `__pending` already false, so it does not
+ * replay on reconcile. */
+@keyframes message-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+.message-in {
+  animation: message-in var(--motion-base) var(--ease-spring) both;
 }
 
 @keyframes send-ripple {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -654,6 +654,15 @@ body.focus-mode .focus-mode-hide {
   100% { transform: scale(1); }
 }
 
+/* Odometer-lite digit roll for RollingNumber — fires only when the numeric
+   value actually changes (component re-keys the inner span), never on
+   first mount. Token-driven duration/easing so reduced-motion zeroes it. */
+@keyframes roll-in {
+  from { transform: translateY(0.7em); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+.roll-in { animation: roll-in var(--motion-base) var(--ease-spring) both; }
+
 @keyframes context-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -688,6 +688,28 @@ body.focus-mode .focus-mode-hide {
   animation: message-in var(--motion-base) var(--ease-spring) both;
 }
 
+/* Zeroing --motion-base/--motion-fast above isn't enough on its own for these
+   two `both`-fill animations: at 0ms the keyframe still resolves immediately
+   and its fill-mode holds the `to` state forever. On `.motion-fade-up` that
+   collides with EmojiPicker's inline per-item `animationDelay` — the delay
+   is untouched (inline styles always win that sub-property over a
+   stylesheet rule), so a staggered item still sits invisible until its delay
+   elapses, then pops. On `.message-in` the `to { opacity: 1 }` hold
+   permanently overrides the `opacity-60` pending-message dim. Disabling the
+   animation outright avoids both — and this override must be declared AFTER
+   `.motion-fade-up`/`.message-in` above (equal specificity, so the later
+   rule in source order wins whenever both apply); placing it up in the
+   `:root` token block near the top of this file would silently lose the
+   cascade to these rules — the same reason the `.motion-stagger-*`
+   no-preference override earlier in this file is placed after
+   `.motion-fade-up` rather than next to the token block. */
+@media (prefers-reduced-motion: reduce) {
+  .motion-fade-up,
+  .message-in {
+    animation: none;
+  }
+}
+
 @keyframes send-ripple {
   to { transform: scale(4); opacity: 0; }
 }
@@ -712,7 +734,7 @@ body.focus-mode .focus-mode-hide {
   to   { opacity: 1; }
 }
 .context-fade-in {
-  animation: context-fade-in 120ms ease-out both;
+  animation: context-fade-in var(--motion-fast) ease-out both;
 }
 
 /* Electron macOS drag regions — no-ops in the browser */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,13 @@
 @theme {
   --font-family-sans: var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI",
     "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --shadow-raised: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-overlay: -4px 0 16px rgba(0, 0, 0, 0.3);
+  --shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
 /* ─── Global interactive element cursors ─────────────────────────────── */
@@ -103,9 +110,11 @@ body {
   --ease-snap: cubic-bezier(0.32, 0.72, 0, 1);        /* iOS-style snappy */
   --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);       /* gentle overshoot-free spring */
   --ease-out-soft: cubic-bezier(0.22, 1, 0.36, 1);    /* fade-in default */
+  --ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);   /* earned-playful overshoot */
   --motion-fast: 120ms;
   --motion-base: 200ms;
   --motion-slow: 320ms;
+  --motion-slower: 480ms;                             /* celebration-scale effects */
 
   /* ─── Density (defaults: comfortable) ──────────────────────────────────
      Components use these vars in place of hardcoded padding/avatar sizes.
@@ -127,6 +136,7 @@ body {
     --motion-fast: 0ms;
     --motion-base: 0ms;
     --motion-slow: 0ms;
+    --motion-slower: 0ms;
   }
 }
 
@@ -506,7 +516,7 @@ body.focus-mode .focus-mode-hide {
     60%  { transform: scale(1.08) rotate(2deg); }
     100% { opacity: 1; transform: scale(1) rotate(0); }
   }
-  .slash-fx-pop { animation: slash-fx-pop 420ms cubic-bezier(0.34, 1.56, 0.64, 1); }
+  .slash-fx-pop { animation: slash-fx-pop 420ms var(--ease-bounce); }
 
   @keyframes slash-menu-in {
     from { opacity: 0; transform: scale(0.95) translateY(4px); }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth/config";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Logo } from "@/components/ui/Logo";
+import { LandingReveal } from "@/components/landing/LandingReveal";
 import {
   Star,
   GitFork,
@@ -100,18 +101,18 @@ export default async function LandingPage() {
           >
             Open source · AGPL-3.0
           </a>
-          <h1 className="mx-auto mb-6 max-w-3xl text-4xl font-black leading-[1.08] tracking-tight sm:text-5xl lg:text-6xl">
+          <h1 className="motion-fade-up mx-auto mb-6 max-w-3xl text-4xl font-black leading-[1.08] tracking-tight sm:text-5xl lg:text-6xl">
             A keyboard-first
             <br />
             Microsoft Teams client.
           </h1>
-          <p className="mx-auto mb-9 max-w-2xl text-[17px] leading-relaxed text-[#8b9ab0]">
+          <p className="motion-fade-up motion-stagger-1 mx-auto mb-9 max-w-2xl text-[17px] leading-relaxed text-[#8b9ab0]">
             Teamsly connects to your real Teams account through the official Microsoft Graph
             API — same channels, DMs, and files — and adds what Teams never shipped: a command
             palette, AI thread summaries, voice rooms, disappearing DMs, themes, and an MCP
             server that lets Claude read and send your messages.
           </p>
-          <div className="flex flex-wrap items-center justify-center gap-3">
+          <div className="motion-fade-up motion-stagger-2 flex flex-wrap items-center justify-center gap-3">
             <Link
               href="/login"
               className="rounded-xl px-6 py-3 text-[15px] font-semibold text-white transition-all hover:brightness-110 active:scale-[0.98]"
@@ -145,9 +146,11 @@ export default async function LandingPage() {
         </div>
 
         {/* Real product screenshot */}
-        <BrowserFrame className="mt-14">
-          <img src="/shots/workspace.png" alt="Teamsly workspace — channels, messages, and sidebar" className="block w-full" loading="eager" />
-        </BrowserFrame>
+        <div className="motion-fade-up motion-stagger-3 mt-14">
+          <BrowserFrame className="tilt-on-hover">
+            <img src="/shots/workspace.png" alt="Teamsly workspace — channels, messages, and sidebar" className="block w-full" loading="eager" />
+          </BrowserFrame>
+        </div>
       </section>
 
       {/* Trust bar */}
@@ -215,38 +218,44 @@ Claude: ✓ Sent to Priya Sharma`}</CodeBlock>
 
       {/* Feature rows with real screenshots */}
       <section id="features" className="mx-auto max-w-6xl scroll-mt-20 px-6">
-        <FeatureRow
-          eyebrow="Your real Teams, faster"
-          title="Channels, DMs, threads — all live from Graph"
-          body="Everything is fetched live from the Microsoft Graph API: channels, group and 1:1 chats, threaded replies, reactions, mentions, and file attachments. No scraping, no shadow copy — Teamsly stores nothing of its own."
-          points={["Channels & direct messages", "Threads, reactions & mentions", "Inline file previews", "Org-wide people search"]}
-          shot="/shots/workspace.png"
-          alt="Teamsly channel view"
-        />
-        <FeatureRow
-          reverse
-          eyebrow="Keyboard-first"
-          title="Jump anywhere with ⌘K"
-          body="A fast command palette to jump between channels and DMs, plus shortcuts throughout. Search finds people you've never messaged and starts a DM in one keystroke."
-          points={["⌘K quick switcher", "Org directory search", "Shortcuts for everything", "Built for people who live in the terminal"]}
-          shot="/shots/cmdk.png"
-          alt="Teamsly command palette"
-        />
-        <FeatureRow
-          eyebrow="Messaging, done right"
-          title="DMs with disappearing messages"
-          body="Send a DM that self-destructs after 30 seconds, 5 minutes, or an hour — it shows a live countdown and vanishes for both sides. Reactions, edits, forwarding, and emoji/GIF are all here too."
-          points={["Disappearing DMs (30s / 5m / 1h)", "Emoji & GIF picker (Tenor)", "Edit, delete, forward", "Smart notifications & focus mode"]}
-          shot="/shots/dm.png"
-          alt="Teamsly direct message view"
-        />
+        <LandingReveal>
+          <FeatureRow
+            eyebrow="Your real Teams, faster"
+            title="Channels, DMs, threads — all live from Graph"
+            body="Everything is fetched live from the Microsoft Graph API: channels, group and 1:1 chats, threaded replies, reactions, mentions, and file attachments. No scraping, no shadow copy — Teamsly stores nothing of its own."
+            points={["Channels & direct messages", "Threads, reactions & mentions", "Inline file previews", "Org-wide people search"]}
+            shot="/shots/workspace.png"
+            alt="Teamsly channel view"
+          />
+        </LandingReveal>
+        <LandingReveal>
+          <FeatureRow
+            reverse
+            eyebrow="Keyboard-first"
+            title="Jump anywhere with ⌘K"
+            body="A fast command palette to jump between channels and DMs, plus shortcuts throughout. Search finds people you've never messaged and starts a DM in one keystroke."
+            points={["⌘K quick switcher", "Org directory search", "Shortcuts for everything", "Built for people who live in the terminal"]}
+            shot="/shots/cmdk.png"
+            alt="Teamsly command palette"
+          />
+        </LandingReveal>
+        <LandingReveal>
+          <FeatureRow
+            eyebrow="Messaging, done right"
+            title="DMs with disappearing messages"
+            body="Send a DM that self-destructs after 30 seconds, 5 minutes, or an hour — it shows a live countdown and vanishes for both sides. Reactions, edits, forwarding, and emoji/GIF are all here too."
+            points={["Disappearing DMs (30s / 5m / 1h)", "Emoji & GIF picker (Tenor)", "Edit, delete, forward", "Smart notifications & focus mode"]}
+            shot="/shots/dm.png"
+            alt="Teamsly direct message view"
+          />
+        </LandingReveal>
       </section>
 
       {/* And more grid */}
       <section className="mx-auto max-w-6xl px-6 pb-24 pt-8">
         <h2 className="mb-3 text-center text-3xl font-black tracking-tight">And a lot more</h2>
         <p className="mb-12 text-center text-[15px] text-[#8b9ab0]">The things you&apos;d expect from a client built by people who use it daily.</p>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <LandingReveal className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {[
             { icon: Sparkles, title: "AI unread summaries", description: "Catch up on long threads in seconds — Claude highlights blockers and decisions." },
             { icon: Mic, title: "Voice rooms", description: "Drop-in audio per channel or DM, powered by LiveKit. No meeting links." },
@@ -268,7 +277,7 @@ Claude: ✓ Sent to Priya Sharma`}</CodeBlock>
               <p className="text-[12px] leading-relaxed text-[#8b9ab0]">{description}</p>
             </div>
           ))}
-        </div>
+        </LandingReveal>
       </section>
 
       {/* Comparison */}
@@ -504,7 +513,7 @@ function FeatureRow({
         </ul>
       </div>
       <div className="w-full lg:flex-1">
-        <BrowserFrame>
+        <BrowserFrame className="tilt-on-hover">
           <img src={shot} alt={alt} className="block w-full" loading="lazy" />
         </BrowserFrame>
       </div>

--- a/src/app/workspace/activity/page.tsx
+++ b/src/app/workspace/activity/page.tsx
@@ -139,7 +139,7 @@ function ActivityRow({
       <button
         type="button"
         onClick={handleClick}
-        className="group flex w-full items-start gap-3 px-4 py-3 text-left transition-colors duration-[80ms] ease-out hover:bg-white/5 focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]"
+        className="group flex w-full items-start gap-3 px-4 py-3 text-left transition-colors duration-[var(--motion-fast)] ease-out hover:bg-white/5 focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]"
       >
         {/* Avatar */}
         <div className="relative mt-0.5 flex-shrink-0">
@@ -166,7 +166,7 @@ function ActivityRow({
         {item.type === "thread" && (
           <ChevronDown
             className={cn(
-              "h-3.5 w-3.5 flex-shrink-0 text-[#6c6f75] transition-transform duration-150",
+              "h-3.5 w-3.5 flex-shrink-0 text-[#6c6f75] transition-transform duration-[var(--motion-fast)]",
               expanded && "rotate-180"
             )}
           />
@@ -514,7 +514,7 @@ export default function ActivityPage() {
                   aria-selected={active}
                   onClick={() => setActiveTab(tab.id)}
                   className={cn(
-                    "relative px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors duration-[80ms] ease-out focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]",
+                    "relative px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors duration-[var(--motion-fast)] ease-out focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]",
                     active
                       ? "text-white"
                       : "text-[#ababad] hover:text-[#d1d2d3]"

--- a/src/app/workspace/activity/page.tsx
+++ b/src/app/workspace/activity/page.tsx
@@ -94,7 +94,7 @@ function ThreadPreviewPanel({
   return (
     <div
       className="mx-4 mb-3 overflow-hidden rounded-lg border border-[#3f4144] bg-[#222529]"
-      style={{ animation: "context-fade-in 150ms ease-out both" }}
+      style={{ animation: "context-fade-in var(--motion-fast) ease-out both" }}
     >
       <div className="p-3">
         <p className="text-[12px] font-semibold text-[#d1d2d3]">{item.senderName}</p>

--- a/src/app/workspace/activity/page.tsx
+++ b/src/app/workspace/activity/page.tsx
@@ -497,7 +497,7 @@ export default function ActivityPage() {
   const showSkeleton = isScanTab && scanLoading && !scanLoadedRef.current;
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="context-fade-in flex h-full flex-col overflow-hidden">
       {/* Header */}
       <div className="flex-shrink-0 border-b border-[#3f4144] px-4 pb-0 pt-4">
         <h1 className="mb-3 text-[18px] font-bold text-white">Activity</h1>

--- a/src/app/workspace/files/page.tsx
+++ b/src/app/workspace/files/page.tsx
@@ -133,7 +133,7 @@ function FileRow({ file }: { file: NormalisedFile }) {
     <RowEl
       type={previewable ? "button" : undefined}
       onClick={previewable ? onRowClick : undefined}
-      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[80ms] hover:bg-[#27292d]"
+      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[var(--motion-fast)] hover:bg-[#27292d]"
     >
       {/* Icon */}
       <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[#2c2d30] text-[#ababad]">
@@ -156,7 +156,7 @@ function FileRow({ file }: { file: NormalisedFile }) {
           target="_blank"
           rel="noopener noreferrer"
           title={`Open ${file.name} in browser`}
-          className="flex-shrink-0 text-[#ababad] opacity-0 transition-opacity duration-[80ms] group-hover:opacity-100 focus:opacity-100"
+          className="flex-shrink-0 text-[#ababad] opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover:opacity-100 focus:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <ExternalLink size={15} />
@@ -233,7 +233,7 @@ export default function FilesPage() {
                 aria-selected={active}
                 onClick={() => setActiveTab(tab.id)}
                 className={cn(
-                  "relative px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors duration-[80ms] ease-out focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]",
+                  "relative px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors duration-[var(--motion-fast)] ease-out focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]",
                   active ? "text-white" : "text-[#ababad] hover:text-[#d1d2d3]"
                 )}
               >
@@ -274,7 +274,7 @@ export default function FilesPage() {
             <p className="text-[13px] text-[#ababad]">Couldn&apos;t load files</p>
             <button
               onClick={fetchFiles}
-              className="flex items-center gap-1.5 rounded-md border border-[#3f4144] px-3 py-1.5 text-[13px] text-[#d1d2d3] transition-colors duration-[80ms] hover:bg-[#27292d]"
+              className="flex items-center gap-1.5 rounded-md border border-[#3f4144] px-3 py-1.5 text-[13px] text-[#d1d2d3] transition-colors duration-[var(--motion-fast)] hover:bg-[#27292d]"
             >
               <RefreshCw size={13} />
               Retry

--- a/src/app/workspace/later/page.tsx
+++ b/src/app/workspace/later/page.tsx
@@ -117,7 +117,7 @@ function BookmarkRow({
           e.stopPropagation();
           onRemove();
         }}
-        className="absolute right-4 top-3 flex h-7 w-7 items-center justify-center rounded text-[var(--text-secondary)] opacity-0 transition-opacity duration-100 hover:bg-[var(--surface-hover)] hover:text-white focus-ring group-hover:opacity-100"
+        className="absolute right-4 top-3 flex h-7 w-7 items-center justify-center rounded text-[var(--text-secondary)] opacity-0 transition-opacity duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-white focus-ring group-hover:opacity-100"
       >
         <Trash2 size={14} strokeWidth={2} />
       </button>

--- a/src/app/workspace/meetings/page.tsx
+++ b/src/app/workspace/meetings/page.tsx
@@ -177,7 +177,7 @@ function EventRow({ event }: { event: MSCalendarEvent }) {
   return (
     <div
       className={cn(
-        "group flex items-start gap-3 rounded-lg px-3 py-3 transition-colors duration-[80ms] hover:bg-white/5",
+        "group flex items-start gap-3 rounded-lg px-3 py-3 transition-colors duration-[var(--motion-fast)] hover:bg-white/5",
         cancelled && "opacity-60"
       )}
     >
@@ -229,7 +229,7 @@ function EventRow({ event }: { event: MSCalendarEvent }) {
             type="button"
             onClick={handleJoin}
             title="Join meeting"
-            className="flex items-center gap-1.5 rounded-md bg-[#0F5A8F] px-2.5 py-1.5 text-[12px] font-medium text-white transition-colors duration-[80ms] hover:bg-[#1470b0] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]"
+            className="flex items-center gap-1.5 rounded-md bg-[#0F5A8F] px-2.5 py-1.5 text-[12px] font-medium text-white transition-colors duration-[var(--motion-fast)] hover:bg-[#1470b0] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]"
           >
             <Video size={13} />
             Join
@@ -239,7 +239,7 @@ function EventRow({ event }: { event: MSCalendarEvent }) {
             type="button"
             onClick={handleOpen}
             title="Open in Outlook"
-            className="flex items-center justify-center rounded-md p-1.5 text-[#6c6f75] transition-colors duration-[80ms] hover:bg-white/8 hover:text-[#ababad] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]"
+            className="flex items-center justify-center rounded-md p-1.5 text-[#6c6f75] transition-colors duration-[var(--motion-fast)] hover:bg-white/8 hover:text-[#ababad] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]"
           >
             <ExternalLink size={14} />
           </button>
@@ -309,7 +309,7 @@ export default function MeetingsPage() {
             onClick={fetchMeetings}
             disabled={loading}
             title="Refresh calendar"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium text-[#ababad] transition-colors duration-[80ms] hover:bg-white/8 hover:text-[#d1d2d3] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F] disabled:opacity-50"
+            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium text-[#ababad] transition-colors duration-[var(--motion-fast)] hover:bg-white/8 hover:text-[#d1d2d3] focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F] disabled:opacity-50"
           >
             <RefreshCw size={13} className={loading ? "animate-spin" : ""} />
             Refresh
@@ -327,7 +327,7 @@ export default function MeetingsPage() {
                 aria-selected={active}
                 onClick={() => setActiveTab(tab.id)}
                 className={cn(
-                  "relative px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors duration-[80ms] ease-out focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]",
+                  "relative px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors duration-[var(--motion-fast)] ease-out focus:outline-none focus-visible:ring-1 focus-visible:ring-[#0F5A8F]",
                   active ? "text-white" : "text-[#ababad] hover:text-[#d1d2d3]"
                 )}
               >
@@ -355,7 +355,7 @@ export default function MeetingsPage() {
             <button
               type="button"
               onClick={fetchMeetings}
-              className="flex items-center gap-1.5 rounded-md border border-[#3f4144] px-3 py-1.5 text-[13px] text-[#d1d2d3] transition-colors duration-[80ms] hover:bg-[#27292d]"
+              className="flex items-center gap-1.5 rounded-md border border-[#3f4144] px-3 py-1.5 text-[13px] text-[#d1d2d3] transition-colors duration-[var(--motion-fast)] hover:bg-[#27292d]"
             >
               <RefreshCw size={13} />
               Retry

--- a/src/components/ai/CatchUpContent.tsx
+++ b/src/components/ai/CatchUpContent.tsx
@@ -45,7 +45,7 @@ export function CatchUpContent({ onNavigate, className }: Props) {
     : null;
 
   return (
-    <div className={["flex h-full flex-col", className ?? ""].join(" ")}>
+    <div className={["context-fade-in flex h-full flex-col", className ?? ""].join(" ")}>
       <div role="tablist" className="flex flex-shrink-0 items-center gap-1 border-b border-[var(--border)] px-4 pt-2">
         {TABS.map((t) => (
           <button

--- a/src/components/ai/CatchUpPanel.tsx
+++ b/src/components/ai/CatchUpPanel.tsx
@@ -31,7 +31,7 @@ export function CatchUpPanel() {
       <aside
         className={[
           "fixed bottom-0 right-0 top-0 z-50 flex w-full flex-col border-l border-[var(--border)] bg-[var(--content-bg)] shadow-[-4px_0_24px_rgba(0,0,0,0.3)] sm:w-[440px]",
-          "transition-transform duration-[280ms] ease-[cubic-bezier(0.34,1.2,0.64,1)]",
+          "transition-transform duration-[var(--motion-slow)] ease-[cubic-bezier(0.34,1.2,0.64,1)]",
           open ? "translate-x-0" : "translate-x-full",
         ].join(" ")}
         aria-label="Catch-up panel"

--- a/src/components/landing/LandingReveal.tsx
+++ b/src/components/landing/LandingReveal.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRevealOnScroll } from "@/hooks/useRevealOnScroll";
+
+/**
+ * Client wrapper that scroll-reveals its children while keeping the landing
+ * page server-rendered and crawler-safe.
+ *
+ * The hidden state (`.reveal-on-scroll`, opacity:0) is the whole reason this
+ * has to be careful: if it shipped in the server HTML, a crawler or a
+ * JS-disabled visitor would see nothing. So we gate it on `armed`, which is
+ * false on the server and during the first client render (matching the server
+ * markup, no hydration mismatch) and only flips true in a mount effect. From
+ * that point IntersectionObserver takes over and adds `.revealed` on scroll.
+ *
+ * Net effect: server HTML has neither class → text is fully visible without
+ * JS; the fade-in only exists once JS has run.
+ */
+export function LandingReveal({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { ref, revealed } = useRevealOnScroll<HTMLDivElement>();
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    setArmed(true);
+  }, []);
+
+  const classes = [armed && "reveal-on-scroll", revealed && "revealed", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div ref={ref} className={classes}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/SignInPage.tsx
+++ b/src/components/layout/SignInPage.tsx
@@ -135,7 +135,7 @@ export function SignInPage() {
 
           <button
             onClick={() => signIn("microsoft-entra-id", { callbackUrl: "/workspace" })}
-            className="group flex w-full items-center justify-center gap-3 rounded-xl px-5 py-3 text-sm font-semibold text-white transition-all duration-150 active:scale-[0.98]"
+            className="group flex w-full items-center justify-center gap-3 rounded-xl px-5 py-3 text-sm font-semibold text-white transition-all duration-[var(--motion-fast)] active:scale-[0.98]"
             style={{
               background: "linear-gradient(135deg, #6366F1 0%, #818CF8 100%)",
               boxShadow: "0 0 0 1px rgba(99,102,241,0.6)",
@@ -159,7 +159,7 @@ export function SignInPage() {
 
           <Link
             href="/demo"
-            className="flex w-full items-center justify-center gap-1 rounded-xl border px-5 py-3 text-sm font-medium text-[#8b9ab0] transition-colors duration-150 hover:border-[#6366F1] hover:text-white"
+            className="flex w-full items-center justify-center gap-1 rounded-xl border px-5 py-3 text-sm font-medium text-[#8b9ab0] transition-colors duration-[var(--motion-fast)] hover:border-[#6366F1] hover:text-white"
             style={{ borderColor: "rgba(255,255,255,0.09)" }}
           >
             Preview UI without signing in

--- a/src/components/messages/AttachmentCard.tsx
+++ b/src/components/messages/AttachmentCard.tsx
@@ -80,7 +80,7 @@ export function AttachmentCard({ attachment }: AttachmentCardProps) {
       // Middle-click (button 1) goes to onAuxClick, not onClick, so the
       // browser's default "open in new tab" already works for us — no
       // explicit handler needed.
-      className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left transition-colors duration-150 hover:border-[var(--border-input)] hover:bg-[var(--surface-hover)]"
+      className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left transition-colors duration-[var(--motion-fast)] hover:border-[var(--border-input)] hover:bg-[var(--surface-hover)]"
     >
       {content}
     </a>
@@ -125,7 +125,7 @@ function InlineImageAttachment({ attachment }: { attachment: MSAttachment }) {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left transition-colors duration-150 hover:border-[var(--border-input)] hover:bg-[var(--surface-hover)]"
+        className="mt-2 flex max-w-[420px] cursor-pointer items-center gap-3 rounded-md border border-[var(--border)] bg-[var(--modal-bg)] px-3 py-2 text-left transition-colors duration-[var(--motion-fast)] hover:border-[var(--border-input)] hover:bg-[var(--surface-hover)]"
       >
         {content}
       </a>

--- a/src/components/messages/CelebrationBurst.tsx
+++ b/src/components/messages/CelebrationBurst.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { usePreferencesStore } from "@/store/preferences";
+
+// Deterministic particle set — no Math.random / Date.now, so a given index
+// always drifts the same way (keeps the effect reproducible + test-friendly).
+const PARTICLE_COUNT = 24;
+// Existing app hues only. NO Slack-palette values (see BRAND.md).
+const COLORS = ["var(--accent)", "#f0b429", "#57bb8a", "#cd5b45", "#818CF8"];
+// Fallback teardown, slightly above --motion-slower (480ms), so the overlay
+// never lingers if onAnimationEnd doesn't fire for every particle (e.g. the
+// var is zeroed under reduced motion, or a particle unmounts mid-flight).
+const TEARDOWN_MS = 600;
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+interface Props {
+  /** Plays a burst once per distinct, non-empty value seen during this mount. */
+  playKey?: string;
+}
+
+/**
+ * Confetti overlay for "earned" celebration moments. Renders nothing unless a
+ * fresh (unseen this mount) non-empty `playKey` arrives AND the user's
+ * celebrationEffects preference is on. The overlay is pointer-events-none and
+ * absolutely positioned, so it never affects feed layout or scroll behavior.
+ */
+export function CelebrationBurst({ playKey }: Props) {
+  const celebrationEffects = usePreferencesStore((s) => s.celebrationEffects);
+  const [currentKey, setCurrentKey] = useState<string | null>(null);
+  // The keyframes live only under (prefers-reduced-motion: no-preference), so
+  // under reduced motion the particles would render statically instead of
+  // animating. Bail out entirely so reduced-motion users see nothing at all.
+  const [reducedMotion, setReducedMotion] = useState(prefersReducedMotion);
+  const seenRef = useRef<Set<string>>(new Set());
+  const endedRef = useRef(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(mq.matches);
+    const onChange = () => setReducedMotion(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  // Start a burst only for a non-empty key we haven't played this mount.
+  useEffect(() => {
+    if (!playKey) return;
+    if (seenRef.current.has(playKey)) return;
+    seenRef.current.add(playKey);
+    setCurrentKey(playKey);
+  }, [playKey]);
+
+  // Reset the animation-end counter and arm a teardown fallback for each burst.
+  // A new distinct key that arrives mid-burst re-runs this effect (and remounts
+  // the particles via the wrapper key below), so the burst replays cleanly.
+  useEffect(() => {
+    if (!currentKey) return;
+    endedRef.current = 0;
+    const t = window.setTimeout(() => setCurrentKey(null), TEARDOWN_MS);
+    return () => window.clearTimeout(t);
+  }, [currentKey]);
+
+  if (!celebrationEffects) return null;
+  if (reducedMotion) return null;
+  if (!currentKey) return null;
+
+  const handleAnimationEnd = () => {
+    endedRef.current += 1;
+    if (endedRef.current >= PARTICLE_COUNT) setCurrentKey(null);
+  };
+
+  return (
+    <div
+      key={currentKey}
+      className="pointer-events-none absolute inset-0 z-10 overflow-hidden"
+      aria-hidden="true"
+    >
+      {Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+        const x = (i % 8 - 3.5) * 28;
+        const y = 120 + (i % 5) * 40;
+        const r = (i % 2 ? 1 : -1) * (180 + i * 20);
+        const color = COLORS[i % COLORS.length];
+        const style = {
+          backgroundColor: color,
+          // Deterministic per-index drift consumed by the confetti-fall
+          // keyframes in globals.css.
+          "--cf-x": `${x}px`,
+          "--cf-y": `${y}px`,
+          "--cf-r": `${r}deg`,
+        } as CSSProperties;
+        return (
+          <span
+            key={i}
+            className="confetti-particle absolute left-1/2 top-1/3 h-[10px] w-[6px] rounded-[2px]"
+            style={style}
+            onAnimationEnd={handleAnimationEnd}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/messages/ChatView.tsx
+++ b/src/components/messages/ChatView.tsx
@@ -798,7 +798,7 @@ export function ChatView({ chatId }: { chatId: string }) {
                         aria-label="Cancel scheduled message"
                         title="Cancel scheduled message"
                         onClick={() => removeScheduled(chatId, m.id)}
-                        className="flex-shrink-0 rounded p-0.5 text-[var(--text-secondary)] transition-colors duration-100 hover:bg-[var(--surface-hover)] hover:text-[var(--accent)]"
+                        className="flex-shrink-0 rounded p-0.5 text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--accent)]"
                       >
                         ✕
                       </button>

--- a/src/components/messages/ContextFilesTab.tsx
+++ b/src/components/messages/ContextFilesTab.tsx
@@ -91,7 +91,7 @@ function ChannelFileRow({ item }: { item: MSDriveItem }) {
     <RowEl
       type={previewable ? "button" : undefined}
       onClick={previewable ? onRowClick : undefined}
-      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
+      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)]"
     >
       <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[var(--surface)] text-[var(--text-secondary)]">
         <Icon size={18} />
@@ -109,7 +109,7 @@ function ChannelFileRow({ item }: { item: MSDriveItem }) {
           rel="noopener noreferrer"
           title={`Open ${item.name} in browser`}
           aria-label={`Open ${item.name} in browser`}
-          className="flex-shrink-0 text-[var(--text-secondary)] opacity-0 transition-opacity duration-[80ms] group-hover:opacity-100 focus:opacity-100"
+          className="flex-shrink-0 text-[var(--text-secondary)] opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover:opacity-100 focus:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <ExternalLink size={15} />
@@ -142,7 +142,7 @@ function ChatFileRow({ item }: { item: MSChatFileAttachment }) {
     <RowEl
       type={href ? "button" : undefined}
       onClick={href ? onRowClick : undefined}
-      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
+      className="group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)]"
     >
       <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-[var(--surface)] text-[var(--text-secondary)]">
         <Icon size={18} />
@@ -161,7 +161,7 @@ function ChatFileRow({ item }: { item: MSChatFileAttachment }) {
           rel="noopener noreferrer"
           title={`Open ${item.name} in browser`}
           aria-label={`Open ${item.name} in browser`}
-          className="flex-shrink-0 text-[var(--text-secondary)] opacity-0 transition-opacity duration-[80ms] group-hover:opacity-100 focus:opacity-100"
+          className="flex-shrink-0 text-[var(--text-secondary)] opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover:opacity-100 focus:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <ExternalLink size={15} />
@@ -227,7 +227,7 @@ export function ContextFilesTab({ mode }: ContextFilesTabProps) {
         <p className="text-[13px] text-[var(--text-secondary)]">Couldn&apos;t load files</p>
         <button
           onClick={fetchFiles}
-          className="flex items-center gap-1.5 rounded-md border border-[var(--border)] px-3 py-1.5 text-[13px] text-[var(--text-primary)] transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
+          className="flex items-center gap-1.5 rounded-md border border-[var(--border)] px-3 py-1.5 text-[13px] text-[var(--text-primary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)]"
         >
           <RefreshCw size={13} />
           Retry

--- a/src/components/messages/EmojiPicker.tsx
+++ b/src/components/messages/EmojiPicker.tsx
@@ -98,7 +98,10 @@ function EmojiButton({
         // into one arbitrary `transition` property — two separate Tailwind
         // transition-property utilities (transition-colors + transition-transform)
         // would collide via tailwind-merge and silently drop the color fade.
-        className="motion-fade-up flex h-9 w-9 items-center justify-center rounded-md text-[22px] [transition:background-color_150ms_ease,transform_var(--motion-fast)_var(--ease-snap)] hover:scale-125 hover:bg-[var(--surface-hover)] focus-visible:scale-125"
+        // `scale` is listed separately from `transform` because Tailwind 4's
+        // `hover:scale-125` compiles to the standalone CSS `scale` property,
+        // not `transform` — without it the hover/focus pop never eases in.
+        className="motion-fade-up flex h-9 w-9 items-center justify-center rounded-md text-[22px] [transition:background-color_150ms_ease,transform_var(--motion-fast)_var(--ease-snap),scale_var(--motion-fast)_var(--ease-snap)] hover:scale-125 hover:bg-[var(--surface-hover)] focus-visible:scale-125"
         style={{ animationDelay: `${Math.min(index, 20) * 12}ms` }}
       >
         {REACTION_EMOJI[type]}

--- a/src/components/messages/EmojiPicker.tsx
+++ b/src/components/messages/EmojiPicker.tsx
@@ -42,8 +42,8 @@ export function EmojiPicker({ children, onSelect }: EmojiPickerProps) {
           <section className="mb-4">
             <h3 className="mb-2 text-[12px] font-bold uppercase tracking-wide text-[var(--text-muted)]">Frequently used</h3>
             <div className="grid grid-cols-9 gap-1">
-              {REACTION_TYPES.map((type) => (
-                <EmojiButton key={type} type={type} onSelect={onSelect} />
+              {REACTION_TYPES.map((type, index) => (
+                <EmojiButton key={type} type={type} index={index} onSelect={onSelect} />
               ))}
             </div>
           </section>
@@ -62,8 +62,8 @@ export function EmojiPicker({ children, onSelect }: EmojiPickerProps) {
           <section>
             <h3 className="mb-2 text-[12px] font-bold uppercase tracking-wide text-[var(--text-muted)]">Teams reactions</h3>
             <div className="grid grid-cols-9 gap-1">
-              {filtered.map((type) => (
-                <EmojiButton key={type} type={type} onSelect={onSelect} />
+              {filtered.map((type, index) => (
+                <EmojiButton key={type} type={type} index={index} onSelect={onSelect} />
               ))}
             </div>
             {filtered.length === 0 && (
@@ -76,7 +76,15 @@ export function EmojiPicker({ children, onSelect }: EmojiPickerProps) {
   );
 }
 
-function EmojiButton({ type, onSelect }: { type: ReactionType; onSelect: (reaction: ReactionType) => void }) {
+function EmojiButton({
+  type,
+  index,
+  onSelect,
+}: {
+  type: ReactionType;
+  index: number;
+  onSelect: (reaction: ReactionType) => void;
+}) {
   return (
     <Popover.Close asChild>
       <button
@@ -84,7 +92,14 @@ function EmojiButton({ type, onSelect }: { type: ReactionType; onSelect: (reacti
         aria-label={type}
         title={type}
         onClick={() => onSelect(type)}
-        className="flex h-9 w-9 items-center justify-center rounded-md text-[22px] transition-colors duration-150 hover:bg-[var(--surface-hover)]"
+        // motion-fade-up staggers the picker's open entrance (capped at index 20
+        // so a long filtered list doesn't trail on forever); the hover/focus pop
+        // is a separate transform-only affordance for picking an emoji. Combined
+        // into one arbitrary `transition` property — two separate Tailwind
+        // transition-property utilities (transition-colors + transition-transform)
+        // would collide via tailwind-merge and silently drop the color fade.
+        className="motion-fade-up flex h-9 w-9 items-center justify-center rounded-md text-[22px] [transition:background-color_150ms_ease,transform_var(--motion-fast)_var(--ease-snap)] hover:scale-125 hover:bg-[var(--surface-hover)] focus-visible:scale-125"
+        style={{ animationDelay: `${Math.min(index, 20) * 12}ms` }}
       >
         {REACTION_EMOJI[type]}
       </button>

--- a/src/components/messages/MessageFeed.tsx
+++ b/src/components/messages/MessageFeed.tsx
@@ -6,11 +6,21 @@ import { MessageItem } from "./MessageItem";
 import { DateDivider } from "./DateDivider";
 import { LoadingSkeleton } from "./LoadingSkeleton";
 import { AiSummaryBanner } from "./AiSummaryBanner";
+import { CelebrationBurst } from "./CelebrationBurst";
 import type { ReactionType } from "@/lib/utils/reactions";
 import { useSmartNotifications } from "@/hooks/useSmartNotifications";
+import { isCelebrationMessage } from "@/lib/utils/celebrate";
+import { messagePlainText } from "@/lib/utils/render-message";
 
 const GROUP_WINDOW_MS = 7 * 60 * 1000;
 const NEAR_BOTTOM_THRESHOLD = 150;
+
+// Message ids that have already been evaluated for a celebration burst.
+// Module-level so a given message fires confetti at most once even as the
+// `messages` array churns under polling refetches. Seeded with the current
+// window each time the open context changes (see the effect below) so
+// pre-existing history never fires.
+const celebratedIds = new Set<string>();
 
 interface Props {
   messages: MSMessage[];
@@ -86,6 +96,13 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
   const CAP_STEP = 100;
   const [visibleCount, setVisibleCount] = useState(INITIAL_CAP);
 
+  // Confetti trigger — the id of the message that earned a celebration burst.
+  // CelebrationBurst plays once per distinct non-empty key.
+  const [celebrateKey, setCelebrateKey] = useState("");
+  // False until the seen-id set has been seeded with the current context's
+  // window; re-armed on every context switch (in the reset effect below).
+  const celebrationSeededRef = useRef(false);
+
   useSmartNotifications({ messages, contextName, contextId, contextKind, currentUserId });
 
   // Detect whether the user is near the bottom of the scroll container.
@@ -146,6 +163,11 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
     setIsNearBottom(true);
     setNewMessagesCount(0);
     setVisibleCount(INITIAL_CAP);
+    // Re-seed the celebration set against the incoming context's history so a
+    // conversation that already contains 🎉 never bursts on open, and clear any
+    // stale trigger from the previous context.
+    celebrationSeededRef.current = false;
+    setCelebrateKey("");
   }, [contextId]);
 
   // On initial load or context change: once messages are present and not
@@ -192,6 +214,36 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
     prevMessageCountRef.current = curr;
     prevLastIdRef.current = lastId;
   }, [messages, loading, isNearBottom, scrollToBottom, currentUserId]);
+
+  // Fire a confetti burst when a newly arrived message is a pure-celebration
+  // message (🎉 / 🎊 / 🥳, no prose). One code path covers own sends (the
+  // optimistic append) and incoming messages in the open conversation.
+  useEffect(() => {
+    if (loading) return;
+    if (messages.length === 0) return;
+
+    // Seed the current context's window on first run so history never fires.
+    if (!celebrationSeededRef.current) {
+      for (const m of messages) celebratedIds.add(m.id);
+      celebrationSeededRef.current = true;
+      return;
+    }
+
+    const last = messages[messages.length - 1];
+    if (!last || celebratedIds.has(last.id)) return;
+    celebratedIds.add(last.id);
+
+    // Own sends burst on the optimistic (pending) append; skip the reconciled
+    // copy — its id swaps to the Graph id and would otherwise fire a second
+    // time — so a send celebrates exactly once. Incoming messages (not ours)
+    // always take the normal path.
+    const isOwn = !!currentUserId && last.from?.user?.id === currentUserId;
+    if (isOwn && !last.__pending) return;
+
+    if (isCelebrationMessage(messagePlainText(last.body.content, last.body.contentType))) {
+      setCelebrateKey(last.id);
+    }
+  }, [messages, loading, currentUserId]);
 
   // Track which anchor request we've already handled so polling refetches
   // don't re-flash the row every 5s. We tag each request with the current
@@ -325,6 +377,12 @@ export function MessageFeed({ messages, loading, contextName, bookmarkContextId,
         <div ref={bottomRef} />
         </div>
       </div>
+
+      {/* Confetti overlay: anchored to the feed viewport (this relative,
+          overflow-hidden container), out of the scroll container so it can't
+          affect scrollHeight, and pointer-events-none so it never blocks the
+          feed or the "new messages" button. */}
+      <CelebrationBurst playKey={celebrateKey} />
 
       {newMessagesCount > 0 && (
         <div className="pointer-events-none absolute bottom-4 left-0 right-0 flex justify-center">

--- a/src/components/messages/MessageHoverToolbar.tsx
+++ b/src/components/messages/MessageHoverToolbar.tsx
@@ -35,7 +35,7 @@ export function MessageHoverToolbar({
 
   return (
     <div
-      className="absolute right-2 top-[-20px] z-[100] flex gap-[2px] rounded-md border border-[var(--border)] bg-[#1a1d21] px-1 py-[2px] opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.35)] transition-opacity duration-[80ms] ease-out group-hover:opacity-100"
+      className="absolute right-2 top-[-20px] z-[100] flex gap-[2px] rounded-md border border-[var(--border)] bg-[#1a1d21] px-1 py-[2px] opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.35)] transition-opacity duration-[var(--motion-fast)] ease-out group-hover:opacity-100"
       role="toolbar"
       aria-label="Message actions"
     >
@@ -116,7 +116,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(function
       aria-pressed={active ?? undefined}
       title={label}
       className={cn(
-        "flex h-7 w-7 items-center justify-center rounded transition-colors duration-100 hover:bg-[var(--surface-hover)] hover:text-white focus-ring",
+        "flex h-7 w-7 items-center justify-center rounded transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-white focus-ring",
         active ? "text-[var(--accent)]" : "text-[var(--text-secondary)]",
         className
       )}

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -1487,10 +1487,13 @@ export function MessageInput({
                 className={cn(
                   // Single arbitrary `transition` property (rather than separate
                   // `transition-[...]`/`transition-transform` utilities) so the
-                  // background/color fade and the transform snap keep their own
-                  // durations — two Tailwind transition-property utilities would
-                  // collide via tailwind-merge and one would silently win outright.
-                  "relative overflow-hidden flex h-8 items-center justify-center rounded [transition:background_150ms_ease-out,color_150ms_ease-out,transform_var(--motion-fast)_var(--ease-snap)] active:scale-90 focus-ring",
+                  // background/color fade and the transform/scale snap keep their
+                  // own durations — two Tailwind transition-property utilities
+                  // would collide via tailwind-merge and one would silently win
+                  // outright. `scale` is listed separately from `transform`
+                  // because Tailwind 4's `active:scale-90` compiles to the
+                  // standalone CSS `scale` property, not `transform`.
+                  "relative overflow-hidden flex h-8 items-center justify-center rounded [transition:background_150ms_ease-out,color_150ms_ease-out,transform_var(--motion-fast)_var(--ease-snap),scale_var(--motion-fast)_var(--ease-snap)] active:scale-90 focus-ring",
                   scheduleTime ? "w-auto gap-1 px-2.5 text-[13px] font-medium" : "w-8",
                   canSend
                     ? "bg-[var(--accent)] text-white hover:opacity-90"

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -1485,7 +1485,12 @@ export function MessageInput({
                 onClick={submit}
                 disabled={!canSend}
                 className={cn(
-                  "relative overflow-hidden flex h-8 items-center justify-center rounded transition-[background,color,transform] duration-150 ease-out focus-ring",
+                  // Single arbitrary `transition` property (rather than separate
+                  // `transition-[...]`/`transition-transform` utilities) so the
+                  // background/color fade and the transform snap keep their own
+                  // durations — two Tailwind transition-property utilities would
+                  // collide via tailwind-merge and one would silently win outright.
+                  "relative overflow-hidden flex h-8 items-center justify-center rounded [transition:background_150ms_ease-out,color_150ms_ease-out,transform_var(--motion-fast)_var(--ease-snap)] active:scale-90 focus-ring",
                   scheduleTime ? "w-auto gap-1 px-2.5 text-[13px] font-medium" : "w-8",
                   canSend
                     ? "bg-[var(--accent)] text-white hover:opacity-90"

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -122,9 +122,12 @@ function MessageItemImpl({
     disabled: isEditing || Boolean(message.__pending || message.__failed),
   });
 
-  // Animate messages that just arrived (within the last 3s) or are optimistic
-  // sends. This covers real-time inbound messages and the user's own pending
-  // messages without needing an extra prop from the feed.
+  // Recency window used only by the slash-result pop (below) — deliberately
+  // NOT used to drive the `message-in` row animation, which must fire only
+  // for the sender's own optimistic send (see `message.__pending` at the
+  // className below). Keying the entrance animation off recency instead
+  // would replay it for polled/history rows and other people's real-time
+  // messages, which is exactly what it must never do.
   const isNew =
     message.__pending ||
     Date.now() - new Date(message.createdDateTime).getTime() < 3000;
@@ -141,12 +144,6 @@ function MessageItemImpl({
         paddingTop: "var(--density-row-py)",
         paddingBottom: "var(--density-row-py)",
       };
-  const animationStyle: React.CSSProperties = {
-    ...densityRowStyle,
-    ...(isNew
-      ? { animation: "message-in var(--motion-base) var(--ease-out-soft) both" }
-      : {}),
-  };
   // Density-driven body typography for the message-body div. Kept separate
   // so the row chrome stays themable independently from text rendering.
   const bodyDensityStyle: React.CSSProperties = {
@@ -387,12 +384,12 @@ function MessageItemImpl({
     return (
       <div
         data-message-id={message.id}
-        style={animationStyle}
+        style={densityRowStyle}
         onMouseEnter={quickReact.onMouseEnter}
         onMouseLeave={quickReact.onMouseLeave}
         className={cn(
-          "group relative flex px-4 transition-colors duration-[80ms] ease-out hover:bg-[var(--message-hover-bg)]",
-          message.__pending && "opacity-60",
+          "group relative flex px-4 transition-colors duration-[var(--motion-fast)] ease-out hover:bg-[var(--message-hover-bg)]",
+          message.__pending && "opacity-60 message-in",
           message.__failed && "border-l-2 border-red-500/60"
         )}
       >
@@ -474,12 +471,12 @@ function MessageItemImpl({
   return (
     <div
       data-message-id={message.id}
-      style={animationStyle}
+      style={densityRowStyle}
       onMouseEnter={quickReact.onMouseEnter}
       onMouseLeave={quickReact.onMouseLeave}
       className={cn(
-        "group relative flex gap-2 px-4 transition-colors duration-[80ms] ease-out hover:bg-[var(--message-hover-bg)]",
-        message.__pending && "opacity-60",
+        "group relative flex gap-2 px-4 transition-colors duration-[var(--motion-fast)] ease-out hover:bg-[var(--message-hover-bg)]",
+        message.__pending && "opacity-60 message-in",
         message.__failed && "border-l-2 border-red-500/60 pl-2"
       )}
     >

--- a/src/components/messages/PollCard.tsx
+++ b/src/components/messages/PollCard.tsx
@@ -57,7 +57,7 @@ export function PollCard({
               {/* Fill bar behind the row content. */}
               <span
                 aria-hidden
-                className="absolute inset-y-0 left-0 bg-[var(--accent)]/15 transition-[width] duration-300"
+                className="absolute inset-y-0 left-0 bg-[var(--accent)]/15 transition-[width] duration-[var(--motion-slow)]"
                 style={{ width: `${pct}%` }}
               />
               <span className="relative z-[1] text-[15px] leading-none">{opt.emoji}</span>

--- a/src/components/messages/ReactionPill.tsx
+++ b/src/components/messages/ReactionPill.tsx
@@ -71,7 +71,7 @@ export function ReactionPill({ reactionType, count, active, onClick }: ReactionP
         type="button"
         onClick={handleClick}
         className={[
-          "inline-flex h-6 items-center gap-1 rounded-md border px-2 py-0.5 text-[12px] transition-colors duration-150 focus-ring",
+          "inline-flex h-6 items-center gap-1 rounded-md border px-2 py-0.5 text-[12px] transition-colors duration-[var(--motion-fast)] focus-ring",
           bursting ? "react-burst" : "",
           active
             ? "border-[var(--accent)] bg-[var(--reaction-active-bg)] text-[var(--text-primary)]"
@@ -91,7 +91,7 @@ export function AddReactionPill({ onSelect }: { onSelect: (reaction: ReactionTyp
       <button
         type="button"
         aria-label="Add reaction"
-        className="inline-flex h-6 items-center rounded-md border border-[var(--reaction-border)] bg-[var(--reaction-bg)] px-2 py-0.5 text-[var(--text-secondary)] transition-colors duration-150 hover:border-[var(--accent)] hover:bg-[var(--reaction-active-bg)] hover:text-[var(--text-primary)] focus-ring"
+        className="inline-flex h-6 items-center rounded-md border border-[var(--reaction-border)] bg-[var(--reaction-bg)] px-2 py-0.5 text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:border-[var(--accent)] hover:bg-[var(--reaction-active-bg)] hover:text-[var(--text-primary)] focus-ring"
       >
         <Plus size={13} />
       </button>

--- a/src/components/messages/SlashCommandMenu.tsx
+++ b/src/components/messages/SlashCommandMenu.tsx
@@ -66,7 +66,7 @@ export function SlashCommandMenu({ filtered, selectedIdx, onHover, onPick, open 
             onPick(cmd);
           }}
           className={cn(
-            "flex w-full items-baseline gap-2 px-3 py-1.5 text-left transition-colors duration-100",
+            "flex w-full items-baseline gap-2 px-3 py-1.5 text-left transition-colors duration-[var(--motion-fast)]",
             idx === selectedIdx
               ? "bg-[var(--surface-hover)]"
               : "hover:bg-[var(--surface-hover)]"

--- a/src/components/messages/ThreadPanel.tsx
+++ b/src/components/messages/ThreadPanel.tsx
@@ -94,7 +94,7 @@ export function ThreadPanel({ message, open, onClose, onSendReply, onForward }: 
           type="button"
           aria-label="Close thread"
           onClick={onClose}
-          className="flex h-7 w-7 items-center justify-center rounded-md text-[#ababad] transition-colors duration-150 hover:bg-[#27292d] hover:text-white"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-[#ababad] transition-colors duration-[var(--motion-fast)] hover:bg-[#27292d] hover:text-white"
         >
           <X size={16} />
         </button>

--- a/src/components/modals/FeedbackModal.tsx
+++ b/src/components/modals/FeedbackModal.tsx
@@ -120,7 +120,7 @@ export function FeedbackModal({ open, onOpenChange }: Props) {
   }
 
   const inputClass =
-    "w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]";
+    "w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-[var(--motion-fast)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]";
   const textareaClass = `${inputClass} resize-none`;
   const labelClass = "text-[12px] font-semibold text-[var(--text-secondary)]";
 
@@ -305,7 +305,7 @@ function TypeButton({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex items-center justify-center gap-2 rounded-lg border px-4 py-3 text-[13px] font-semibold transition-colors duration-100",
+        "flex items-center justify-center gap-2 rounded-lg border px-4 py-3 text-[13px] font-semibold transition-colors duration-[var(--motion-fast)]",
         active
           ? "border-[var(--accent)] bg-[var(--accent)]/10 text-white"
           : "border-[var(--border)] bg-[var(--surface)] text-[var(--text-secondary)] hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]"

--- a/src/components/modals/ForwardMessageModal.tsx
+++ b/src/components/modals/ForwardMessageModal.tsx
@@ -152,7 +152,7 @@ export function ForwardMessageModal({ open, onOpenChange, message, onForward }: 
             <h2 className="text-[15px] font-bold text-[var(--text-primary)]">Forward message</h2>
             <Dialog.Close
               aria-label="Close"
-              className="flex h-7 w-7 items-center justify-center rounded text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
+              className="flex h-7 w-7 items-center justify-center rounded text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
             >
               <X size={16} />
             </Dialog.Close>
@@ -302,7 +302,7 @@ function DestinationRow({
       type="button"
       onClick={onSelect}
       className={cn(
-        "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[80ms]",
+        "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[var(--motion-fast)]",
         active ? "bg-[var(--accent)] text-white" : "text-[var(--text-primary)] hover:bg-[var(--surface-hover)]"
       )}
     >

--- a/src/components/modals/JumpToSwitcher.tsx
+++ b/src/components/modals/JumpToSwitcher.tsx
@@ -96,7 +96,7 @@ export function JumpToSwitcher({ open, onOpenChange, items }: JumpToSwitcherProp
             </kbd>
             <Dialog.Close
               aria-label="Close jump to"
-              className="mr-3 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
+              className="mr-3 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
             >
               <X size={16} />
             </Dialog.Close>
@@ -116,7 +116,7 @@ export function JumpToSwitcher({ open, onOpenChange, items }: JumpToSwitcherProp
                     type="button"
                     onMouseEnter={() => setActiveIndex(index)}
                     onClick={() => selectItem(item)}
-                    className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors duration-[80ms] ${
+                    className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors duration-[var(--motion-fast)] ${
                       index === activeIndex
                         ? "bg-[var(--accent)] text-[var(--text-white)]"
                         : "text-[var(--text-primary)] hover:bg-[var(--surface-hover)]"

--- a/src/components/modals/PreferencesModal.tsx
+++ b/src/components/modals/PreferencesModal.tsx
@@ -435,11 +435,13 @@ function AccentSwatch({
 
 function NotificationsPanel() {
   const desktop = usePreferencesStore((s) => s.desktopNotifications);
+  const celebrationEffects = usePreferencesStore((s) => s.celebrationEffects);
   const mentionsOnly = usePreferencesStore((s) => s.mentionsOnly);
   const keywords = usePreferencesStore((s) => s.notificationKeywords);
   const soundTheme = usePreferencesStore((s) => s.soundTheme);
   const soundVolume = usePreferencesStore((s) => s.soundVolume);
   const setDesktop = usePreferencesStore((s) => s.setDesktopNotifications);
+  const setCelebrationEffects = usePreferencesStore((s) => s.setCelebrationEffects);
   const setMentionsOnly = usePreferencesStore((s) => s.setMentionsOnly);
   const setKeywords = usePreferencesStore((s) => s.setNotificationKeywords);
   const setSoundTheme = usePreferencesStore((s) => s.setSoundTheme);
@@ -462,6 +464,12 @@ function NotificationsPanel() {
         hint="Mute everything except direct @mentions and DMs."
         value={mentionsOnly}
         onChange={setMentionsOnly}
+      />
+      <ToggleRow
+        label="Celebration effects"
+        hint="Confetti when a message is pure celebration (🎉)."
+        value={celebrationEffects}
+        onChange={setCelebrationEffects}
       />
 
       <FieldGroup label="Sound" hint="Tone style for incoming notifications.">

--- a/src/components/modals/PreferencesModal.tsx
+++ b/src/components/modals/PreferencesModal.tsx
@@ -102,7 +102,7 @@ export function PreferencesModal({ open, onOpenChange }: Props) {
                   key={item.key}
                   type="button"
                   onClick={() => setSection(item.key)}
-                  className={`flex items-center justify-between gap-2 rounded-md px-2 py-[6px] text-left text-[13px] transition-colors duration-100 focus-ring ${
+                  className={`flex items-center justify-between gap-2 rounded-md px-2 py-[6px] text-left text-[13px] transition-colors duration-[var(--motion-fast)] focus-ring ${
                     active
                       ? "bg-[var(--accent)] text-[var(--text-white)]"
                       : "text-[var(--text-secondary)] hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-primary)]"
@@ -409,7 +409,7 @@ function AccentSwatch({
       className="group flex flex-col items-center gap-[6px] rounded focus-ring"
     >
       <span
-        className={`relative flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ${
+        className={`relative flex h-8 w-8 items-center justify-center rounded-full transition-all duration-[var(--motion-fast)] ${
           selected
             ? "ring-2 ring-[var(--text-primary)] ring-offset-2 ring-offset-[var(--modal-bg)]"
             : "hover:ring-2 hover:ring-[var(--text-secondary)] hover:ring-offset-2 hover:ring-offset-[var(--modal-bg)]"
@@ -421,7 +421,7 @@ function AccentSwatch({
         )}
       </span>
       <span
-        className={`text-[11px] transition-colors duration-100 ${
+        className={`text-[11px] transition-colors duration-[var(--motion-fast)] ${
           selected ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] group-hover:text-[var(--text-secondary)]"
         }`}
       >
@@ -573,12 +573,12 @@ function ToggleRow({
         aria-checked={value}
         aria-label={label || undefined}
         onClick={() => onChange(!value)}
-        className={`relative mt-[2px] h-5 w-9 flex-shrink-0 rounded-full transition-colors duration-150 ${
+        className={`relative mt-[2px] h-5 w-9 flex-shrink-0 rounded-full transition-colors duration-[var(--motion-fast)] ${
           value ? "bg-[var(--accent)]" : "bg-[var(--border-input)]"
         }`}
       >
         <span
-          className={`absolute top-[2px] h-4 w-4 rounded-full bg-white transition-transform duration-150 ${
+          className={`absolute top-[2px] h-4 w-4 rounded-full bg-white transition-transform duration-[var(--motion-fast)] ${
             value ? "translate-x-[18px]" : "translate-x-[2px]"
           }`}
         />
@@ -1029,7 +1029,7 @@ function ModeButton({
       type="button"
       aria-pressed={active}
       onClick={() => onSelect(mode)}
-      className={`flex w-[90px] flex-col items-center gap-2 rounded-lg border py-3 text-[12px] font-semibold transition-colors duration-150 focus-ring ${
+      className={`flex w-[90px] flex-col items-center gap-2 rounded-lg border py-3 text-[12px] font-semibold transition-colors duration-[var(--motion-fast)] focus-ring ${
         active
           ? "border-[var(--accent)] bg-[var(--accent-light)] text-[var(--text-primary)]"
           : "border-[var(--border)] bg-[var(--surface)] text-[var(--text-secondary)] hover:border-[var(--border-input)] hover:text-[var(--text-primary)]"
@@ -1051,7 +1051,7 @@ function Checkbox({ checked, onChange }: { checked: boolean; onChange: (v: boole
         onChange={(e) => onChange(e.target.checked)}
       />
       <span
-        className={`flex h-4 w-4 items-center justify-center rounded border transition-colors duration-150 ${
+        className={`flex h-4 w-4 items-center justify-center rounded border transition-colors duration-[var(--motion-fast)] ${
           checked
             ? "border-[var(--accent)] bg-[var(--accent)]"
             : "border-[var(--border-input)] bg-[var(--surface)]"

--- a/src/components/modals/SearchModal.tsx
+++ b/src/components/modals/SearchModal.tsx
@@ -208,7 +208,7 @@ export function SearchModal({
             </kbd>
             <Dialog.Close
               aria-label="Close search"
-              className="mr-3 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
+              className="mr-3 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
             >
               <X size={16} />
             </Dialog.Close>
@@ -309,7 +309,7 @@ function MessageResult({ message, query, teamName, onSelect }: { message: MSMess
     <button
       type="button"
       onClick={onSelect}
-      className="flex w-full gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
+      className="flex w-full gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)]"
     >
       <div className="mt-[3px] flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-[var(--accent)] text-[10px] font-bold text-[var(--text-white)]">
         {initials || "?"}
@@ -348,7 +348,7 @@ function PersonResult({
     <button
       type="button"
       onClick={onSelect}
-      className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
+      className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)]"
     >
       <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[10px] font-bold text-[var(--text-white)]">
         {initials || "?"}
@@ -382,7 +382,7 @@ function EntityResult({
     <button
       type="button"
       onClick={onSelect}
-      className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[80ms] hover:bg-[var(--surface-hover)]"
+      className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)]"
     >
       <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-[var(--surface-raised)] text-[var(--text-secondary)]">
         {icon}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -91,7 +91,7 @@ function TabButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-center gap-2 rounded-md px-2 py-[6px] text-left text-[14px] transition-colors duration-100 ${
+      className={`flex items-center gap-2 rounded-md px-2 py-[6px] text-left text-[14px] transition-colors duration-[var(--motion-fast)] ${
         active ? "bg-[var(--accent)] text-white" : "text-[var(--text-secondary)] hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-primary)]"
       }`}
     >
@@ -192,7 +192,7 @@ function NotificationsPanel() {
           value={keywords}
           onChange={(event) => setKeywords(event.target.value)}
           placeholder="launch, incident, blocker"
-          className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
+          className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-[var(--motion-fast)] placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
         />
       </FieldGroup>
       <FieldGroup
@@ -204,7 +204,7 @@ function NotificationsPanel() {
           onChange={(event) => handleMutedChange(event.target.value)}
           placeholder="standup, lunch, friday-jam"
           rows={2}
-          className="min-h-[56px] resize-y rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
+          className="min-h-[56px] resize-y rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-[var(--motion-fast)] placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
         />
       </FieldGroup>
       <FieldGroup
@@ -224,7 +224,7 @@ function NotificationsPanel() {
               value={quietHoursStart}
               onChange={(event) => setQuietHoursStart(event.target.value)}
               disabled={!quietHoursEnabled}
-              className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 focus:border-[var(--text-primary)] disabled:opacity-50"
+              className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-[var(--motion-fast)] focus:border-[var(--text-primary)] disabled:opacity-50"
             />
             <span className="text-[12px] text-[var(--text-muted)]">to</span>
             <input
@@ -232,7 +232,7 @@ function NotificationsPanel() {
               value={quietHoursEnd}
               onChange={(event) => setQuietHoursEnd(event.target.value)}
               disabled={!quietHoursEnabled}
-              className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 focus:border-[var(--text-primary)] disabled:opacity-50"
+              className="h-8 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-[var(--motion-fast)] focus:border-[var(--text-primary)] disabled:opacity-50"
             />
           </div>
         </div>
@@ -341,12 +341,12 @@ function ToggleRow({
         role="switch"
         aria-checked={value}
         onClick={() => onChange(!value)}
-        className={`relative mt-[2px] h-5 w-9 flex-shrink-0 rounded-full transition-colors duration-150 ${
+        className={`relative mt-[2px] h-5 w-9 flex-shrink-0 rounded-full transition-colors duration-[var(--motion-fast)] ${
           value ? "bg-[var(--status-online)]" : "bg-[var(--border-input)]"
         }`}
       >
         <span
-          className={`absolute top-[2px] h-4 w-4 rounded-full bg-white transition-transform duration-150 ${
+          className={`absolute top-[2px] h-4 w-4 rounded-full bg-white transition-transform duration-[var(--motion-fast)] ${
             value ? "translate-x-[18px]" : "translate-x-[2px]"
           }`}
         />
@@ -373,7 +373,7 @@ function RadioRow({
       type="button"
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
-      className={`flex items-start gap-3 rounded-md border px-3 py-2 text-left transition-colors duration-100 ${
+      className={`flex items-start gap-3 rounded-md border px-3 py-2 text-left transition-colors duration-[var(--motion-fast)] ${
         checked
           ? "border-[var(--accent)] bg-[var(--accent-light)]"
           : "border-[var(--border)] bg-[var(--surface)]"

--- a/src/components/modals/StatusMessageModal.tsx
+++ b/src/components/modals/StatusMessageModal.tsx
@@ -166,7 +166,7 @@ export function StatusMessageModal({ open, onOpenChange }: Props) {
                 placeholder="What's your status?"
                 minRows={3}
                 maxRows={6}
-                className="w-full resize-none rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-150 placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]"
+                className="w-full resize-none rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none transition-colors duration-[var(--motion-fast)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]"
               />
               <span
                 className={`absolute bottom-2 right-3 text-[11px] tabular-nums ${

--- a/src/components/profile/UserProfilePopover.tsx
+++ b/src/components/profile/UserProfilePopover.tsx
@@ -40,7 +40,7 @@ export function UserProfilePopover({
             </div>
             <Popover.Close
               aria-label="Close profile"
-              className="flex h-7 w-7 items-center justify-center rounded-md text-[#ababad] transition-colors duration-150 hover:bg-[#27292d] hover:text-white"
+              className="flex h-7 w-7 items-center justify-center rounded-md text-[#ababad] transition-colors duration-[var(--motion-fast)] hover:bg-[#27292d] hover:text-white"
             >
               <X size={16} />
             </Popover.Close>
@@ -55,7 +55,7 @@ export function UserProfilePopover({
               <button
                 type="button"
                 onClick={onSendDm}
-                className="inline-flex h-8 items-center gap-2 rounded-md bg-[#0F5A8F] px-3 text-[13px] font-bold text-white transition-colors duration-150 hover:bg-[#0A4571]"
+                className="inline-flex h-8 items-center gap-2 rounded-md bg-[#0F5A8F] px-3 text-[13px] font-bold text-white transition-colors duration-[var(--motion-fast)] hover:bg-[#0A4571]"
               >
                 <MessageSquare size={14} />
                 Send DM
@@ -66,7 +66,7 @@ export function UserProfilePopover({
                     type="button"
                     onClick={() => openTeamsCall([email])}
                     title="Call"
-                    className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#3f4144] bg-transparent text-[#ababad] transition-colors duration-150 hover:bg-[#27292d] hover:text-white"
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#3f4144] bg-transparent text-[#ababad] transition-colors duration-[var(--motion-fast)] hover:bg-[#27292d] hover:text-white"
                   >
                     <Phone size={14} />
                   </button>
@@ -74,7 +74,7 @@ export function UserProfilePopover({
                     type="button"
                     onClick={() => openTeamsCall([email], { withVideo: true })}
                     title="Video call"
-                    className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#3f4144] bg-transparent text-[#ababad] transition-colors duration-150 hover:bg-[#27292d] hover:text-white"
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#3f4144] bg-transparent text-[#ababad] transition-colors duration-[var(--motion-fast)] hover:bg-[#27292d] hover:text-white"
                   >
                     <Video size={14} />
                   </button>

--- a/src/components/sidebar/DemoSidebar.tsx
+++ b/src/components/sidebar/DemoSidebar.tsx
@@ -81,7 +81,7 @@ export function DemoSidebar() {
       <button
         type="button"
         onClick={() => setSearchOpen(true)}
-        className="mx-3 my-2 flex h-7 items-center gap-2 rounded-md border border-[#565856] bg-[#2c2d30] px-2 text-left text-[13px] text-[#ababad] [transition:border-color_150ms_ease,background_150ms_ease] hover:border-white hover:bg-[#1a1d21] focus:border-white focus:bg-[#1a1d21] focus:outline-none"
+        className="mx-3 my-2 flex h-7 items-center gap-2 rounded-md border border-[#565856] bg-[#2c2d30] px-2 text-left text-[13px] text-[#ababad] [transition:border-color_var(--motion-fast)_ease,background_var(--motion-fast)_ease] hover:border-white hover:bg-[#1a1d21] focus:border-white focus:bg-[#1a1d21] focus:outline-none"
       >
         <Search className="h-3.5 w-3.5 flex-shrink-0" />
         <span className="truncate">Search...</span>

--- a/src/components/sidebar/DemoSidebar.tsx
+++ b/src/components/sidebar/DemoSidebar.tsx
@@ -71,7 +71,7 @@ export function DemoSidebar() {
 
   return (
     <div className="flex w-[260px] flex-shrink-0 flex-col overflow-hidden bg-[#19171d]">
-      <div className="flex h-[49px] items-center justify-between border-b border-[#3f4144] px-4 transition-colors duration-[80ms] ease-out hover:bg-[#27242c]">
+      <div className="flex h-[49px] items-center justify-between border-b border-[#3f4144] px-4 transition-colors duration-[var(--motion-fast)] ease-out hover:bg-[#27242c]">
         <span className="truncate text-[15px] font-black text-white">
           {activeTeam?.displayName ?? "Teamsly"}
         </span>
@@ -91,18 +91,18 @@ export function DemoSidebar() {
         <div className="mb-1">
           <button
             onClick={() => setChannelsOpen((v) => !v)}
-            className="group/section flex w-full items-center justify-between px-4 py-1 text-[13px] font-bold text-[#ababad] transition-colors duration-[80ms] ease-out hover:text-white"
+            className="group/section flex w-full items-center justify-between px-4 py-1 text-[13px] font-bold text-[#ababad] transition-colors duration-[var(--motion-fast)] ease-out hover:text-white"
           >
             <span className="flex min-w-0 items-center gap-1">
               <ChevronRight
                 className={cn(
-                  "h-3 w-3 transition-transform duration-200 ease-out",
+                  "h-3 w-3 transition-transform duration-[var(--motion-base)] ease-out",
                   channelsOpen && "rotate-90"
                 )}
               />
               <span className="truncate">Channels</span>
             </span>
-            <Plus className="h-3.5 w-3.5 opacity-0 transition-opacity duration-150 group-hover/section:opacity-100" />
+            <Plus className="h-3.5 w-3.5 opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover/section:opacity-100" />
           </button>
 
           {channelsOpen &&
@@ -130,18 +130,18 @@ export function DemoSidebar() {
         <div className="mt-3">
           <button
             onClick={() => setDmsOpen((v) => !v)}
-            className="group/section flex w-full items-center justify-between px-4 py-1 text-[13px] font-bold text-[#ababad] transition-colors duration-[80ms] ease-out hover:text-white"
+            className="group/section flex w-full items-center justify-between px-4 py-1 text-[13px] font-bold text-[#ababad] transition-colors duration-[var(--motion-fast)] ease-out hover:text-white"
           >
             <span className="flex min-w-0 items-center gap-1">
               <ChevronRight
                 className={cn(
-                  "h-3 w-3 transition-transform duration-200 ease-out",
+                  "h-3 w-3 transition-transform duration-[var(--motion-base)] ease-out",
                   dmsOpen && "rotate-90"
                 )}
               />
               <span className="truncate">Direct Messages</span>
             </span>
-            <Plus className="h-3.5 w-3.5 opacity-0 transition-opacity duration-150 group-hover/section:opacity-100" />
+            <Plus className="h-3.5 w-3.5 opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover/section:opacity-100" />
           </button>
 
           {dmsOpen &&
@@ -220,14 +220,14 @@ function SidebarItem({
     <button
       onClick={onClick}
       className={cn(
-        "mx-2 flex h-7 w-[calc(100%-16px)] items-center gap-2 rounded-md px-2 text-[15px] transition-colors duration-[80ms] ease-out",
+        "mx-2 flex h-7 w-[calc(100%-16px)] items-center gap-2 rounded-md px-2 text-[15px] transition-colors duration-[var(--motion-fast)] ease-out",
         active ? "bg-[#0F5A8F] text-white" : "text-[#ababad] hover:bg-[#27292d] hover:text-white"
       )}
     >
       <span className="flex-shrink-0 opacity-70">{icon}</span>
       <span className={cn("truncate", unread && "font-black text-white")}>{label}</span>
       {unread && (
-        <span className="ml-auto flex h-[18px] min-w-[18px] flex-shrink-0 scale-100 items-center justify-center rounded-full bg-[#cd2553] px-[5px] text-[11px] font-bold text-white transition-transform duration-150">
+        <span className="ml-auto flex h-[18px] min-w-[18px] flex-shrink-0 scale-100 items-center justify-center rounded-full bg-[#cd2553] px-[5px] text-[11px] font-bold text-white transition-transform duration-[var(--motion-fast)]">
           {unreadCount > 99 ? "99+" : unreadCount}
         </span>
       )}

--- a/src/components/sidebar/DemoWorkspaceBar.tsx
+++ b/src/components/sidebar/DemoWorkspaceBar.tsx
@@ -21,7 +21,7 @@ export function DemoWorkspaceBar() {
           title={team.displayName}
           onClick={() => switchTeam(team.id)}
           className={cn(
-            "relative flex h-10 w-10 items-center justify-center rounded-[14px] text-sm font-bold [transition:border-radius_200ms_ease,background-color_150ms_ease]",
+            "relative flex h-10 w-10 items-center justify-center rounded-[14px] text-sm font-bold [transition:border-radius_var(--motion-base)_ease,background-color_var(--motion-fast)_ease]",
             activeTeamId === team.id
               ? "rounded-lg bg-[#0F5A8F] text-white"
               : "bg-[#26415C] text-white hover:rounded-lg"

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import { clearAllReminders } from "@/lib/storage/reminders";
 import { cn } from "@/lib/utils";
 import { isDisappearing, unwrapMessage, wrapMessage, UNDECODABLE_BLOB_GRACE_MS } from "@/lib/utils/disappear";
 import { useScheduledStore } from "@/store/scheduled";
+import { RollingNumber } from "@/components/ui/RollingNumber";
 
 async function sweepAllDms(
   chatIds: string[],
@@ -623,7 +624,7 @@ export function Sidebar() {
       <button
         type="button"
         onClick={() => useSearchStore.getState().open()}
-        className="mx-3 my-2 flex h-7 items-center gap-2 rounded-md border border-[var(--border-input)] bg-[var(--reaction-bg)] px-2 text-left text-[13px] text-[var(--text-secondary)] [transition:border-color_150ms_ease,background_150ms_ease] hover:border-white/50 hover:bg-[var(--sidebar-hover)] focus:border-white/50 focus:bg-[var(--sidebar-hover)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+        className="mx-3 my-2 flex h-7 items-center gap-2 rounded-md border border-[var(--border-input)] bg-[var(--reaction-bg)] px-2 text-left text-[13px] text-[var(--text-secondary)] [transition:border-color_var(--motion-fast)_var(--ease-out-soft),background_var(--motion-fast)_var(--ease-out-soft)] hover:border-white/50 hover:bg-[var(--sidebar-hover)] focus:border-white/50 focus:bg-[var(--sidebar-hover)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
       >
         <Search className="h-3.5 w-3.5 flex-shrink-0" />
         <span className="truncate">Search...</span>
@@ -944,7 +945,7 @@ function SectionHeader({
       <span className="truncate">{label}</span>
       {count > 0 && (
         <span className="ml-auto flex h-[15px] min-w-[15px] flex-shrink-0 items-center justify-center rounded-full bg-[var(--badge-unread)] px-[4px] text-[10px] font-bold text-white">
-          {count > 99 ? "99+" : count}
+          {count > 99 ? "99+" : <RollingNumber value={count} />}
         </span>
       )}
     </button>
@@ -992,7 +993,10 @@ function SidebarItem({
   useEffect(() => {
     if (unreadCount > prevCountRef.current) {
       setPulsing(true);
-      const t = setTimeout(() => setPulsing(false), 300);
+      // Kept in step with the badge-pulse animation's CSS duration below
+      // (var(--motion-slow) = 320ms) so the inline style isn't torn off
+      // before the keyframe finishes.
+      const t = setTimeout(() => setPulsing(false), 320);
       return () => clearTimeout(t);
     }
     prevCountRef.current = unreadCount;
@@ -1019,7 +1023,14 @@ function SidebarItem({
           fontSize: "var(--density-sidebar-font-size)",
         }}
         className={cn(
-          "press-snap mx-2 flex w-[calc(100%-16px)] items-center gap-2 rounded-md px-2 transition-colors [transition-duration:var(--motion-fast)] [transition-timing-function:var(--ease-out-soft)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]",
+          // Single combined [transition:...] property (not a second transition-*
+          // utility) — tailwind-merge strips an earlier transition-property
+          // utility when a later one is stacked on top of it (see
+          // MultiTenantSwitcher.tsx / ThreadPanel.tsx for the same pattern).
+          // Includes `scale` alongside `transform`: Tailwind v4 compiles
+          // `active:scale-[...]` to the standalone `scale` CSS property, not
+          // `transform`, so a transform-only transition wouldn't ease it.
+          "active:scale-[0.98] mx-2 flex w-[calc(100%-16px)] items-center gap-2 rounded-md px-2 [transition:background-color_var(--motion-base)_var(--ease-spring),color_var(--motion-base)_var(--ease-spring),scale_var(--motion-base)_var(--ease-spring)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]",
           active
             ? "bg-[var(--accent)]/15 font-semibold text-[var(--text-primary)]"
             : "text-[var(--text-secondary)] hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-primary)]"
@@ -1050,7 +1061,7 @@ function SidebarItem({
               "flex h-[16px] min-w-[16px] flex-shrink-0 items-center justify-center rounded-full bg-[var(--badge-unread)] px-[4px] text-[10px] font-bold text-white",
               voiceCount > 0 || isSnoozed ? "ml-1" : "ml-auto"
             )}
-            style={pulsing ? { animation: 'badge-pulse 300ms ease-out' } : undefined}
+            style={pulsing ? { animation: 'badge-pulse var(--motion-slow) ease-out' } : undefined}
           >
             {unreadCount > 99 ? "99+" : unreadCount}
           </span>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -642,7 +642,7 @@ export function Sidebar() {
           />
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
+              "grid transition-[grid-template-rows] duration-[var(--motion-base)] [transition-timing-function:var(--ease-spring)]",
               unreadsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -699,7 +699,7 @@ export function Sidebar() {
           />
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
+              "grid transition-[grid-template-rows] duration-[var(--motion-base)] [transition-timing-function:var(--ease-spring)]",
               threadsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -720,7 +720,7 @@ export function Sidebar() {
           />
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
+              "grid transition-[grid-template-rows] duration-[var(--motion-base)] [transition-timing-function:var(--ease-spring)]",
               starredOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -778,7 +778,7 @@ export function Sidebar() {
             >
               <ChevronRight
                 className={cn(
-                  "h-2.5 w-2.5 transition-transform duration-200 ease-out",
+                  "h-2.5 w-2.5 transition-transform duration-[var(--motion-base)] ease-out",
                   channelsOpen && "rotate-90"
                 )}
               />
@@ -802,7 +802,7 @@ export function Sidebar() {
 
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
+              "grid transition-[grid-template-rows] duration-[var(--motion-base)] [transition-timing-function:var(--ease-spring)]",
               channelsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -841,7 +841,7 @@ export function Sidebar() {
             >
               <ChevronRight
                 className={cn(
-                  "h-2.5 w-2.5 transition-transform duration-200 ease-out",
+                  "h-2.5 w-2.5 transition-transform duration-[var(--motion-base)] ease-out",
                   dmsOpen && "rotate-90"
                 )}
               />
@@ -873,7 +873,7 @@ export function Sidebar() {
 
           <div
             className={cn(
-              "grid transition-[grid-template-rows] duration-200 [transition-timing-function:var(--ease-spring)]",
+              "grid transition-[grid-template-rows] duration-[var(--motion-base)] [transition-timing-function:var(--ease-spring)]",
               dmsOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
             )}
           >
@@ -937,7 +937,7 @@ function SectionHeader({
     >
       <ChevronRight
         className={cn(
-          "h-2.5 w-2.5 flex-shrink-0 transition-transform duration-200 ease-out",
+          "h-2.5 w-2.5 flex-shrink-0 transition-transform duration-[var(--motion-base)] ease-out",
           open && "rotate-90"
         )}
       />

--- a/src/components/ui/RollingNumber.tsx
+++ b/src/components/ui/RollingNumber.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+/** Odometer-lite: when `value` changes, old number slides up+fades, new slides in. */
+export function RollingNumber({ value }: { value: number }) {
+  const prev = useRef(value);
+  const [anim, setAnim] = useState(false);
+  useEffect(() => {
+    if (prev.current !== value) {
+      prev.current = value;
+      setAnim(true);
+      const t = setTimeout(() => setAnim(false), 240);
+      return () => clearTimeout(t);
+    }
+  }, [value]);
+  return (
+    <span className="relative inline-block overflow-hidden tabular-nums">
+      <span key={value} className={anim ? "roll-in inline-block" : "inline-block"}>{value}</span>
+    </span>
+  );
+}

--- a/src/hooks/useRevealOnScroll.ts
+++ b/src/hooks/useRevealOnScroll.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Scroll-reveal primitive for the marketing page. Attach `ref` to a container
+ * and flip `revealed` to true the first time it is ≥15% visible, then stop
+ * observing (the reveal is one-shot).
+ *
+ * SSR/no-JS note: this hook never touches the DOM on the server, and callers
+ * apply the hidden `.reveal-on-scroll` class only AFTER mount (see
+ * `LandingReveal`). If IntersectionObserver is unavailable, it reveals
+ * immediately so content is never trapped at opacity:0.
+ */
+export function useRevealOnScroll<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T | null>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      setRevealed(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setRevealed(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.15 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return { ref, revealed };
+}

--- a/src/lib/utils/celebrate.test.ts
+++ b/src/lib/utils/celebrate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isCelebrationMessage } from "./celebrate";
+
+describe("isCelebrationMessage", () => {
+  it("accepts pure celebration emoji", () => {
+    expect(isCelebrationMessage("🎉")).toBe(true);
+    expect(isCelebrationMessage("🎉🎉🎉")).toBe(true);
+    expect(isCelebrationMessage("🎊 🥳")).toBe(true);
+    expect(isCelebrationMessage("🥳🚀")).toBe(true); // other emoji allowed alongside a trigger
+  });
+  it("rejects text, mixed content, missing trigger, and empties", () => {
+    expect(isCelebrationMessage("party at 🎉 9")).toBe(false);
+    expect(isCelebrationMessage("congrats!")).toBe(false);
+    expect(isCelebrationMessage("🚀🚀")).toBe(false); // emoji but no celebration trigger
+    expect(isCelebrationMessage("")).toBe(false);
+    expect(isCelebrationMessage("<p>🎉</p>")).toBe(true); // html-wrapped still counts
+    expect(isCelebrationMessage("🎉".repeat(40))).toBe(false); // > 32 chars after strip
+  });
+});

--- a/src/lib/utils/celebrate.ts
+++ b/src/lib/utils/celebrate.ts
@@ -1,0 +1,11 @@
+/** Celebration detector (#72 motion pass): a message that is nothing but
+ * emoji, at least one of which is a celebration trigger, earns confetti. */
+const TRIGGERS = ["\u{1F389}", "\u{1F38A}", "\u{1F973}"]; // 🎉 🎊 🥳
+const EMOJI_ONLY = /^(?:\p{Extended_Pictographic}|\p{Emoji_Component}|‍|️|\s)+$/u;
+
+export function isCelebrationMessage(raw: string): boolean {
+  const text = raw.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim();
+  if (!text || text.length > 32) return false;
+  if (!TRIGGERS.some((t) => text.includes(t))) return false;
+  return EMOJI_ONLY.test(text);
+}

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -60,6 +60,8 @@ export interface Preferences {
   density: Density;
   desktopNotifications: boolean;
   notificationSound: boolean;
+  /** Confetti when a message is pure celebration (🎉). Purely local delight. */
+  celebrationEffects: boolean;
   mentionsOnly: boolean;
   notificationKeywords: string;
   /**
@@ -139,6 +141,7 @@ interface PreferencesState extends Preferences {
   setDensity: (d: Density) => void;
   setDesktopNotifications: (v: boolean) => void;
   setNotificationSound: (v: boolean) => void;
+  setCelebrationEffects: (v: boolean) => void;
   setMentionsOnly: (v: boolean) => void;
   setNotificationKeywords: (v: string) => void;
   setMutedKeywords: (keywords: string[]) => void;
@@ -184,6 +187,7 @@ const DEFAULTS: Preferences = {
   density: "comfortable",
   desktopNotifications: true,
   notificationSound: true,
+  celebrationEffects: true,
   mentionsOnly: false,
   notificationKeywords: "",
   mutedKeywords: [],
@@ -230,6 +234,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       setDensity: (density) => set({ density }),
       setDesktopNotifications: (desktopNotifications) => set({ desktopNotifications }),
       setNotificationSound: (notificationSound) => set({ notificationSound }),
+      setCelebrationEffects: (celebrationEffects) => set({ celebrationEffects }),
       setMentionsOnly: (mentionsOnly) => set({ mentionsOnly }),
       setNotificationKeywords: (notificationKeywords) => set({ notificationKeywords }),
       setMutedKeywords: (mutedKeywords) => set({ mutedKeywords }),


### PR DESCRIPTION
Implements the approved motion-pass design (spec + plan in `docs/superpowers/specs`/`plans`, committed on this branch). "Playful but earned": big effects only on explicit triggers, ambient motion stays calm, reduced-motion always wins. Zero new dependencies; transform/opacity only. Closes #72.

## What ships
- **Token foundation**: `--ease-bounce`, `--motion-slower`, radius + shadow theme tokens (1:1 with current values — verified byte-identical to Tailwind 4 defaults, zero visual change); ~85 hardcoded durations/easings across ~30 files routed through the tokens (they now honor `prefers-reduced-motion`).
- **Celebration confetti** 🎉: a message that's pure celebration emoji fires a one-shot 24-particle CSS burst (deterministic, no randomness) for sender and receivers, once per message id, never for history. New `celebrationEffects` preference (default on) + reduced-motion double-gate. Detector is TDD'd (`celebrate.test.ts`).
- **Send feel**: own optimistic messages spring up from the composer (`__pending`-gated — history/polled messages never animate; survives the memo comparator and reconcile remount); send-button micro-press.
- **Emoji picker**: hover pop + capped stagger on open.
- **Sidebar & badges**: springy hover/press, odometer-style unread count roll (`RollingNumber`), consistent 120ms panel crossfade on conversation switch (remount-scoped — doesn't replay on polls).
- **Landing page**: staggered hero fade-up, scroll-reveal feature cards (IntersectionObserver, one-shot), ≤4° screenshot tilt. Crawler-safe: all copy stays server-rendered; the hidden reveal state is applied client-side post-mount only (verified via SSR curl).

## Notable engineering finds (fixed on this branch)
- tailwind-merge silently strips stacked `transition-*` utilities → combined `[transition:...]` arbitrary properties, documented inline.
- Tailwind 4 compiles `scale-*` to the standalone `scale` property (not `transform`) — three press/pop effects would never have eased without listing `scale` in the transition.
- `both`-fill animations at 0ms duration still hold their fill state under reduced motion → explicit `animation: none` overrides, cascade-ordered after the base rules.

## Known limitations (deliberate)
- The token sweep is not 100%: ~19 in-tolerance hover-fade literals remain in Sidebar/MessageInput/MessageItem (pre-existing, no regression) — follow-up ticket filed.
- New `--shadow-*` tokens are foundation-only (no call sites swapped yet).
- "🎉2024" counts as a celebration (emoji-component digits) — errs in the fun direction.
- Per-item sidebar badges keep their existing pulse; only section-header badges roll.

## Verification
`npm test` 26/26 (2 new suites) and `npm run build` green at every one of the 12 commits; six task-scoped reviews + a whole-branch final review, all findings fixed or triaged above. **Needs an eyeball pass on the preview deploy** (send 🎉🎉 in demo, hover the picker, scroll the landing page) — motion feel can't be CI'd.