### PR TITLE
chore(ui): finish the motion-token sweep for residual hover-fade durations

### DIFF
--- a/src/components/messages/EmojiPicker.tsx
+++ b/src/components/messages/EmojiPicker.tsx
@@ -101,7 +101,7 @@ function EmojiButton({
         // `scale` is listed separately from `transform` because Tailwind 4's
         // `hover:scale-125` compiles to the standalone CSS `scale` property,
         // not `transform` — without it the hover/focus pop never eases in.
-        className="motion-fade-up flex h-9 w-9 items-center justify-center rounded-md text-[22px] [transition:background-color_150ms_ease,transform_var(--motion-fast)_var(--ease-snap),scale_var(--motion-fast)_var(--ease-snap)] hover:scale-125 hover:bg-[var(--surface-hover)] focus-visible:scale-125"
+        className="motion-fade-up flex h-9 w-9 items-center justify-center rounded-md text-[22px] [transition:background-color_var(--motion-fast)_ease,transform_var(--motion-fast)_var(--ease-snap),scale_var(--motion-fast)_var(--ease-snap)] hover:scale-125 hover:bg-[var(--surface-hover)] focus-visible:scale-125"
         style={{ animationDelay: `${Math.min(index, 20) * 12}ms` }}
       >
         {REACTION_EMOJI[type]}

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -1176,7 +1176,7 @@ export function MessageInput({
                   insertMention(c);
                 }}
                 className={cn(
-                  "flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors duration-100",
+                  "flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors duration-[var(--motion-fast)]",
                   idx === mentionSelectedIdx
                     ? "bg-[var(--surface-hover)]"
                     : "hover:bg-[var(--surface-hover)]"
@@ -1198,7 +1198,7 @@ export function MessageInput({
           </div>
         )}
 
-        <div className="rounded-md border border-[var(--border-input)] bg-[var(--surface)] transition-[border-color,box-shadow] duration-150 focus-within:border-[var(--accent)] focus-within:shadow-[0_0_0_2px_var(--accent-light)]">
+        <div className="rounded-md border border-[var(--border-input)] bg-[var(--surface)] transition-[border-color,box-shadow] duration-[var(--motion-fast)] focus-within:border-[var(--accent)] focus-within:shadow-[0_0_0_2px_var(--accent-light)]">
           {/* Formatting toolbar */}
           <div className="flex items-center gap-0.5 border-b border-[var(--border)] px-3 py-1">
             {toolbarButtons.map((item, idx) => {
@@ -1222,7 +1222,7 @@ export function MessageInput({
                     e.preventDefault();
                     applyFormat(item.action);
                   }}
-                  className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-secondary)] transition-colors duration-100 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] active:bg-[var(--accent)] active:text-white focus-ring"
+                  className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] active:bg-[var(--accent)] active:text-white focus-ring"
                 >
                   {item.icon}
                 </button>
@@ -1239,7 +1239,7 @@ export function MessageInput({
                 aria-label="Attach file"
                 disabled={isBusy}
                 onClick={() => fileInputRef.current?.click()}
-                className="flex-shrink-0 rounded p-1 text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring disabled:opacity-40"
+                className="flex-shrink-0 rounded p-1 text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring disabled:opacity-40"
               >
                 <Paperclip className="h-4 w-4" />
               </button>
@@ -1278,7 +1278,7 @@ export function MessageInput({
                   aria-label="Insert emoji"
                   onClick={() => setEmojiOpen((o) => !o)}
                   className={cn(
-                    "rounded p-1 transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring",
+                    "rounded p-1 transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring",
                     emojiOpen ? "bg-[var(--surface-hover)] text-white" : "text-[var(--text-secondary)]"
                   )}
                 >
@@ -1318,7 +1318,7 @@ export function MessageInput({
                   }
                 }}
                 className={cn(
-                  "rounded px-1.5 py-0.5 transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring",
+                  "rounded px-1.5 py-0.5 transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring",
                   slashMenuOpen ? "bg-[var(--surface-hover)] text-white" : "text-[var(--text-secondary)]"
                 )}
               >
@@ -1331,7 +1331,7 @@ export function MessageInput({
                   type="button"
                   aria-label="Send a GIF"
                   disabled={isBusy}
-                  className="rounded px-1.5 py-0.5 text-[10px] font-bold text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring disabled:opacity-40"
+                  className="rounded px-1.5 py-0.5 text-[10px] font-bold text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring disabled:opacity-40"
                 >
                   GIF
                 </button>
@@ -1493,7 +1493,7 @@ export function MessageInput({
                   // outright. `scale` is listed separately from `transform`
                   // because Tailwind 4's `active:scale-90` compiles to the
                   // standalone CSS `scale` property, not `transform`.
-                  "relative overflow-hidden flex h-8 items-center justify-center rounded [transition:background_150ms_ease-out,color_150ms_ease-out,transform_var(--motion-fast)_var(--ease-snap),scale_var(--motion-fast)_var(--ease-snap)] active:scale-90 focus-ring",
+                  "relative overflow-hidden flex h-8 items-center justify-center rounded [transition:background_var(--motion-fast)_ease-out,color_var(--motion-fast)_ease-out,transform_var(--motion-fast)_var(--ease-snap),scale_var(--motion-fast)_var(--ease-snap)] active:scale-90 focus-ring",
                   scheduleTime ? "w-auto gap-1 px-2.5 text-[13px] font-medium" : "w-8",
                   canSend
                     ? "bg-[var(--accent)] text-white hover:opacity-90"
@@ -1525,7 +1525,7 @@ export function MessageInput({
                 <div className="flex flex-shrink-0 items-center gap-2">
                   <div className="h-1 w-20 overflow-hidden rounded-full bg-[var(--border)]">
                     <div
-                      className="h-full rounded-full bg-[var(--accent)] transition-[width] duration-150"
+                      className="h-full rounded-full bg-[var(--accent)] transition-[width] duration-[var(--motion-fast)]"
                       style={{ width: `${uploadProgress}%` }}
                     />
                   </div>
@@ -1541,7 +1541,7 @@ export function MessageInput({
                       type="button"
                       aria-label={`Remove attachment ${pendingFile.name}`}
                       onClick={() => setPendingFile(null)}
-                      className="flex-shrink-0 rounded p-0.5 text-[var(--text-secondary)] transition-colors duration-100 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring"
+                      className="flex-shrink-0 rounded p-0.5 text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-ring"
                     >
                       <X className="h-3 w-3" />
                     </button>

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -415,7 +415,7 @@ function MessageItemImpl({
         {/* Gutter width = head row's avatar column: 32px avatar + gap-2 (8px) = 40px,
             so continuation text aligns pixel-for-pixel under the group head's body. */}
         <span
-          className="flex w-10 flex-shrink-0 select-none items-start justify-end gap-0.5 pr-2 pt-[3px] text-right text-[11px] tabular-nums leading-[18px] text-[var(--text-muted)] opacity-0 transition-opacity duration-100 group-hover:opacity-100"
+          className="flex w-10 flex-shrink-0 select-none items-start justify-end gap-0.5 pr-2 pt-[3px] text-right text-[11px] tabular-nums leading-[18px] text-[var(--text-muted)] opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover:opacity-100"
           title={formatFullTimestamp(message.createdDateTime)}
         >
           {message.__pending && (

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -479,7 +479,7 @@ export function Sidebar() {
         <DropdownMenu.Trigger asChild>
           <button
             type="button"
-            className="flex h-[var(--chrome-header-h)] w-full items-center justify-between border-b border-[var(--border)] px-4 transition-colors duration-[80ms] ease-out hover:bg-[var(--sidebar-hover)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+            className="flex h-[var(--chrome-header-h)] w-full items-center justify-between border-b border-[var(--border)] px-4 transition-colors duration-[var(--motion-fast)] ease-out hover:bg-[var(--sidebar-hover)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
           >
             <span className="truncate text-[15px] font-black text-white">
               {activeTeam?.displayName ?? "Teamsly"}
@@ -774,7 +774,7 @@ export function Sidebar() {
             <button
               type="button"
               onClick={() => setChannelsOpen((v) => !v)}
-              className="flex min-w-0 flex-1 items-center gap-1 transition-colors duration-[80ms] ease-out hover:text-[var(--text-secondary)] focus:outline-none"
+              className="flex min-w-0 flex-1 items-center gap-1 transition-colors duration-[var(--motion-fast)] ease-out hover:text-[var(--text-secondary)] focus:outline-none"
             >
               <ChevronRight
                 className={cn(
@@ -791,12 +791,12 @@ export function Sidebar() {
                   aria-label="Mark all channels read"
                   title="Mark all read"
                   onClick={() => teamChannels.forEach((ch) => markRead(ch.id))}
-                  className="opacity-0 transition-colors duration-150 hover:text-[var(--text-secondary)] focus:outline-none focus-visible:opacity-100 group-hover/section:opacity-100"
+                  className="opacity-0 transition-colors duration-[var(--motion-fast)] hover:text-[var(--text-secondary)] focus:outline-none focus-visible:opacity-100 group-hover/section:opacity-100"
                 >
                   <CheckCheck className="h-3.5 w-3.5" />
                 </button>
               )}
-              <Plus className="h-3 w-3 opacity-0 transition-opacity duration-150 group-hover/section:opacity-100" />
+              <Plus className="h-3 w-3 opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover/section:opacity-100" />
             </div>
           </div>
 
@@ -837,7 +837,7 @@ export function Sidebar() {
             <button
               type="button"
               onClick={() => setDmsOpen((v) => !v)}
-              className="flex min-w-0 flex-1 items-center gap-1 transition-colors duration-[80ms] ease-out hover:text-[var(--text-secondary)] focus:outline-none"
+              className="flex min-w-0 flex-1 items-center gap-1 transition-colors duration-[var(--motion-fast)] ease-out hover:text-[var(--text-secondary)] focus:outline-none"
             >
               <ChevronRight
                 className={cn(
@@ -854,7 +854,7 @@ export function Sidebar() {
                   aria-label="Mark all direct messages read"
                   title="Mark all read"
                   onClick={() => chats.forEach((chat) => markRead(chat.id))}
-                  className="opacity-0 transition-colors duration-150 hover:text-[var(--text-secondary)] focus:outline-none focus-visible:opacity-100 group-hover/section:opacity-100"
+                  className="opacity-0 transition-colors duration-[var(--motion-fast)] hover:text-[var(--text-secondary)] focus:outline-none focus-visible:opacity-100 group-hover/section:opacity-100"
                 >
                   <CheckCheck className="h-3.5 w-3.5" />
                 </button>
@@ -897,7 +897,7 @@ export function Sidebar() {
                   type="button"
                   disabled={loadingMoreChats}
                   onClick={loadMoreChats}
-                  className="mx-2 mt-0.5 flex h-7 w-[calc(100%-16px)] items-center gap-1.5 rounded-md px-2 text-[13px] text-[var(--text-muted)] transition-colors duration-[80ms] ease-out hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-secondary)] disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+                  className="mx-2 mt-0.5 flex h-7 w-[calc(100%-16px)] items-center gap-1.5 rounded-md px-2 text-[13px] text-[var(--text-muted)] transition-colors duration-[var(--motion-fast)] ease-out hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-secondary)] disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
                 >
                   <ChevronDown className="h-3 w-3 flex-shrink-0" />
                   <span>{loadingMoreChats ? "Loading..." : "Show older chats"}</span>
@@ -933,7 +933,7 @@ function SectionHeader({
     <button
       type="button"
       onClick={onToggle}
-      className="group/section flex w-full items-center gap-1.5 px-4 py-1 text-[12px] font-semibold text-[var(--text-muted)] transition-colors duration-[80ms] ease-out hover:text-[var(--text-secondary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+      className="group/section flex w-full items-center gap-1.5 px-4 py-1 text-[12px] font-semibold text-[var(--text-muted)] transition-colors duration-[var(--motion-fast)] ease-out hover:text-[var(--text-secondary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
     >
       <ChevronRight
         className={cn(
@@ -1076,7 +1076,7 @@ function SidebarItem({
               aria-label="Conversation options"
               onClick={(e) => e.stopPropagation()}
               className={cn(
-                "absolute right-3 top-1/2 -translate-y-1/2 flex h-5 w-5 items-center justify-center rounded text-[var(--text-secondary)] transition-opacity duration-100 hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-primary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]",
+                "absolute right-3 top-1/2 -translate-y-1/2 flex h-5 w-5 items-center justify-center rounded text-[var(--text-secondary)] transition-opacity duration-[var(--motion-fast)] hover:bg-[var(--sidebar-hover)] hover:text-[var(--text-primary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]",
                 menuOpen ? "opacity-100" : "opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100"
               )}
             >


### PR DESCRIPTION
Closes #177.

Finishes the #72 motion pass by snapping the ~19 residual **in-tolerance** hover/color-fade duration literals onto `var(--motion-fast)` (120ms), so they zero under `prefers-reduced-motion` like the rest of the motion system.

## What changed
Snapped every literal within 40ms of a token → `var(--motion-fast)`:

| File | Snapped |
|------|---------|
| `Sidebar.tsx` | 5× `duration-[80ms]`, 3× `duration-150`, 1× `duration-100` |
| `MessageInput.tsx` | 6× `duration-150`, 3× `duration-100`, + the two inline `150ms` in the send button's `[transition:…]` |
| `MessageItem.tsx` | 1× `duration-100` (timestamp gutter hover) |
| `EmojiPicker.tsx` | 1× inline `150ms` (straggler beyond #177's named files) |

## Deliberately left alone (out of tolerance)
- **`duration-75` ×14** in the sidebar dropdown items (45ms from the nearest token)
- **`send-ripple 400ms`** animation (80ms from the nearest token)

Purely a durations change — no easing, transition-property, or timing-function behavior moves. The `[transition:…]` sites already followed the combined-property pattern (tailwind-merge / TW4 `scale` quirks), so only the numeric values changed.

## Verification
- `npm test` → **48/48 pass**
- `npm run build` → **exit 0**, 43/43 static pages
- grep confirms zero `duration-150|duration-100|duration-[80ms]|_NNms_` residuals remain; `duration-75` and `400ms` preserved